### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -507,16 +507,16 @@ can install some projects that depend on MATLAB, in particular:
 
 
 To use this software, you can simply enable its compilation using the `ROBOTOLOGY_USES_MATLAB` CMake option.
-Once this software has been compiled by the superbuild, you just need to add some directories of the robotology-superbuild install (typically `$ROBOTOLOGY_SUPERBUILD_ROOT/build/install`) to [the MATLAB path](http://mathworks.com/help/matlab/matlab_env/add-folders-to-search-path-upon-startup-on-unix-or-macintosh.html).
-In particular you need to add to the MATLAB path the `$ROBOTOLOGY_SUPERBUILD_ROOT/build/install/mex` directory and all the subdirectories `$ROBOTOLOGY_SUPERBUILD_ROOT/build/install/share/WBToolbox`.
+Once this software has been compiled by the superbuild, you just need to add some directories of the robotology-superbuild install (typically `$ROBOTOLOGY_SUPERBUILD_ROOT/build/install`) to [the MATLAB path](https://www.mathworks.com/help/matlab/matlab_env/what-is-the-matlab-search-path.html).
+In particular you need to add to the MATLAB path the `$ROBOTOLOGY_SUPERBUILD_INSTALL_PREFIX/mex` directory and all the subdirectories `$ROBOTOLOGY_SUPERBUILD_INSTALL_PREFIX/share/WBToolbox`.
 
 As an example, you could add this line to your MATLAB script that uses the robotology-superbuild matlab software:
 ~~~
-    addpath(['robotology_superbuild_install_folder'  /mex])
-    addpath(genpath(['robotology_superbuild_install_folder'  /share/WB-Toolbox]))available
+    addpath([getenv('ROBOTOLOGY_SUPERBUILD_INSTALL_PREFIX')  '/mex'])
+    addpath([getenv('ROBOTOLOGY_SUPERBUILD_INSTALL_PREFIX')  '/share/WBToolbox'])
 ~~~
 Anyway we strongly suggest that you add this directories to the MATLAB path in robust way,
-for example by modifying the `startup.m` or the `MATLABPATH` enviromental variable [as described in official MATLAB documentation](http://mathworks.com/help/matlab/matlab_env/add-folders-to-search-path-upon-startup-on-unix-or-macintosh.html).
+for example by modifying the `startup.m` or the `MATLABPATH` enviromental variable [as described in official MATLAB documentation](https://www.mathworks.com/help/matlab/matlab_env/add-folders-to-matlab-search-path-at-startup.html).
 Another way is to run (only once) the script `startup_robotology_superbuild.m` in the `$ROBOTOLOGY_SUPERBUILD_ROOT/build` folder. This should be enough to permanently add the required paths for all the toolbox that use MATLAB.
 
 For more info on configuring MATLAB software with the robotology-superbuild, please check the [WB-Toolbox README](https://github.com/robotology/WB-Toolbox).

--- a/README.md
+++ b/README.md
@@ -332,11 +332,11 @@ Currently the YCM superbuild does not support building a global install target, 
 
 To use this binaries and libraries, you should update the necessary environment variables.
 
-Set the environment variable `ROBOTOLOGY_SUPERBUILD_ROOT` so that it points to the  directory where you cloned the robotology-superbuild repository.
+Set the environment variable `ROBOTOLOGY_SUPERBUILD_ROOT` so that it points to the  directory where you cloned the robotology-superbuild repository, and `ROBOTOLOGY_SUPERBUILD_INSTALL_PREFIX`to the directory where you have installed the robotology-superbuild (`ROBOTOLOGY_SUPERBUILD_INSTALL_PREFIX = $ROBOTOLOGY_SUPERBUILD_INSTALL_PREFIX/build/install`)
 
-Append `$ROBOTOLOGY_SUPERBUILD_ROOT/build/install/bin` to your PATH.
+Append `$ROBOTOLOGY_SUPERBUILD_INSTALL_PREFIX/bin` to your PATH.
 
-Append `$ROBOTOLOGY_SUPERBUILD_ROOT/build/install/share/yarp`, `$ROBOTOLOGY_SUPERBUILD_ROOT/build/install/share/iCub`, `$ROBOTOLOGY_SUPERBUILD_ROOT/build/install/share/ICUBcontrib` and `$ROBOTOLOGY_SUPERBUILD_ROOT/robotology/icub-tests/suits` to your [`YARP_DATA_DIRS`](http://wiki.icub.org/yarpdoc/yarp_data_dirs.html) environment variable.
+Append `$ROBOTOLOGY_SUPERBUILD_INSTALL_PREFIX/share/yarp`, `$ROBOTOLOGY_SUPERBUILD_INSTALL_PREFIX/share/iCub`, `$ROBOTOLOGY_SUPERBUILD_INSTALL_PREFIX/share/ICUBcontrib` and `$ROBOTOLOGY_SUPERBUILD_ROOT/robotology/icub-tests/suits` to your [`YARP_DATA_DIRS`](http://wiki.icub.org/yarpdoc/yarp_data_dirs.html) environment variable.
 
 Software installed by the following [profile](#profile-cmake-options) or [dependencies](#dependencies-cmake-options) CMake options require specific enviromental variables to be set, as documented in options-specific documentation:
 * [`ROBOTOLOGY_ENABLE_DYNAMICS`](#dynamics) 


### PR DESCRIPTION
A link in the README.md was no longer working, and I have improved the `addpath()` by using the `ROBOTOLOGY_SUPERBUILD_INSTALL_PREFIX ` and removing what looks a typo error (the word [`available`](https://github.com/robotology/robotology-superbuild/compare/master...lrapetti:patch-1#diff-04c6e90faac2675aa89e2176d2eec7d8L516) after the function).