### PR TITLE
Set ROBOTOLOGY_ENABLE_ROBOT_TESTING default value to OFF

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,7 +54,7 @@ option(ROBOTOLOGY_USES_CYBERITH_SDK "Enable compilation of software that depend 
 
 # Enable/disable different profiles
 option(ROBOTOLOGY_ENABLE_CORE "Enable compilation of core software libraries." TRUE)
-option(ROBOTOLOGY_ENABLE_ROBOT_TESTING "Enable compilation of software for robot testing." TRUE)
+option(ROBOTOLOGY_ENABLE_ROBOT_TESTING "Enable compilation of software for robot testing." FALSE)
 option(ROBOTOLOGY_ENABLE_DYNAMICS "Enable compilation of software for balancing and walking." FALSE)
 option(ROBOTOLOGY_ENABLE_TELEOPERATION "Enable compilation of software for teleoperation." FALSE)
 option(ROBOTOLOGY_ENABLE_ICUB_HEAD "Enable compilation of software necessary on the system running in the head of the iCub robot." FALSE)


### PR DESCRIPTION
Despite what was written in the PR description of https://github.com/robotology/robotology-superbuild/pull/303, by default the `ROBOT_TESTING` component was set enabled. As discussed in  https://github.com/robotology/robotology-superbuild/pull/303, however, most users do not need RTF and icub-tests, and disabling them also reduce the chance of users experiencing https://github.com/robotology/robotology-superbuild/issues/215 .