### PR TITLE
Updated ReadMe for Winodows: Configure your environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -317,18 +317,35 @@ cmake --build . --config Release
 ### Configure your environment
 Currently the YCM superbuild does not support building a global install target, so all binaries are installed in `robotology-superbuild/build/install/bin` and all libraries in `robotology-superbuild/build/install/lib`.
 
-To use this binaries and libraries, you should update the necessary environment variables.
+To use this binaries and libraries, you should update the necessary environment variables. You can use Rapid Enviornment Edittor to update the environment variables.
 
-Set the environment variable `ROBOTOLOGY_SUPERBUILD_ROOT` so that it points to the  directory where you cloned the robotology-superbuild repository, and `ROBOTOLOGY_SUPERBUILD_INSTALL_PREFIX`to the directory where you have installed the robotology-superbuild (`ROBOTOLOGY_SUPERBUILD_INSTALL_PREFIX = $ROBOTOLOGY_SUPERBUILD_INSTALL_PREFIX/build/install`)
+Set the environment variable `ROBOTOLOGY_SUPERBUILD_ROOT` so that it points to the  directory where you cloned the robotology-superbuild repository, and `ROBOTOLOGY_SUPERBUILD_INSTALL_PREFIX`to the directory where you have installed the robotology-superbuild:
+```
+ROBOTOLOGY_SUPERBUILD_ROOT=<path to code workspace>\robotology-superbuild
+ROBOTOLOGY_SUPERBUILD_INSTALL_PREFIX = %ROBOTOLOGY_SUPERBUILD_ROOT%\build\install
+```
 
-Append `$ROBOTOLOGY_SUPERBUILD_INSTALL_PREFIX/bin` to your PATH.
+Append `$ROBOTOLOGY_SUPERBUILD_INSTALL_PREFIX\bin` to your PATH:
+```
+Path=%ROBOTOLOGY_SUPERBUILD_INSTALL_PREFIX%\bin
+```
 
-Append `$ROBOTOLOGY_SUPERBUILD_INSTALL_PREFIX/share/yarp`, `$ROBOTOLOGY_SUPERBUILD_INSTALL_PREFIX/share/iCub`, `$ROBOTOLOGY_SUPERBUILD_INSTALL_PREFIX/share/ICUBcontrib` and `$ROBOTOLOGY_SUPERBUILD_ROOT/robotology/icub-tests/suits` to your [`YARP_DATA_DIRS`](http://wiki.icub.org/yarpdoc/yarp_data_dirs.html) environment variable.
+Append the following variables to your [`YARP_DATA_DIRS`](http://wiki.icub.org/yarpdoc/yarp_data_dirs.html) environment variable:
+```
+YARP_DATA_DIRS=
+%ROBOTOLOGY_SUPERBUILD_INSTALL_PREFIX%\share\yarp
+$ROBOTOLOGY_SUPERBUILD_INSTALL_PREFIX%\share\iCub
+$ROBOTOLOGY_SUPERBUILD_INSTALL_PREFIX%\share\ICUBcontrib
+$ROBOTOLOGY_SUPERBUILD_ROOT%\robotology\icub-tests\suits
+```
 
 Software installed by the following [profile](#profile-cmake-options) or [dependencies](#dependencies-cmake-options) CMake options require specific enviromental variables to be set, as documented in options-specific documentation:
 * [`ROBOTOLOGY_ENABLE_DYNAMICS`](#dynamics) 
 * [`ROBOTOLOGY_USES_MATLAB`](#matlab)
 * [`ROBOTOLOGY_USES_OCTAVE`](#octave)
+
+
+**Important: you can troubleshoot the applications, SDKs, and dll load dependencies using dependency walker: [link1](http://www.dependencywalker.com/) or [link2](https://github.com/lucasg/Dependencies)**
 
 Update
 ======

--- a/README.md
+++ b/README.md
@@ -317,7 +317,7 @@ cmake --build . --config Release
 ### Configure your environment
 Currently the YCM superbuild does not support building a global install target, so all binaries are installed in `robotology-superbuild/build/install/bin` and all libraries in `robotology-superbuild/build/install/lib`.
 
-To use this binaries and libraries, you should update the necessary environment variables. You can a program such as [Rapid Enviroment Editor](https://www.rapidee.com/) to update the environment variables.
+To use this binaries and libraries, you should update the necessary environment variables. You can use a program such as [Rapid Enviroment Editor](https://www.rapidee.com/) to update the environment variables.
 
 Set the environment variable `ROBOTOLOGY_SUPERBUILD_ROOT` so that it points to the  directory where you cloned the robotology-superbuild repository, and `ROBOTOLOGY_SUPERBUILD_INSTALL_PREFIX`to the directory where you have installed the robotology-superbuild:
 ```
@@ -325,7 +325,7 @@ ROBOTOLOGY_SUPERBUILD_ROOT=<path to code workspace>\robotology-superbuild
 ROBOTOLOGY_SUPERBUILD_INSTALL_PREFIX = %ROBOTOLOGY_SUPERBUILD_ROOT%\build\install
 ```
 
-Append `$ROBOTOLOGY_SUPERBUILD_INSTALL_PREFIX\bin` to your PATH:
+Append `%ROBOTOLOGY_SUPERBUILD_INSTALL_PREFIX%\bin` to your PATH:
 ```
 Path=%ROBOTOLOGY_SUPERBUILD_INSTALL_PREFIX%\bin
 ```

--- a/README.md
+++ b/README.md
@@ -317,7 +317,7 @@ cmake --build . --config Release
 ### Configure your environment
 Currently the YCM superbuild does not support building a global install target, so all binaries are installed in `robotology-superbuild/build/install/bin` and all libraries in `robotology-superbuild/build/install/lib`.
 
-To use this binaries and libraries, you should update the necessary environment variables. You can use Rapid Enviornment Edittor to update the environment variables.
+To use this binaries and libraries, you should update the necessary environment variables. You can a program such as [Rapid Enviroment Editor](https://www.rapidee.com/) to update the environment variables.
 
 Set the environment variable `ROBOTOLOGY_SUPERBUILD_ROOT` so that it points to the  directory where you cloned the robotology-superbuild repository, and `ROBOTOLOGY_SUPERBUILD_INSTALL_PREFIX`to the directory where you have installed the robotology-superbuild:
 ```

--- a/README.md
+++ b/README.md
@@ -334,9 +334,9 @@ Append the following variables to your [`YARP_DATA_DIRS`](http://wiki.icub.org/y
 ```
 YARP_DATA_DIRS=
 %ROBOTOLOGY_SUPERBUILD_INSTALL_PREFIX%\share\yarp
-$ROBOTOLOGY_SUPERBUILD_INSTALL_PREFIX%\share\iCub
-$ROBOTOLOGY_SUPERBUILD_INSTALL_PREFIX%\share\ICUBcontrib
-$ROBOTOLOGY_SUPERBUILD_ROOT%\robotology\icub-tests\suits
+%ROBOTOLOGY_SUPERBUILD_INSTALL_PREFIX%\share\iCub
+%ROBOTOLOGY_SUPERBUILD_INSTALL_PREFIX%\share\ICUBcontrib
+%ROBOTOLOGY_SUPERBUILD_ROOT%\robotology\icub-tests\suits
 ```
 
 Software installed by the following [profile](#profile-cmake-options) or [dependencies](#dependencies-cmake-options) CMake options require specific enviromental variables to be set, as documented in options-specific documentation:

--- a/README.md
+++ b/README.md
@@ -345,7 +345,7 @@ Software installed by the following [profile](#profile-cmake-options) or [depend
 * [`ROBOTOLOGY_USES_OCTAVE`](#octave)
 
 
-**Important: you can troubleshoot the applications, SDKs, and dll load dependencies using dependency walker: [link1](http://www.dependencywalker.com/) or [link2](https://github.com/lucasg/Dependencies)**
+ **If you have problems in Windows in launching executables or using libraries installed by superbuild, it is possible that due to some existing software on your machine your executables are not loading the correct `dll` for some of the dependencies. This is the so-called [DLL Hell](https://en.wikipedia.org/wiki/DLL_Hell#Causes), and for example it can happen if you are using the [Anaconda](https://www.anaconda.com/) Python distribution on your Windows installation.  To troubleshoot this kind of problems, you can open the library or executable that is not working correctly using the [`Dependencies`](https://github.com/lucasg/Dependencies) software. This software will show you which DLL your executable or library is loading. If you have any issue of this kind and need help, feel free to [open an issue in our issue tracker](https://github.com/robotology/robotology-superbuild/issues/new).**
 
 Update
 ======


### PR DESCRIPTION
@traversaro As we discussed in #151 I have updated the mentioned section of the readme in this PR:

- Increase the readability of configuring the Winodows: Configure your environment similar to the ones of Linux and MacOS.

- There was a typo on  `ROBOTOLOGY_SUPERBUILD_INSTALL_PREFIX = $ROBOTOLOGY_SUPERBUILD_INSTALL_PREFIX/build/install`, which is fixed, also `$` and `/` are changed to `%VARIABLE NAME%` and `\`.

- I have added a note `Important` at the end of Configuration section to respond [this comment](https://github.com/loc2/lab-events-demos/issues/62#issuecomment-449487202), so that the users can benefit from dependency walker to check if there are dependency problem, I have not mentioned the sophos antivirus problem directly.


-  