### PR TITLE
Added USB camera yarp device in icub-head profile

### DIFF
--- a/.ci/install_debian.sh
+++ b/.ci/install_debian.sh
@@ -10,7 +10,7 @@ export DEBIAN_FRONTEND=noninteractive
 apt-get install -y clang valgrind ccache ninja-build
 
 # Core dependencies
-apt-get install -y libeigen3-dev build-essential cmake cmake-curses-gui coinor-libipopt-dev libboost-system-dev libboost-filesystem-dev libboost-thread-dev libtinyxml-dev libace-dev libedit-dev libgsl0-dev libopencv-dev libode-dev liblua5.1-dev lua5.1 git swig qtbase5-dev qtdeclarative5-dev qtmultimedia5-dev qml-module-qtquick2 qml-module-qtquick-window2 qml-module-qtmultimedia qml-module-qtquick-dialogs qml-module-qtquick-controls qml-module-qt-labs-folderlistmodel qml-module-qt-labs-settings libsdl1.2-dev libxml2-dev
+apt-get install -y libeigen3-dev build-essential cmake cmake-curses-gui coinor-libipopt-dev libboost-system-dev libboost-filesystem-dev libboost-thread-dev libtinyxml-dev libace-dev libedit-dev libgsl0-dev libopencv-dev libode-dev liblua5.1-dev lua5.1 git swig qtbase5-dev qtdeclarative5-dev qtmultimedia5-dev qml-module-qtquick2 qml-module-qtquick-window2 qml-module-qtmultimedia qml-module-qtquick-dialogs qml-module-qtquick-controls qml-module-qt-labs-folderlistmodel qml-module-qt-labs-settings libsdl1.2-dev libxml2-dev libv4l-dev
 
 # Python
 apt-get install -y python-dev

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ Complete documentation on how to use a YCM-based superbuild is available in the 
 ### System Dependencies
 On Debian based systems (as Ubuntu) you can install the C++ toolchain, Git, CMake and Eigen (and other dependencies necessary for the software include in `robotology-superbuild`) using `apt-get`:
 ```
-sudo apt-get install libeigen3-dev build-essential cmake cmake-curses-gui coinor-libipopt-dev libboost-system-dev libboost-filesystem-dev libboost-thread-dev libtinyxml-dev libedit-dev libace-dev libgsl0-dev libopencv-dev libode-dev liblua5.1-dev lua5.1 git swig qtbase5-dev qtdeclarative5-dev qtmultimedia5-dev qml-module-qtquick2 qml-module-qtquick-window2 qml-module-qtmultimedia qml-module-qtquick-dialogs qml-module-qtquick-controls qml-module-qt-labs-folderlistmodel qml-module-qt-labs-settings libsdl1.2-dev libxml2-dev
+sudo apt-get install libeigen3-dev build-essential cmake cmake-curses-gui coinor-libipopt-dev libboost-system-dev libboost-filesystem-dev libboost-thread-dev libtinyxml-dev libedit-dev libace-dev libgsl0-dev libopencv-dev libode-dev liblua5.1-dev lua5.1 git swig qtbase5-dev qtdeclarative5-dev qtmultimedia5-dev qml-module-qtquick2 qml-module-qtquick-window2 qml-module-qtmultimedia qml-module-qtquick-dialogs qml-module-qtquick-controls qml-module-qt-labs-folderlistmodel qml-module-qt-labs-settings libsdl1.2-dev libxml2-dev libv4l-dev
 ```
 
 If you enabled any [profile](#profile-cmake-options) or [dependency](#dependencies-cmake-options) specific CMake option you may need to install additional system dependencies, following the dependency-specific documentation (in particular, the `ROBOTOLOGY_USES_GAZEBO` option is enabled by default, so you should install Gazebo unless you plan to disable this option):

--- a/cmake/BuildYARP.cmake
+++ b/cmake/BuildYARP.cmake
@@ -16,6 +16,16 @@ else()
   set(YARP_COMPILE_BINDINGS OFF)
 endif()
 
+
+if (APPLE OR WIN32)
+  set(ENABLE_USBCAMERA OFF)
+else()
+  set(ENABLE_USBCAMERA ${ROBOTOLOGY_ENABLE_ICUB_HEAD})
+endif()
+
+
+
+
 ycm_ep_helper(YARP TYPE GIT
                    STYLE GITHUB
                    REPOSITORY robotology/yarp.git
@@ -51,4 +61,5 @@ ycm_ep_helper(YARP TYPE GIT
                               -DYARP_USE_I2C:BOOL=${ROBOTOLOGY_ENABLE_ICUB_HEAD}
                               -DYARP_USE_SDL:BOOL=ON
                               -DCREATE_PYTHON:BOOL=${ROBOTOLOGY_USES_PYTHON}
-                              -DCREATE_LUA:BOOL=${ROBOTOLOGY_USES_LUA})
+                              -DCREATE_LUA:BOOL=${ROBOTOLOGY_USES_LUA}
+                              -DENABLE_yarpmod_usbCamera:BOOL=${ENABLE_USBCAMERA})


### PR DESCRIPTION
With this PR the `usbCamera yarp device` is compiled if `icub-head profile` is active.
Since some robots mount usb cameras, it is important to make the corresponding device available.

To achieve this, I changed the cmake file ```cmake/BuildYARP.cmake ``` enabling the usbCamera cmake option only on Linux system.
Moreover I updated the installation instructions for Linux system by adding `libv4l-dev` library, because `usbCamera`is based on `video4linux library`.

I verified the `usbCamera` device is available using `yarpdev --list` command. I think this check besides CI tests, could be sufficient to verify that these changes could be ok.
