### PR TITLE
[travis] Drop compilation on clang on Linux

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,6 @@ stages:
 
 compiler:
   - gcc
-  - clang
 
 env:
   global:


### PR DESCRIPTION
As discussed in https://github.com/robotology/robotology-superbuild/pull/196#issuecomment-479784237 . 