### PR TITLE
Document requirement to export Qt5_DIR in macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,11 @@ To install Eigen and CMake, it is possible to use [Homebrew](http://brew.sh/):
 brew install ace eigen cmake boost tinyxml swig qt5 gsl pkg-config jpeg sqlite readline tinyxml dartsim/dart/ipopt
 ```
 
+Since Qt5 is not symlinked in `/usr/local` by default in the homebrew formula, `Qt5_DIR` needs to be properly set to make sure that CMake-based projects are able to find Qt5.
+```
+export Qt5_DIR=/usr/local/opt/qt5/lib/cmake/Qt5
+```
+
 If you want to enable a [profile](#profile-cmake-options) or a [dependency](#dependencies-cmake-options) specific CMake option, you may need to install additional system dependencies following the dependency-specific documentation (in particular, the `ROBOTOLOGY_USES_GAZEBO` option is enabled by default, so you should install Gazebo unless you plan to disable this option):
 * [`ROBOTOLOGY_ENABLE_IHMC`](#ihmc)
 * [`ROBOTOLOGY_USES_GAZEBO`](#gazebo)


### PR DESCRIPTION
Document the requirement to export the environment variable Qt5_DIR in macOS since by default Qt5 is not symlinked in /usr/local by the homebrew formula.

This solves #4.

cc @traversaro 