### PR TITLE
Updated WBToolbox tag in ProjectsTagsMaster.cmake

### DIFF
--- a/cmake/ProjectsTagsMaster.cmake
+++ b/cmake/ProjectsTagsMaster.cmake
@@ -5,4 +5,3 @@ macro(set_tag tag_name tag_value)
 endmacro()
 
 set_tag(RTF_TAG d06f411e8c976018c62f520577a03085a4c300bf)
-set_tag(WBToolbox_TAG 0ff5ca4aecc607e1f1901abffe3b7c960a4e6b11)


### PR DESCRIPTION
Now the `master` branch of Whole Body Toolbox is aligned with the other robotology repositories.