### PR TITLE
If ICUB_HEAD profile is enabled enable serialport device in YARP

### DIFF
--- a/cmake/BuildYARP.cmake
+++ b/cmake/BuildYARP.cmake
@@ -44,6 +44,7 @@ ycm_ep_helper(YARP TYPE GIT
                               -DENABLE_yarpmod_fakebot:BOOL=ON
                               -DENABLE_yarpmod_imuBosch_BNO055:BOOL=${ROBOTOLOGY_ENABLE_ICUB_HEAD}
                               -DENABLE_yarpmod_SDLJoypad:BOOL=ON
+                              -DENABLE_yarpmod_serialport:BOOL=${ROBOTOLOGY_ENABLE_ICUB_HEAD}
                               -DYARP_COMPILE_EXPERIMENTAL_WRAPPERS:BOOL=ON
                               -DYARP_COMPILE_RTF_ADDONS:BOOL=ON
                               -DYARP_COMPILE_BINDINGS:BOOL=${YARP_COMPILE_BINDINGS}


### PR DESCRIPTION
This was detected by @pattacini when testing face expressions on the `iCubGenova01` "Blacky" robot. This matches indeed the documentation present in http://wiki.icub.org/wiki/Compilation_on_the_pc104 . In that page, regarding YARP also the `serial` device was enabled, but apparently the `serial` device is a builtin device of YARP (https://github.com/robotology/yarp/blob/v3.1.2/src/libYARP_dev/src/devices/ServerSerial/ServerSerial.cpp#L17) so there is no need to explicitly enable it (probably this changed at some point in the past). Furthermore, also the `portaudio` device  is enabled, but I do not see it used anywhere in https://github.com/robotology/robots-configuration/search?q=portaudio&unscoped_q=portaudio, so I guess that device is not actually required. 