### PR TITLE
GitHub Actions: force use of system-installed boost

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,12 @@ jobs:
 
     steps:
     - uses: actions/checkout@master
+    
+    # Workaround for https://github.com/actions/virtual-environments/issues/10
+    - name: Avoid to use GitHub Actions-installed boost
+      shell: bash
+      run: |
+        echo "::set-env name=BOOST_ROOT::"
         
     # Print environment variables to simplify development and debugging
     - name: Environment Variables


### PR DESCRIPTION
Attempt to fix GitHub Actions compilation with a workaround for https://github.com/actions/virtual-environments/issues/10 .
Without this fix, the GitHub Action jobs are failing, see https://github.com/robotology/robotology-superbuild/commit/9d8587921d79540c50fa98a906738a350179618a/checks?check_suite_id=405495333 .