### PR TITLE
Point osqp to upstream version v0.5.0

### DIFF
--- a/cmake/Buildosqp.cmake
+++ b/cmake/Buildosqp.cmake
@@ -6,8 +6,8 @@ include(YCMEPHelper)
 
 ycm_ep_helper(osqp TYPE GIT
               STYLE GITHUB
-              REPOSITORY robotology-dependencies/osqp.git
-              TAG fix-lf-problems
+              REPOSITORY oxfordcontrol/osqp.git
+              TAG  v0.5.0
               COMPONENT dynamics
               FOLDER external
               CMAKE_ARGS -DUNITTESTS:BOOL=OFF)


### PR DESCRIPTION
Check if the Xenial problem discussed in comments linked in https://github.com/robotology/robotology-superbuild/issues/242 is still present. 