### PR TITLE
Set IDYNTREE_USES_IPOPT to ON in BuildiDynTree

### DIFF
--- a/cmake/BuildiDynTree.cmake
+++ b/cmake/BuildiDynTree.cmake
@@ -18,7 +18,8 @@ ycm_ep_helper(iDynTree TYPE GIT
               TAG master
               COMPONENT dynamics
               FOLDER robotology
-              CMAKE_ARGS -DIDYNTREE_USES_MATLAB:BOOL=${ROBOTOLOGY_USES_MATLAB}
+              CMAKE_ARGS -DIDYNTREE_USES_IPOPT:BOOL=ON
+                         -DIDYNTREE_USES_MATLAB:BOOL=${ROBOTOLOGY_USES_MATLAB}
                          -DIDYNTREE_USES_PYTHON:BOOL=${ROBOTOLOGY_USES_PYTHON}
                          -DIDYNTREE_USES_OCTAVE:BOOL=${ROBOTOLOGY_USES_OCTAVE}
               DEPENDS ${iDynTree_DEPENDS})


### PR DESCRIPTION
Fix https://github.com/robotology/robotology-superbuild/issues/221 .
The usual problems related to the use of `CMAKE_ARGS` discussed in https://github.com/robotology/robotology-superbuild/issues/68 apply. 