### PR TITLE
Set ICUB_USE_icub_firmware_shared to ON for compiling CAN/ETH tools

### DIFF
--- a/cmake/BuildICUB.cmake
+++ b/cmake/BuildICUB.cmake
@@ -61,4 +61,5 @@ ycm_ep_helper(ICUB TYPE GIT
                                     -DENABLE_icubmod_parametricCalibrator:BOOL=${ROBOTOLOGY_ENABLE_ICUB_HEAD}
                                     -DENABLE_icubmod_parametricCalibratorEth:BOOL=${ROBOTOLOGY_ENABLE_ICUB_HEAD}
                                     -DENABLE_icubmod_xsensmtx:BOOL=${ROBOTOLOGY_ENABLE_ICUB_HEAD}
+                                    -DICUB_USE_icub_firmware_shared:BOOL=${ROBOTOLOGY_ENABLE_ICUB_HEAD}
                                     -DICUBMAIN_COMPILE_SIMULATORS:BOOL=${ICUBMAIN_COMPILE_SIMULATORS})


### PR DESCRIPTION
Sets ICUB_USE_icub_firmware_shared to ON from ROBOTOLOGY_ENABLE_ICUB_HEAD for compiling the usual tools `canLoader, ethLoader, FirmwareUpdater, strainCalib, strainCalibrationDataAcquisition`.
Fixes https://github.com/robotology/robotology-superbuild/issues/281.