### PR TITLE
Windows CI: Add  missing qt5 ports to vcpkg dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,7 +79,7 @@ jobs:
         # To avoid problems with non-relocatable packages, we unzip the archive exactly in the same C:/vcpkg-robotology 
         # that has been used to create the pre-compiled archive
         cd C:/
-        wget https://github.com/robotology-playground/robotology-superbuild-dependencies/releases/download/v0.0.1/vcpkg-robotology.zip
+        wget https://github.com/robotology-playground/robotology-superbuild-dependencies/releases/download/v0.0.2/vcpkg-robotology.zip
         unzip vcpkg-robotology.zip        
         
     # ===================


### PR DESCRIPTION
In particular, add `qt5-declarative`, `qt5-multimedia` and `qt5-quickcontrols2` by using https://github.com/robotology-playground/robotology-superbuild-dependencies/releases/tag/0.0.2 .