### PR TITLE
Update BuildWBToolbox with the current dependencies

### DIFF
--- a/cmake/BuildWBToolbox.cmake
+++ b/cmake/BuildWBToolbox.cmake
@@ -1,4 +1,4 @@
-# Copyright (C) 2017  iCub Facility, Istituto Italiano di Tecnologia
+# Copyright (C) 2017-2018  iCub Facility, Istituto Italiano di Tecnologia
 # Authors: Silvio Traversaro <silvio.traversaro@iit.it>
 # CopyPolicy: Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
 
@@ -8,8 +8,8 @@ include(FindOrBuildPackage)
 find_or_build_package(YARP QUIET)
 find_or_build_package(ICUB QUIET)
 find_or_build_package(iDynTree QUIET)
-find_or_build_package(wholeBodyInterface QUIET)
-find_or_build_package(yarpWholeBodyInterface QUIET)
+find_or_build_package(qpOASES QUIET)
+
 
 ycm_ep_helper(WBToolbox TYPE GIT
               STYLE GITHUB
@@ -20,5 +20,4 @@ ycm_ep_helper(WBToolbox TYPE GIT
               DEPENDS YARP
                       ICUB
                       iDynTree
-                      wholeBodyInterface
-                      yarpWholeBodyInterface)
+                      qpOASES)


### PR DESCRIPTION
Fix https://github.com/robotology/robotology-superbuild/issues/120 and https://github.com/robotology/robotology-superbuild/issues/44 .