### PR TITLE
Cleanup YARP and ICUB cmake options

### DIFF
--- a/cmake/BuildICUB.cmake
+++ b/cmake/BuildICUB.cmake
@@ -28,6 +28,7 @@ ycm_ep_helper(ICUB TYPE GIT
                                     -DENABLE_icubmod_gazecontrollerclient:BOOL=ON
                                     -DENABLE_icubmod_serial:BOOL=${ROBOTOLOGY_ENABLE_ICUB_ROBOT}
                                     -DENABLE_icubmod_serialport:BOOL=${ROBOTOLOGY_ENABLE_ICUB_ROBOT}
+                                    -DENABLE_icubmod_skinWrapper:BOOL=${ROBOTOLOGY_ENABLE_ICUB_ROBOT}
                                     -DENABLE_icubmod_dragonfly2:BOOL=${ROBOTOLOGY_ENABLE_ICUB_ROBOT}
                                     -DENABLE_icubmod_portaudio:BOOL=${ROBOTOLOGY_ENABLE_ICUB_ROBOT}
                                     -DENABLE_icubmod_sharedcan:BOOL=${ROBOTOLOGY_ENABLE_ICUB_ROBOT_CAN}
@@ -37,10 +38,12 @@ ycm_ep_helper(ICUB TYPE GIT
                                     -DENABLE_icubmod_canBusSkin:BOOL=${ROBOTOLOGY_ENABLE_ICUB_ROBOT_CAN}
                                     -DENABLE_icubmod_canBusVirtualAnalogSensor:BOOL=${ROBOTOLOGY_ENABLE_ICUB_ROBOT_CAN}
                                     -DENABLE_icubmod_cfw2can:BOOL=${ROBOTOLOGY_ENABLE_ICUB_ROBOT_CAN}
-                                    -DENABLE_icubmod_embObjStrain:BOOL=${ROBOTOLOGY_ENABLE_ICUB_ROBOT_ETH}
-                                    -DENABLE_icubmod_embObjMais:BOOL=${ROBOTOLOGY_ENABLE_ICUB_ROBOT_ETH}
+                                    -DENABLE_icubmod_embObjFTsensor:BOOL=${ROBOTOLOGY_ENABLE_ICUB_ROBOT_ETH}
+                                    -DENABLE_icubmod_embObjIMU:BOOL=${ROBOTOLOGY_ENABLE_ICUB_ROBOT_ETH}
                                     -DENABLE_icubmod_embObjInertials:BOOL=${ROBOTOLOGY_ENABLE_ICUB_ROBOT_ETH}
+                                    -DENABLE_icubmod_embObjMais:BOOL=${ROBOTOLOGY_ENABLE_ICUB_ROBOT_ETH}
                                     -DENABLE_icubmod_embObjMotionControl:BOOL=${ROBOTOLOGY_ENABLE_ICUB_ROBOT_ETH}
                                     -DENABLE_icubmod_embObjSkin:BOOL=${ROBOTOLOGY_ENABLE_ICUB_ROBOT_ETH}
+                                    -DENABLE_icubmod_embObjStrain:BOOL=${ROBOTOLOGY_ENABLE_ICUB_ROBOT_ETH}
                                     -DENABLE_icubmod_embObjVirtualAnalogSensor:BOOL=${ROBOTOLOGY_ENABLE_ICUB_ROBOT_ETH}
                                     -DENABLE_icubmod_parametricCalibratorEth:BOOL=${ROBOTOLOGY_ENABLE_ICUB_ROBOT_ETH})

--- a/cmake/BuildYARP.cmake
+++ b/cmake/BuildYARP.cmake
@@ -16,6 +16,10 @@ else()
   set(YARP_COMPILE_BINDINGS OFF)
 endif()
 
+if(ROBOTOLOGY_ENABLE_ICUB_ROBOT_ETH OR ROBOTOLOGY_ENABLE_ICUB_ROBOT_CAN)
+  set(ROBOTOLOGY_ENABLE_ICUB_ROBOT ON)
+endif()
+
 ycm_ep_helper(YARP TYPE GIT
                    STYLE GITHUB
                    REPOSITORY robotology/yarp.git
@@ -31,7 +35,6 @@ ycm_ep_helper(YARP TYPE GIT
                               -DCREATE_GUIS:BOOL=ON
                               -DYARP_USE_SYSTEM_SQLITE:BOOL=ON
                               -DCREATE_LIB_MATH:BOOL=ON
-                              -DDOX_GENERATE_XML:BOOL=OFF
                               -DCREATE_OPTIONAL_CARRIERS:BOOL=ON
                               -DENABLE_yarpcar_bayer:BOOL=ON
                               -DENABLE_yarpcar_tcpros:BOOL=ON
@@ -41,14 +44,10 @@ ycm_ep_helper(YARP TYPE GIT
                               -DENABLE_yarpidl_thrift:BOOL=ON
                               -DCREATE_DEVICE_LIBRARY_MODULES:BOOL=ON
                               -DENABLE_yarpcar_human:BOOL=ON
-                              -DENABLE_yarpcar_mjpeg:BOOL=OFF
                               -DENABLE_yarpcar_rossrv:BOOL=ON
                               -DENABLE_yarpmod_fakebot:BOOL=ON
-                              -DENABLE_yarpmod_opencv_grabber:BOOL=OFF
-                              -DYARP_COMPILE_TESTS:BOOL=OFF
+                              -DENABLE_yarpmod_imuBosch_BNO055:BOOL=${ROBOTOLOGY_ENABLE_ICUB_ROBOT}
                               -DYARP_COMPILE_EXPERIMENTAL_WRAPPERS:BOOL=ON
                               -DYARP_COMPILE_RTF_ADDONS:BOOL=ON
-                              -DYARP_DOXYGEN_XML:BOOL=OFF
-                              -DYARP_DOXYGEN_TAGFILE:BOOL=OFF
                               -DYARP_COMPILE_BINDINGS:BOOL=${YARP_COMPILE_BINDINGS}
                               -DCREATE_PYTHON:BOOL=${ROBOTOLOGY_USES_PYTHON})


### PR DESCRIPTION
Enabled some options that are necessary to use the superbuild on iCub's head,
see https://github.com/robotology/robotology-superbuild/issues/88#issuecomment-397646254 .

Furthermore, remove some options that were hardcoded to OFF: not mentioning them
leave to the users the freedom to eventually set them to ON if they need them.