### PR TITLE
Add missing ICUB_HEAD profile options in the BuildICUB script

### DIFF
--- a/cmake/BuildICUB.cmake
+++ b/cmake/BuildICUB.cmake
@@ -52,5 +52,7 @@ ycm_ep_helper(ICUB TYPE GIT
                                     -DENABLE_icubmod_embObjSkin:BOOL=${ROBOTOLOGY_ENABLE_ICUB_HEAD}
                                     -DENABLE_icubmod_embObjStrain:BOOL=${ROBOTOLOGY_ENABLE_ICUB_HEAD}
                                     -DENABLE_icubmod_embObjVirtualAnalogSensor:BOOL=${ROBOTOLOGY_ENABLE_ICUB_HEAD}
+                                    -DENABLE_icubmod_parametricCalibrator:BOOL=${ROBOTOLOGY_ENABLE_ICUB_HEAD}
                                     -DENABLE_icubmod_parametricCalibratorEth:BOOL=${ROBOTOLOGY_ENABLE_ICUB_HEAD}
+                                    -DENABLE_icubmod_xsensmtx:BOOL=${ROBOTOLOGY_ENABLE_ICUB_HEAD}
                                     -DICUBMAIN_COMPILE_SIMULATORS:BOOL=${ICUBMAIN_COMPILE_SIMULATORS})


### PR DESCRIPTION
As emerged during the tests on iCubGenova01 ( see https://github.com/robotology/robotology-superbuild/pull/212 ).