### PR TITLE
Bump YCM bootstrapped version to latest released version v0.10.4

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -99,8 +99,8 @@ endif()
 # Bootstrap YCM
 set(YCM_FOLDER robotology)
 set(YCM_COMPONENT core)
-set(YCM_TAG v0.10.2)
-set(YCM_MINIMUM_VERSION 0.10.2)
+set(YCM_TAG v0.10.4)
+set(YCM_MINIMUM_VERSION 0.10.4)
 include(YCMBootstrap)
 
 include(FindOrBuildPackage)


### PR DESCRIPTION
Without this change, YARP downloads its own version of YCM, as 0.10.2 is not recent enough for YARP.