### PR TITLE
Always disable Python bindings of robot-testing-framework

### DIFF
--- a/cmake/BuildRobotTestingFramework.cmake
+++ b/cmake/BuildRobotTestingFramework.cmake
@@ -9,7 +9,7 @@ ycm_ep_helper(RobotTestingFramework TYPE GIT
                                     STYLE GITHUB
                                     REPOSITORY robotology/robot-testing-framework.git
                                     CMAKE_ARGS -DENABLE_LUA_PLUGIN:BOOL=${ROBOTOLOGY_USES_LUA}
-                                               -DENABLE_PYTHON_PLUGIN:BOOL=${ROBOTOLOGY_USES_PYTHON}
+                                               -DENABLE_PYTHON_PLUGIN:BOOL=OFF
                                     COMPONENT core
                                     FOLDER robotology)
 


### PR DESCRIPTION
Unfortunately RTF does not support Python3, so it is better to just remove python support for it from the superbuild: https://github.com/robotology/robot-testing-framework/issues/37 .

This is a first step towards supporting macOS ( https://github.com/robotology/robotology-superbuild/issues/289 ) and Ubuntu 20.04 (that will use Python 3 by default). 