### PR TITLE
Update installations docs to mention that CMake 3.12 is required and require it at CMake level

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@
 # Authors: Silvio Traversaro <silvio.traversaro@iit.it>
 # CopyPolicy: Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
 
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.12)
 project(robotology-superbuild NONE)
 
 ## we have to enable C because it is currently used
@@ -99,16 +99,6 @@ elseif(ROBOTOLOGY_PROJECT_TAGS STREQUAL "Custom")
 else()
     message(FATAL_ERROR "The ROBOTOLOGY_PROJECT_TAGS variable can be Stable, Unstable or Custom. ${ROBOTOLOGY_PROJECT_TAGS} value is not supported.")
 endif()
-
-#Set CMake policies
-if(NOT CMAKE_VERSION VERSION_LESS 3.0)
-    cmake_policy(SET CMP0045 NEW)
-    cmake_policy(SET CMP0046 NEW)
-endif()
-if(NOT CMAKE_VERSION VERSION_LESS 3.1)
-    cmake_policy(SET CMP0054 NEW)
-endif()
-
 
 # Bootstrap YCM
 set(YCM_FOLDER robotology)

--- a/README.md
+++ b/README.md
@@ -107,6 +107,11 @@ On Debian based systems (as Ubuntu) you can install the C++ toolchain, Git, CMak
 sudo apt-get install libeigen3-dev build-essential cmake cmake-curses-gui coinor-libipopt-dev libboost-system-dev libboost-filesystem-dev libboost-thread-dev libtinyxml-dev libedit-dev libace-dev libgsl0-dev libopencv-dev libode-dev liblua5.1-dev lua5.1 git swig qtbase5-dev qtdeclarative5-dev qtmultimedia5-dev qml-module-qtquick2 qml-module-qtquick-window2 qml-module-qtmultimedia qml-module-qtquick-dialogs qml-module-qtquick-controls qml-module-qt-labs-folderlistmodel qml-module-qt-labs-settings libsdl1.2-dev libxml2-dev libv4l-dev
 ```
 
+For what regards CMake, the robotology-superbuild requires CMake 3.12 . If you are using a system in which the default version of CMake is older, you can easily install a newer CMake version in several ways. For the following distributions, we recommend the following methods:  
+* Ubuntu 18.04 : use the latest CMake release in the [Kitware APT repository](https://apt.kitware.com/). You can find the full instructions for the installation on the website.
+* Debian 9 : use the CMake 3.13.2 in the `stretch-backports` repository, following the instructions to install from backports available in  [Debian documentation](https://backports.debian.org/Instructions/).
+More details can be found at https://github.com/robotology/QA/issues/364 .
+
 If you enabled any [profile](#profile-cmake-options) or [dependency](#dependencies-cmake-options) specific CMake option you may need to install additional system dependencies, following the dependency-specific documentation (in particular, the `ROBOTOLOGY_USES_GAZEBO` option is enabled by default, so you should install Gazebo unless you plan to disable this option):
 * [`ROBOTOLOGY_USES_GAZEBO`](#gazebo)
 


### PR DESCRIPTION
Following the announcement in https://github.com/robotology/QA/issues/364 and the discussion  in  https://github.com/robotology/ycm/issues/261 ,  we require CMake 3.12 now . This PR updates the documentation, indicating the recommended way to install a recent CMake in Debian 9 and Ubuntu 18.04 . 