### PR TITLE
Cleanup related to run the superbuild inside the pc104/icub-head system

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,16 +57,16 @@ option(ROBOTOLOGY_ENABLE_CORE "Enable compilation of core software libraries." T
 option(ROBOTOLOGY_ENABLE_DYNAMICS "Enable compilation of software for balancing and walking." FALSE)
 option(ROBOTOLOGY_ENABLE_IHMC "Enable compilation of software necessary to use YARP with the IHMC Open Robotic Software." FALSE)
 option(ROBOTOLOGY_ENABLE_TELEOPERATION "Enable compilation of software for teleoperation." FALSE)
+option(ROBOTOLOGY_ENABLE_ICUB_HEAD "Enable compilation of software necessary on the system running in the head of the iCub robot." FALSE)
+include(CMakeDependentOption)
+cmake_dependent_option(ROBOTOLOGY_USES_CFW2CAN "Enable compilation of software that runs on the head of the iCub and depends on CFW2CAN." FALSE "ROBOTOLOGY_ENABLE_ICUB_HEAD" FALSE)
+
 
 # Mark as advanced all the profiles that do not have a mantainer
 option(ROBOTOLOGY_ENABLE_GRASPING "Enable compilation of software for grasping." FALSE)
 mark_as_advanced(ROBOTOLOGY_ENABLE_GRASPING)
 option(ROBOTOLOGY_ENABLE_IOL "Enable compilation of software necessary for the Interactive Objects Learning demo." FALSE)
 mark_as_advanced(ROBOTOLOGY_ENABLE_IOL)
-option(ROBOTOLOGY_ENABLE_ICUB_ROBOT_ETH "Enable compilation of software necessary on the pc running on the Ethernet-based iCub robot." FALSE)
-mark_as_advanced(ROBOTOLOGY_ENABLE_ICUB_ROBOT_ETH)
-option(ROBOTOLOGY_ENABLE_ICUB_ROBOT_CAN "Enable compilation of software necessary on the pc running on the CAN-based iCub robot." FALSE)
-mark_as_advanced(ROBOTOLOGY_ENABLE_ICUB_ROBOT_CAN)
 option(ROBOTOLOGY_ENABLE_R1_ROBOT "Enable compilation of software necessary on the pc running on the R1 robot." FALSE)
 mark_as_advanced(ROBOTOLOGY_ENABLE_R1_ROBOT)
 
@@ -165,8 +165,7 @@ if(ROBOTOLOGY_ENABLE_IOL)
 endif()
 
 # iCub Robot
-if(ROBOTOLOGY_ENABLE_ICUB_ROBOT_ETH OR ROBOTOLOGY_ENABLE_ICUB_ROBOT_CAN)
-  # Workaround for https://github.com/robotology/robotology-superbuild/issues/127
+if(ROBOTOLOGY_ENABLE_ICUB_HEAD)
   find_or_build_package(icub-firmware-shared)
   find_or_build_package(ICUB)
   find_or_build_package(robots-configuration)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -169,6 +169,7 @@ if(ROBOTOLOGY_ENABLE_ICUB_HEAD)
   find_or_build_package(icub-firmware-shared)
   find_or_build_package(ICUB)
   find_or_build_package(robots-configuration)
+  find_or_build_package(xsensmt-yarp-driver)
 endif()
 
 # R1 Robot

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Table of Contents
   * [Profile-specific documentation](#profile-specific-documentation)
     * [Core profile](#core)
     * [Dynamics profile](#dynamics)
+    * [iCub Head profile](#icub-head)
     * [Teleoperation profile](#teleoperation)
     * [IHMC profile](#ihmc)
   * [Dependencies-specific documentation](#dependencies-specific-documentation)
@@ -60,6 +61,7 @@ Note that any dependencies of the included packages that is not available in the
 |:------------:|:-----------:|:---------------------:|:-------------:|:----:|
 | `ROBOTOLOGY_ENABLE_CORE` | The core robotology software packages, necessary for most users. | [`YARP`](https://github.com/robotology/yarp), [`ICUB`](https://github.com/robotology/icub-main), [`RTF`](https://github.com/robotology/robot-testing), [`ICUBcontrib`](https://github.com/robotology/icub-contrib-common), [`icub-models`](https://github.com/robotology/icub-models) and[`icub-tests`](https://github.com/robotology/icub-tests). [`GazeboYARPPlugins`](https://github.com/robotology/GazeboYARPPlugins) and [`icub-gazebo`](https://github.com/robotology/icub-gazebo) if the `ROBOTOLOGY_USES_GAZEBO` option is enabled. | `ON` | [Documentation on Core profile.](#core) |
 | `ROBOTOLOGY_ENABLE_DYNAMICS` | The robotology software packages related to balancing, walking and force control. | [`iDynTree`](https://github.com/robotology/idyntree), [`blockfactory`](https://github.com/robotology/blockfactory), [`wb-Toolbox`](https://github.com/robotology/wb-Toolbox), [`whole-body-controllers`](https://github.com/robotology/whole-body-controllers), [`walking-controllers`](https://github.com/robotology/walking-controllers). [`icub-gazebo-wholebody`](https://github.com/robotology-playground/icub-gazebo-wholebody) if the `ROBOTOLOGY_USES_GAZEBO` option is enabled. | `OFF` | [Documentation on Dynamics profile.](#dynamics)  |
+| `ROBOTOLOGY_ENABLE_ICUB_HEAD` | The robotology software packages needed on the system that is running on the head of the iCub robot, or in general to communicate directly with iCub low-level devices. | [`robots-configurations`](https://github.com/robotology/robots-configuration), [`icub-firmware`](https://github.com/robotology/icub-firmware), [`icub-firmware-shared`](https://github.com/robotology/icub-firmware-shared). Furthermore, several additional devices are compiled in `YARP` and `ICUB` if this option is enabled. | `OFF` | [Documentation on iCub Head profile.](#icub-head)  |
 | `ROBOTOLOGY_ENABLE_TELEOPERATION` | The robotology software packages related to teleoperation. | [`walking-teleoperation`](https://github.com/robotology/walking-teleoperation). To use Oculus or Cyberith Omnidirectional Treadmill enable `ROBOTOLOGY_USES_OCULUS_SDK` and `ROBOTOLOGY_USES_CYBERITH_SDK` options. | `OFF` | [Documentation on teleoperation profile.](#teleoperation)  |
 | `ROBOTOLOGY_ENABLE_IHMC` | The robotology software packages necessary to use [YARP](https://github.com/robotology/yarp) with the [IHMC Open Robotic Software](https://github.com/ihmcrobotics/ihmc-open-robotics-software). | [`ihmc-ors-yarp`](https://github.com/robotology-playground/ihmc-ors-yarp) | `OFF` | [Documentation on IHMC profile.](#ihmc)  |
 
@@ -77,6 +79,8 @@ The dependencies CMake options specify if the packages dependending on something
 | `ROBOTOLOGY_USES_OCTAVE`  | Include software and plugins that depend on [Octave](https://www.gnu.org/software/octave/).  | `OFF` |  [Documentation on Octave dependency.](#octave) |
 | `ROBOTOLOGY_USES_OCULUS_SDK`  | Include software and plugins that depend on [Oculus](https://www.oculus.com/).  | `OFF` |  [Documentation on Oculus dependency.](#oculus) |
 | `ROBOTOLOGY_USES_CYBERITH_SDK`  | Include software and plugins that depend on [Cyberith](https://www.cyberith.com/).  | `OFF` |  [Documentation on Cyberith dependency.](#cyberith) |
+| `ROBOTOLOGY_USES_CFW2CAN`  | Include software and plugins that depend on [CFW2 CAN custom board](http://wiki.icub.org/wiki/CFW_card).  | `OFF` | No specific documentation is available for this  option, as it is just used with the [iCub Head profile](#icub-head), in which the related documentation can be found.  |
+
 
 Installation
 ============
@@ -445,6 +449,34 @@ Install matio following the [installation instructions](https://github.com/tbeu/
 ### Configuration
 `$ROBOTOLOGY_SUPERBUILD_INSTALL_PREFIX/share/codyco` must be appended to the `YARP_DATA_DIRS` enviromental variable.
 If you are using Linux or macOS, the `$ROBOTOLOGY_SUPERBUILD_INSTALL_PREFIX/share/robotology-superbuild/setup.sh` script will append the necessary path to `YARP_DATA_DIRS`.
+
+
+## iCub Head
+
+This profile is enabled by the `ROBOTOLOGY_ENABLE_ICUB_HEAD` CMake option. It is used in the system installed on iCub head,
+or if you are a developer that needs to access iCub hardware devices directly without passing through the iCub head.
+
+**Warning: the migration of existing iCub setups to use the robotology-superbuild is an ongoing process, and it is possible
+that your iCub still needs to be migrated. For any doubt, please get in contact with [icub-support](https://github.com/robotology/icub-support).
+
+The configuration and compilation of this profile is supported only on Linux systems.
+
+
+### System Dependencies
+The steps necessary to install the system dependencies of the iCub Head profile are provided in
+operating system-specific installation documentation, and no additional required system dependency is required.
+
+On old iCub systems equipped with the [CFW2 CAN board](http://wiki.icub.org/wiki/CFW_card), it may be necessary to have the cfw2can driver
+installed on the iCub head (it is tipically already pre-installed in the OS image installed in the system in the iCub head). In that
+case, you also need to enable the `ROBOTOLOGY_USES_CFW2CAN` option to compile the software that depends on cfw2can. In case of doubt,
+please always get in contact with [icub-support](https://github.com/robotology/icub-support).
+
+### Check the installation
+The `ROBOTOLOGY_ENABLE_ICUB_HEAD` installs several YARP devices for communicating directly with embedded boards of the iCub.
+To check if the installation was correct, you can list all the available YARP devices using the `yarpdev --list` command,
+and check if devices whose name is starting with `embObj` are present in the list. If those devices are present, then the installation
+should be working correctly.
+
 
 ## Teleoperation
 This profile is enabled by the `ROBOTOLOGY_ENABLE_TELEOPERATION` CMake option. 

--- a/cmake/BuildICUB.cmake
+++ b/cmake/BuildICUB.cmake
@@ -10,8 +10,7 @@ find_or_build_package(YARP QUIET)
 set(ICUB_DEPENDS "")
 list(APPEND ICUB_DEPENDS YARP)
 
-if(ROBOTOLOGY_ENABLE_ICUB_ROBOT_ETH OR ROBOTOLOGY_ENABLE_ICUB_ROBOT_CAN)
-  set(ROBOTOLOGY_ENABLE_ICUB_ROBOT ON)
+if(ROBOTOLOGY_ENABLE_ICUB_HEAD)
   find_or_build_package(icub-firmware-shared QUIET)
   list(APPEND ICUB_DEPENDS icub-firmware-shared)
 endif()
@@ -33,25 +32,25 @@ ycm_ep_helper(ICUB TYPE GIT
                    CMAKE_CACHE_ARGS -DENABLE_icubmod_cartesiancontrollerserver:BOOL=ON
                                     -DENABLE_icubmod_cartesiancontrollerclient:BOOL=ON
                                     -DENABLE_icubmod_gazecontrollerclient:BOOL=ON
-                                    -DENABLE_icubmod_serial:BOOL=${ROBOTOLOGY_ENABLE_ICUB_ROBOT}
-                                    -DENABLE_icubmod_serialport:BOOL=${ROBOTOLOGY_ENABLE_ICUB_ROBOT}
-                                    -DENABLE_icubmod_skinWrapper:BOOL=${ROBOTOLOGY_ENABLE_ICUB_ROBOT}
-                                    -DENABLE_icubmod_dragonfly2:BOOL=${ROBOTOLOGY_ENABLE_ICUB_ROBOT}
-                                    -DENABLE_icubmod_portaudio:BOOL=${ROBOTOLOGY_ENABLE_ICUB_ROBOT}
-                                    -DENABLE_icubmod_sharedcan:BOOL=${ROBOTOLOGY_ENABLE_ICUB_ROBOT_CAN}
-                                    -DENABLE_icubmod_canmotioncontrol:BOOL=${ROBOTOLOGY_ENABLE_ICUB_ROBOT_CAN}
-                                    -DENABLE_icubmod_canBusAnalogSensor:BOOL=${ROBOTOLOGY_ENABLE_ICUB_ROBOT_CAN}
-                                    -DENABLE_icubmod_canBusInertialMTB:BOOL=${ROBOTOLOGY_ENABLE_ICUB_ROBOT_CAN}
-                                    -DENABLE_icubmod_canBusSkin:BOOL=${ROBOTOLOGY_ENABLE_ICUB_ROBOT_CAN}
-                                    -DENABLE_icubmod_canBusVirtualAnalogSensor:BOOL=${ROBOTOLOGY_ENABLE_ICUB_ROBOT_CAN}
-                                    -DENABLE_icubmod_cfw2can:BOOL=${ROBOTOLOGY_ENABLE_ICUB_ROBOT_CAN}
-                                    -DENABLE_icubmod_embObjFTsensor:BOOL=${ROBOTOLOGY_ENABLE_ICUB_ROBOT_ETH}
-                                    -DENABLE_icubmod_embObjIMU:BOOL=${ROBOTOLOGY_ENABLE_ICUB_ROBOT_ETH}
-                                    -DENABLE_icubmod_embObjInertials:BOOL=${ROBOTOLOGY_ENABLE_ICUB_ROBOT_ETH}
-                                    -DENABLE_icubmod_embObjMais:BOOL=${ROBOTOLOGY_ENABLE_ICUB_ROBOT_ETH}
-                                    -DENABLE_icubmod_embObjMotionControl:BOOL=${ROBOTOLOGY_ENABLE_ICUB_ROBOT_ETH}
-                                    -DENABLE_icubmod_embObjSkin:BOOL=${ROBOTOLOGY_ENABLE_ICUB_ROBOT_ETH}
-                                    -DENABLE_icubmod_embObjStrain:BOOL=${ROBOTOLOGY_ENABLE_ICUB_ROBOT_ETH}
-                                    -DENABLE_icubmod_embObjVirtualAnalogSensor:BOOL=${ROBOTOLOGY_ENABLE_ICUB_ROBOT_ETH}
-                                    -DENABLE_icubmod_parametricCalibratorEth:BOOL=${ROBOTOLOGY_ENABLE_ICUB_ROBOT_ETH}
+                                    -DENABLE_icubmod_serial:BOOL=${ROBOTOLOGY_ENABLE_ICUB_HEAD}
+                                    -DENABLE_icubmod_serialport:BOOL=${ROBOTOLOGY_ENABLE_ICUB_HEAD}
+                                    -DENABLE_icubmod_skinWrapper:BOOL=${ROBOTOLOGY_ENABLE_ICUB_HEAD}
+                                    -DENABLE_icubmod_dragonfly2:BOOL=${ROBOTOLOGY_ENABLE_ICUB_HEAD}
+                                    -DENABLE_icubmod_portaudio:BOOL=${ROBOTOLOGY_ENABLE_ICUB_HEAD}
+                                    -DENABLE_icubmod_sharedcan:BOOL=${ROBOTOLOGY_ENABLE_ICUB_HEAD}
+                                    -DENABLE_icubmod_canmotioncontrol:BOOL=${ROBOTOLOGY_ENABLE_ICUB_HEAD}
+                                    -DENABLE_icubmod_canBusAnalogSensor:BOOL=${ROBOTOLOGY_ENABLE_ICUB_HEAD}
+                                    -DENABLE_icubmod_canBusInertialMTB:BOOL=${ROBOTOLOGY_ENABLE_ICUB_HEAD}
+                                    -DENABLE_icubmod_canBusSkin:BOOL=${ROBOTOLOGY_ENABLE_ICUB_HEAD}
+                                    -DENABLE_icubmod_canBusVirtualAnalogSensor:BOOL=${ROBOTOLOGY_ENABLE_ICUB_HEAD}
+                                    -DENABLE_icubmod_cfw2can:BOOL=${ROBOTOLOGY_USES_CFW2CAN}
+                                    -DENABLE_icubmod_embObjFTsensor:BOOL=${ROBOTOLOGY_ENABLE_ICUB_HEAD}
+                                    -DENABLE_icubmod_embObjIMU:BOOL=${ROBOTOLOGY_ENABLE_ICUB_HEAD}
+                                    -DENABLE_icubmod_embObjInertials:BOOL=${ROBOTOLOGY_ENABLE_ICUB_HEAD}
+                                    -DENABLE_icubmod_embObjMais:BOOL=${ROBOTOLOGY_ENABLE_ICUB_HEAD}
+                                    -DENABLE_icubmod_embObjMotionControl:BOOL=${ROBOTOLOGY_ENABLE_ICUB_HEAD}
+                                    -DENABLE_icubmod_embObjSkin:BOOL=${ROBOTOLOGY_ENABLE_ICUB_HEAD}
+                                    -DENABLE_icubmod_embObjStrain:BOOL=${ROBOTOLOGY_ENABLE_ICUB_HEAD}
+                                    -DENABLE_icubmod_embObjVirtualAnalogSensor:BOOL=${ROBOTOLOGY_ENABLE_ICUB_HEAD}
+                                    -DENABLE_icubmod_parametricCalibratorEth:BOOL=${ROBOTOLOGY_ENABLE_ICUB_HEAD}
                                     -DICUBMAIN_COMPILE_SIMULATORS:BOOL=${ICUBMAIN_COMPILE_SIMULATORS})

--- a/cmake/BuildYARP.cmake
+++ b/cmake/BuildYARP.cmake
@@ -16,10 +16,6 @@ else()
   set(YARP_COMPILE_BINDINGS OFF)
 endif()
 
-if(ROBOTOLOGY_ENABLE_ICUB_ROBOT_ETH OR ROBOTOLOGY_ENABLE_ICUB_ROBOT_CAN)
-  set(ROBOTOLOGY_ENABLE_ICUB_ROBOT ON)
-endif()
-
 ycm_ep_helper(YARP TYPE GIT
                    STYLE GITHUB
                    REPOSITORY robotology/yarp.git
@@ -46,11 +42,11 @@ ycm_ep_helper(YARP TYPE GIT
                               -DENABLE_yarpcar_human:BOOL=ON
                               -DENABLE_yarpcar_rossrv:BOOL=ON
                               -DENABLE_yarpmod_fakebot:BOOL=ON
-                              -DENABLE_yarpmod_imuBosch_BNO055:BOOL=${ROBOTOLOGY_ENABLE_ICUB_ROBOT}
+                              -DENABLE_yarpmod_imuBosch_BNO055:BOOL=${ROBOTOLOGY_ENABLE_ICUB_HEAD}
                               -DENABLE_yarpmod_SDLJoypad:BOOL=ON
                               -DYARP_COMPILE_EXPERIMENTAL_WRAPPERS:BOOL=ON
                               -DYARP_COMPILE_RTF_ADDONS:BOOL=ON
                               -DYARP_COMPILE_BINDINGS:BOOL=${YARP_COMPILE_BINDINGS}
-                              -DYARP_USE_I2C:BOOL=${ROBOTOLOGY_ENABLE_ICUB_ROBOT}
+                              -DYARP_USE_I2C:BOOL=${ROBOTOLOGY_ENABLE_ICUB_HEAD}
                               -DYARP_USE_SDL:BOOL=ON
                               -DCREATE_PYTHON:BOOL=${ROBOTOLOGY_USES_PYTHON})

--- a/cmake/Buildrobots-configuration.cmake
+++ b/cmake/Buildrobots-configuration.cmake
@@ -8,6 +8,14 @@ include(FindOrBuildPackage)
 find_or_build_package(YARP QUIET)
 find_or_build_package(ICUBcontrib QUIET)
 
+# This custom code is present to make sure that:
+# * On iCub Head images, the behavior is to install only those specific robot files
+# * On other systems (i.e. developers laptop) all the robots configuration files are installed
+set(robots-configuration_CMAKE_ARGS "")
+if("$ENV{YARP_ROBOT_NAME}" STREQUAL "")
+    list(APPEND robots-configuration_CMAKE_ARGS "-DINSTALL_ALL_ROBOTS:BOOL=ON")
+endif()
+
 
 ycm_ep_helper(robots-configuration TYPE GIT
                                    STYLE GITHUB
@@ -15,4 +23,5 @@ ycm_ep_helper(robots-configuration TYPE GIT
                                    DEPENDS YARP
                                            ICUBcontrib
                                    COMPONENT iCub
-                                   FOLDER robotology)
+                                   FOLDER robotology
+                                   CMAKE_ARGS ${robots-configuration_CMAKE_ARGS})

--- a/cmake/Buildxsensmt-yarp-driver.cmake
+++ b/cmake/Buildxsensmt-yarp-driver.cmake
@@ -1,0 +1,15 @@
+# Copyright (C) 2019  iCub Facility, Istituto Italiano di Tecnologia
+# CopyPolicy: Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
+
+include(YCMEPHelper)
+include(FindOrBuildPackage)
+
+find_or_build_package(YARP QUIET)
+
+ycm_ep_helper(xsensmt-yarp-driver TYPE GIT
+              STYLE GITHUB
+              REPOSITORY robotology-playground/xsensmt-yarp-driver.git
+              TAG master
+              COMPONENT iCub
+              FOLDER robotology
+              DEPENDS YARP)


### PR DESCRIPTION
This PR contains several commits related to the cleanup of the part of the superbuild used to automatize the setup of iCub software on the head of the iCub robot. It consolidates a few commits (sorry) to avoid overloading the CI infrastructure. .

Details explanation is present in each commit: 

* https://github.com/robotology/robotology-superbuild/commit/9cbfd6528bb7181e86e3560eec654e4af046c8d3 :  Renamed ROBOTOLOGY_ENABLE_ICUB_ROBOT_ETH and ROBOTOLOGY_ENABLE_ICUB_ROBOT_CAN options to ROBOTOLOGY_ENABLE_ICUB_HEAD e ROBOTOLOGY_USES_CFW2CAN
* https://github.com/robotology/robotology-superbuild/commit/bf65022af7bf7568121794e0be8ba485a0bf4968 : Make sure that robots-configurations installs fine on system without YARP_ROBOT_NAME defined as an enviroment variable 
* https://github.com/robotology/robotology-superbuild/commit/bccea52438684881408fe51364b2e279c4c6a9f4 : Add `xsensmt-yarp-driver` repository to the iCub Head profile 
*  https://github.com/robotology/robotology-superbuild/commit/1a3a0bdb7b29ff1884d74abe8df5ec1f6ed70b7d :  Add documentation on the iCub Head profile to the README

The major modification that people that already use this on the robot (@nunoguedelha @GiulioRomualdi  @S-Dafarra @gabrielenava @aerydna @Nicogene perhaps someone in @serena-ivaldi's lab, @InriaBrice ?)  **must be aware of** is: 
* Once you update the robotology-superbuild after this PR, you should manually set to `ON` the `ROBOTOLOGY_ENABLE_ICUB_HEAD` option 

Instead, an interesting combined effect of this PR, https://github.com/robotology/robots-configuration/pull/93 and https://github.com/robotology/robots-configuration/pull/92 when they are merged is that now the `ROBOTOLOGY_ENABLE_ICUB_HEAD` can be used in any Linux-based computer, so also people that need to connect directly to boards such as the EMS or the FT sensor, can do that via the superbuild, just enabling the `ROBOTOLOGY_ENABLE_ICUB_HEAD`  option. @fjandrad @InesSorrentino @HosameldinMohamed @marcoaccame @valegagge 