### PR TITLE
Updated WB-Toolbox informations

### DIFF
--- a/README.md
+++ b/README.md
@@ -508,7 +508,7 @@ can install some projects that depend on MATLAB, in particular:
 
 To use this software, you can simply enable its compilation using the `ROBOTOLOGY_USES_MATLAB` CMake option.
 Once this software has been compiled by the superbuild, you just need to add some directories of the robotology-superbuild install (typically `$ROBOTOLOGY_SUPERBUILD_ROOT/build/install`) to [the MATLAB path](http://mathworks.com/help/matlab/matlab_env/add-folders-to-search-path-upon-startup-on-unix-or-macintosh.html).
-In particular you need to add to the MATLAB path the `$ROBOTOLOGY_SUPERBUILD_ROOT/build/install/mex` directory and all the subdirectories `$ROBOTOLOGY_SUPERBUILD_ROOT/build/install/share/WB-Toolbox`.
+In particular you need to add to the MATLAB path the `$ROBOTOLOGY_SUPERBUILD_ROOT/build/install/mex` directory and all the subdirectories `$ROBOTOLOGY_SUPERBUILD_ROOT/build/install/share/WBToolbox`.
 
 As an example, you could add this line to your MATLAB script that uses the robotology-superbuild matlab software:
 ~~~

--- a/cmake/ProjectsTagsMaster.cmake
+++ b/cmake/ProjectsTagsMaster.cmake
@@ -5,4 +5,4 @@ macro(set_tag tag_name tag_value)
 endmacro()
 
 set_tag(RTF_TAG d06f411e8c976018c62f520577a03085a4c300bf)
-set_tag(WBToolbox_TAG e7998ffc391f876a991bcd20f9d0eaf4266827f9)
+set_tag(WBToolbox_TAG 0ff5ca4aecc607e1f1901abffe3b7c960a4e6b11)

--- a/cmake/template/startup_robotology_superbuild.m.in
+++ b/cmake/template/startup_robotology_superbuild.m.in
@@ -8,7 +8,7 @@ installDir = '@CMAKE_BINARY_DIR@/install';
 mexDir     = [installDir, filesep, 'mex'];
 mexWrapDir = [mexDir, filesep, 'mexwbi-wrappers'];
 mexUtDir   = [mexDir, filesep, 'mexwbi-utilities'];
-shareDir   = [installDir, filesep, 'share/WB-Toolbox'];
+shareDir   = [installDir, filesep, 'share/WBToolbox'];
 imgDir     = [shareDir, filesep, 'images'];
 
 if exist(mexDir, 'dir')


### PR DESCRIPTION
The toolbox's directory name inside `share/` was recently changed and the documentation needed to be updated accordingly. Furthermore, the tag has been bumped for including the latest bugfixes.

In order to avoid breaking controllers after https://github.com/robotology/wb-toolbox/pull/147, the tag in `master` points to the commit https://github.com/robotology/wb-toolbox/commit/0ff5ca4aecc607e1f1901abffe3b7c960a4e6b11.

Refer to https://github.com/robotology/wb-toolbox/pull/148.