### PR TITLE
Add support for setup.sh and expand Gazebo documentation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -156,6 +156,21 @@ if(ROBOTOLOGY_USES_MATLAB)
   configure_file(${CMAKE_CURRENT_SOURCE_DIR}/cmake/template/startup_robotology_superbuild.m.in ${CMAKE_BINARY_DIR}/startup_robotology_superbuild.m)
 endif()
 
+# Configure a basic setup.sh for *nix system
+if(ROBOTOLOGY_USES_GAZEBO)
+  # TODO(traversaro): make sure that Gazebo exports this, for now hardcode
+  if(APPLE)
+    set(GAZEBO_SETUP_SH_PATH "/usr/local/share/gazebo/setup.sh")
+  else()
+    set(GAZEBO_SETUP_SH_PATH "/usr/share/gazebo/setup.sh")
+  endif()
+endif()
+
+if(NOT WIN32)
+  include(ConfigureFileWithCMakeIf)
+  configure_file_with_cmakeif(${CMAKE_CURRENT_SOURCE_DIR}/cmake/template/setup.sh.in ${CMAKE_BINARY_DIR}/install/share/${PROJECT_NAME}/setup.sh @ONLY)
+endif()
+
 ycm_write_dot_file(${CMAKE_CURRENT_BINARY_DIR}/robotology-superbuild.dot)
 
 set_package_properties(Git PROPERTIES TYPE RUNTIME)

--- a/README.md
+++ b/README.md
@@ -123,14 +123,29 @@ Currently the YCM superbuild does not support building a global install target, 
 To use this binaries and libraries, you should update the `PATH` and `LD_CONFIG_PATH` environment variables.
 
 An easy way is to add this lines to the '.bashrc` file in your home directory:
+```bash
+export ROBOTOLOGY_SUPERBUILD_ROOT=/directory/where/you/downloaded/robotology-superbuild/
+export ROBOTOLOGY_SUPERBUILD_INSTALL_PREFIX=$ROBOTOLOGY_SUPERBUILD_ROOT/build/install
+# Extend PATH (see https://en.wikipedia.org/wiki/PATH_(variable) )
+export PATH=$PATH:$ROBOTOLOGY_SUPERBUILD_INSTALL_PREFIX/bin
+# YARP related env variables (see http://www.yarp.it/yarp_data_dirs.html )
+export YARP_DATA_DIRS=$YARP_DATA_DIRS:$ROBOTOLOGY_SUPERBUILD_INSTALL_PREFIX/share/yarp
+                                     :$ROBOTOLOGY_SUPERBUILD_INSTALL_PREFIX/share/iCub
+# Extend CMAKE_PREFIX_PATH (see https://cmake.org/cmake/help/v3.8/variable/CMAKE_PREFIX_PATH.html )
+export CMAKE_PREFIX_PATH=$CMAKE_PREFIX_PATH:$ROBOTOLOGY_SUPERBUILD_INSTALL_PREFIX
 ```
-export ROBOTOLOGY_SUPERBUILD_ROOT=/directory/where/you/downloaded/robotology-superbuild
-export PATH=$PATH:$ROBOTOLOGY_SUPERBUILD_ROOT/build/install/bin
-export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$ROBOTOLOGY_SUPERBUILD_ROOT/build/install/lib
-export YARP_DATA_DIRS=$YARP_DATA_DIRS:$ROBOTOLOGY_SUPERBUILD_ROOT/build/install/share/codyco
-                                     :$ROBOTOLOGY_SUPERBUILD_ROOT/build/install/share/yarp
-                                     :$ROBOTOLOGY_SUPERBUILD_ROOT/build/install/share/iCub
+
+Software installed by the following [profile](#profile-cmake-options) or [dependencies](#dependencies-cmake-options) CMake options require specific enviromental variables to be set, as documented in options-specific documentation:
+* [`ROBOTOLOGY_ENABLE_DYNAMICS`](#dynamics) 
+* [`ROBOTOLOGY_USES_GAZEBO`](#gazebo)
+* [`ROBOTOLOGY_USES_MATLAB`](#matlab)
+
+As a convenient feature the superbuild provides an automatically generated `setup.sh` sh script that will set
+all the necessary enviromental variables:
 ```
+source $ROBOTOLOGY_SUPERBUILD_INSTALL_PREFIX/share/robotology-superbuild/setup.sh
+```
+
 To use the updated `.bashrc` in your terminal you should run the following command:
 ```bash
 user@host:~$ source ~/.bashrc
@@ -182,18 +197,26 @@ To use this binaries you should update the `PATH` environment variables.
 
 An easy way is to add these lines to the `.bashrc` or `.bash_profile` file in your home directory:
 ```bash
-ROBOTOLOGY_SUPERBUILD_ROOT=/directory/where/you/downloaded/robotology-superbuild
-export PATH=$PATH:$ROBOTOLOGY_SUPERBUILD_ROOT/build/install/bin
-export YARP_DATA_DIRS=$YARP_DATA_DIRS:$ROBOTOLOGY_SUPERBUILD_ROOT/build/install/share/codyco
-                                     :$ROBOTOLOGY_SUPERBUILD_ROOT/build/install/share/yarp
-                                     :$ROBOTOLOGY_SUPERBUILD_ROOT/build/install/share/iCub
+export ROBOTOLOGY_SUPERBUILD_ROOT=/directory/where/you/downloaded/robotology-superbuild/
+export ROBOTOLOGY_SUPERBUILD_INSTALL_PREFIX=$ROBOTOLOGY_SUPERBUILD_ROOT/build/install
+# Extend PATH (see https://en.wikipedia.org/wiki/PATH_(variable) )
+export PATH=$PATH:$ROBOTOLOGY_SUPERBUILD_INSTALL_PREFIX/bin
+# YARP related env variables (see http://www.yarp.it/yarp_data_dirs.html )
+export YARP_DATA_DIRS=$YARP_DATA_DIRS:$ROBOTOLOGY_SUPERBUILD_INSTALL_PREFIX/share/yarp
+                                     :$ROBOTOLOGY_SUPERBUILD_INSTALL_PREFIX/share/iCub
+# Extend CMAKE_PREFIX_PATH (see https://cmake.org/cmake/help/v3.8/variable/CMAKE_PREFIX_PATH.html )
+export CMAKE_PREFIX_PATH=$CMAKE_PREFIX_PATH:$ROBOTOLOGY_SUPERBUILD_INSTALL_PREFIX
 ```
 
-Most of the modules in the robotology-superbuild are correctly configured to automatically find the libraries.
-If you create a new application or library that need to be linked to robotology-superbuild libraries (or if you are having issues with the dynamic loader) add also the following line to your `.bashrc` or `.bash_profile`.
+Software installed by the following [profile](#profile-cmake-options) or [dependencies](#dependencies-cmake-options) CMake options require specific enviromental variables to be set, as documented in options-specific documentation:
+* [`ROBOTOLOGY_ENABLE_DYNAMICS`](#dynamics) 
+* [`ROBOTOLOGY_USES_GAZEBO`](#gazebo)
+* [`ROBOTOLOGY_USES_MATLAB`](#matlab)
 
-```bash
-export DYLD_LIBRARY_PATH=$DYLD_LIBRARY_PATH:$ROBOTOLOGY_SUPERBUILD_ROOT/build/install/lib
+As a convenient feature the superbuild provides an automatically generated `setup.sh` sh script that will set
+all the necessary enviromental variables:
+```
+source $ROBOTOLOGY_SUPERBUILD_INSTALL_PREFIX/share/robotology-superbuild/setup.sh
 ```
 
 To use the updated `.bashrc` in your terminal you should run the following command:
@@ -248,11 +271,16 @@ Currently the YCM superbuild does not support building a global install target, 
 
 To use this binaries and libraries, you should update the necessary environment variables.
 
-Set the environment variable `ROBOTOLOGY_SUPERBUILD_ROOT` so that it points to the  directory where you clone the robotology-superbuild repository.
+Set the environment variable `ROBOTOLOGY_SUPERBUILD_ROOT` so that it points to the  directory where you cloned the robotology-superbuild repository.
 
-Append `$ROBOTOLOGY_SUPERBUILD_ROOT/build/install/bin` to your PATH
+Append `$ROBOTOLOGY_SUPERBUILD_ROOT/build/install/bin` to your PATH.
 
-Append `$ROBOTOLOGY_SUPERBUILD_ROOT/build/install/share/codyco`, `$ROBOTOLOGY_SUPERBUILD_ROOT/build/install/share/yarp` and `$ROBOTOLOGY_SUPERBUILD_ROOT/build/install/share/icub` to your [YARP\_DATA\_DIRS](http://wiki.icub.org/yarpdoc/yarp_data_dirs.html) environment variable.
+Append `$ROBOTOLOGY_SUPERBUILD_ROOT/build/install/share/yarp` and `$ROBOTOLOGY_SUPERBUILD_ROOT/build/install/share/icub` to your [`YARP_DATA_DIRS`](http://wiki.icub.org/yarpdoc/yarp_data_dirs.html) environment variable.
+
+Software installed by the following [profile](#profile-cmake-options) or [dependencies](#dependencies-cmake-options) CMake options require specific enviromental variables to be set, as documented in options-specific documentation:
+* [`ROBOTOLOGY_ENABLE_DYNAMICS`](#dynamics) 
+* [`ROBOTOLOGY_USES_GAZEBO`](#gazebo)
+* [`ROBOTOLOGY_USES_MATLAB`](#matlab)
 
 Update
 ======
@@ -310,7 +338,8 @@ Profile-specific documentation
 This profile is enabled by the `ROBOTOLOGY_ENABLE_CORE` CMake option.
 
 ### Configuration
-**TODO**
+The configuration necessary to use the software installed in the Core profile is provided in
+operating system-specific installation documentation. 
 
 ### Check the installation
 **TODO**
@@ -319,10 +348,9 @@ This profile is enabled by the `ROBOTOLOGY_ENABLE_CORE` CMake option.
 This profile is enabled by the `ROBOTOLOGY_ENABLE_DYNAMICS` CMake option.
 
 ### Configuration
-**TODO**
+`$ROBOTOLOGY_SUPERBUILD_INSTALL_PREFIX/share/codyco` must be appended to the `YARP_DATA_DIRS` enviromental variable.
+If you are using Linux or macOS, the `$ROBOTOLOGY_SUPERBUILD_INSTALL_PREFIX/share/robotology-superbuild/setup.sh` script will append the necessary path to `YARP_DATA_DIRS`.
 
-### Check the installation
-**TODO**
 
 Dependencies-specific documentation
 ===================================
@@ -330,8 +358,25 @@ Dependencies-specific documentation
 ## Gazebo
 Support for this dependency is enabled by the `ROBOTOLOGY_USES_GAZEBO` CMake option.
 
+**Warning: at the moment the Gazebo simulator does not support Windows, so this option is only supported 
+on Linux and macOS.**
+
 ### Configuration
-**TODO**
+To enable the `ROBOTOLOGY_USES_GAZEBO` option, first ensure that Gazebo is installed on your machine, following the 
+instructions available at http://gazebosim.org/tutorials?cat=install . Make sure to install also the 
+development files, i.e. `libgazebo*-dev` on Debian/Ubuntu. 
+
+Once the superbuild with `` enabled has been compiled, it is necessary to append a few superbuild-specific path to the Gazebo enviromental variables:
+~~~
+# Gazebo related env variables (see http://gazebosim.org/tutorials?tut=components#EnvironmentVariables )
+# This is /usr/local/share/gazebo/setup.sh if Gazebo was installed in macOS using homebrew
+source /usr/share/gazebo/setup.sh
+export GAZEBO_PLUGIN_PATH=${GAZEBO_PLUGIN_PATH}:${ROBOTOLOGY_SUPERBUILD_INSTALL_PREFIX}/lib
+export GAZEBO_MODEL_PATH=${GAZEBO_MODEL_PATH}:${ROBOTOLOGY_SUPERBUILD_INSTALL_PREFIX}/share/gazebo/models
+export GAZEBO_RESOURCE_PATH=${GAZEBO_RESOURCE_PATH}:${ROBOTOLOGY_SUPERBUILD_INSTALL_PREFIX}/share/gazebo/worlds
+~~~
+
+The `$ROBOTOLOGY_SUPERBUILD_INSTALL_PREFIX/share/robotology-superbuild/setup.sh` script will append the necessary path to the Gazebo enviromental variables. 
 
 ### Check the installation
 **TODO**
@@ -344,7 +389,6 @@ Support for this dependency is enabled by the `ROBOTOLOGY_USES_LUA` CMake option
 
 ### Check the installation
 **TODO**
-
 
 ## MATLAB
 Support for this dependency is enabled by the `ROBOTOLOGY_USES_MATLAB` CMake option.
@@ -375,7 +419,7 @@ Another way is to run (only once) the script `startup_robotology_superbuild.m` i
 For more info on configuring MATLAB software with the robotology-superbuild, please check the [WB-Toolbox README](https://github.com/robotology/WB-Toolbox).
 
 **Note: tipically we assume that a user that selects the `ROBOTOLOGY_USES_MATLAB` also has Simulink installed in his computer. If this is not the case, you can enable the advanced CMake option `ROBOTOLOGY_NOT_USE_SIMULINK` to compile all the subprojects that depend on MATLAB, but disable the subprojecs that depend on Simulink (i.e. the
-[WB-Toolbox](https://github.com/robotology/WB-Toolbox) ).**
+[WB-Toolbox](https://github.com/robotology/WB-Toolbox) ) if tou have enabled the `ROBOTOLOGY_ENABLE_DYNAMICS` CMake options.**
 
 ### Check the installation
 **TODO**

--- a/cmake/ConfigureFileWithCMakeIf.cmake
+++ b/cmake/ConfigureFileWithCMakeIf.cmake
@@ -1,0 +1,77 @@
+#.rst:
+# ConfigureFileWithCMakeIf
+# ------------------------
+#
+# An enhanced version of configure_file that supports also template-style ifs.
+#
+#
+# .. command:: configure_file_with_cmakeif
+#
+# Enhanced version of configure_file that permits to include or not several lines
+# of the input document using the @cmakeif VARIABLE/@endcmakeif VARIABLE command
+#
+#  configure_file_with_cmakeif(<input> <output> ARGN)
+#
+# All the commands are shelled to the configure_file command called inside 
+#
+
+#=============================================================================
+# Copyright 2013 Istituto Italiano di Tecnologia (IIT)
+#   Authors: Daniele E. Domenichelli <daniele.domenichelli@iit.it>
+#
+# Distributed under the OSI-approved BSD License (the "License");
+# see accompanying file Copyright.txt for details.
+#
+# This software is distributed WITHOUT ANY WARRANTY; without even the
+# implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the License for more information.
+#=============================================================================
+# (To distribute this file outside of CMake, substitute the full
+#  License text for the above reference.)
+
+
+if(COMMAND configure_file_with_cmakeif)
+  return()
+endif()
+
+
+function(CONFIGURE_FILE_WITH_CMAKEIF _input_file _output)
+  # Read input file
+  file(READ ${_input_file} _input_string)
+
+  if(_input_string STREQUAL "")
+    message(FATAL_ERROR "Empty file ${_input_file}")
+  endif()
+
+  # Find couples of @cmakeif / @endcmakeif
+  string(REGEX MATCHALL "@cmakeif[ ]+[A-Za-z0-9_]+" _matched_ifs ${_input_string})
+  list(LENGTH _matched_ifs _nr_of_matched_ifs)
+  string(REGEX MATCHALL "@endcmakeif" _matched_endifs ${_input_string})
+  list(LENGTH _matched_endifs _nr_of_matched_endifs)
+
+  if(NOT (${_nr_of_matched_ifs} EQUAL ${_nr_of_matched_endifs}))
+    message(FATAL_ERROR "@cmakeif/@endcmakeif mismatch in file ${_input_file}")
+  endif()
+
+  foreach(_if ${_matched_ifs})
+    string(REGEX MATCH "([A-Za-z0-9_]+)$" _condition ${_if})
+    set(_condition ${CMAKE_MATCH_0})
+    if(${_condition})
+      # if the condition is valid, just strip the @cmakeif/@endcmakeif
+      string(REPLACE ${_if} "" _input_string ${_input_string})
+      string(REPLACE "@endcmakeif ${_condition}" "" _input_string ${_input_string})
+    else()
+      # if the condition is not valid, remove all the contents of the @cmakeif/@endcmakeif
+      string(FIND ${_input_string} "@cmakeif" _first_char_to_delete)
+      string(FIND ${_input_string} "@endcmakeif" _last_char_to_delete)
+      string(LENGTH "@endcmakeif ${_condition}" _length_of_ending_tag)
+      math(EXPR length_of_string_to_delete "${_last_char_to_delete}+${_length_of_ending_tag}-${_first_char_to_delete}")
+      string(SUBSTRING ${_input_string} ${_first_char_to_delete} ${length_of_string_to_delete} string_to_delete)
+      string(REPLACE ${string_to_delete} "" _input_string ${_input_string})
+    endif()
+  endforeach()
+
+  set(_processed_file ${CMAKE_CURRENT_BINARY_DIR}/temp-configure-file-with-cmakeif.txt)
+  file(WRITE ${_processed_file} ${_input_string})
+  configure_file(${_processed_file} ${_output} ${ARGN})
+endfunction()

--- a/cmake/template/setup.sh.in
+++ b/cmake/template/setup.sh.in
@@ -1,0 +1,24 @@
+# Automatically generated setup file for @PROJECT_NAME@
+
+export ROBOTOLOGY_SUPERBUILD_ROOT=@PROJECT_SOURCE_DIR@
+export ROBOTOLOGY_SUPERBUILD_INSTALL_PREFIX=@PROJECT_BINARY_DIR@/install
+# Extend PATH (see https://en.wikipedia.org/wiki/PATH_(variable) )
+export PATH=$PATH:$ROBOTOLOGY_SUPERBUILD_INSTALL_PREFIX/bin
+# YARP related env variables (see http://www.yarp.it/yarp_data_dirs.html )
+export YARP_DATA_DIRS=$YARP_DATA_DIRS:$ROBOTOLOGY_SUPERBUILD_INSTALL_PREFIX/share/yarp:$ROBOTOLOGY_SUPERBUILD_INSTALL_PREFIX/share/iCub
+# Extend CMAKE_PREFIX_PATH (see https://cmake.org/cmake/help/v3.8/variable/CMAKE_PREFIX_PATH.html )
+export CMAKE_PREFIX_PATH=${CMAKE_PREFIX_PATH}:${ROBOTOLOGY_SUPERBUILD_INSTALL_PREFIX}
+
+@cmakeif ROBOTOLOGY_USES_GAZEBO
+# ROBOTOLOGY_USES_GAZEBO-specific lines
+# Gazebo related env variables (see http://gazebosim.org/tutorials?tut=components#EnvironmentVariables )
+source @GAZEBO_SETUP_SH_PATH@
+export GAZEBO_PLUGIN_PATH=${GAZEBO_PLUGIN_PATH}:${ROBOTOLOGY_SUPERBUILD_INSTALL_PREFIX}/lib
+export GAZEBO_MODEL_PATH=${GAZEBO_MODEL_PATH}:${ROBOTOLOGY_SUPERBUILD_INSTALL_PREFIX}/share/gazebo/models
+export GAZEBO_RESOURCE_PATH=${GAZEBO_RESOURCE_PATH}:${ROBOTOLOGY_SUPERBUILD_INSTALL_PREFIX}/share/gazebo/worlds
+@endcmakeif ROBOTOLOGY_USES_GAZEBO
+
+@cmakeif ROBOTOLOGY_ENABLE_DYNAMICS
+# ROBOTOLOGY_ENABLE_DYNAMICS-specific lines
+export YARP_DATA_DIRS=$YARP_DATA_DIRS:$ROBOTOLOGY_SUPERBUILD_ROOT/build/install/share/codyco
+@endcmakeif ROBOTOLOGY_ENABLE_DYNAMICS


### PR DESCRIPTION
This PR adds a basic support for generating a `setup.sh` file to set all the the environmental variables necessary to run all the robotology-superbuild software, to streamline installation of an existing superbuild. 

The main difference with respect to catkin/ament style `setup.sh` is that:
* All the environmental variables are still extensively documented in the superbuild documentation, and the expert user may chose to set them manually (or only set a subset of them). The `setup.sh` is just a convenient feature, but it should not be a black box in which an arbitrary number of enviroment variables are set. 
* While in catkin/ament the environmental variables are set by the subprojects via hooks, the idea here is that the superbuild maintainer is responsible to manage which environmental variables are present in the setup.sh . This is done to ensure that the number of environmental variables used is always limited, and the `setup.sh` logic is small and readable. 

cc @nunoguedelha @vibhoraggarwal 