### PR TITLE
Fix GitHub Actions CI by removing apt Microsoft repos

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,13 @@ jobs:
     - name: Environment Variables
       shell: bash
       run: env
+
+    # Remove apt repos that are known to break from time to time 
+    # See https://github.com/actions/virtual-environments/issues/323  
+    - name: Remove broken apt repos [Ubuntu]
+      if: matrix.os == 'ubuntu-latest'
+      run: |
+        for apt_file in `grep -lr microsoft /etc/apt/sources.list.d/`; do sudo rm $apt_file; done
         
     # ============
     # DEPENDENCIES


### PR DESCRIPTION
Microsoft apt repos break apt-get update for several days once in a while.
As there is currently no plan to fix these outages from Microsoft side (see https://github.com/dotnet/core/issues/4167) and we are not using the repos, the best course of action is just to remove them. 

See: 
* https://github.com/actions/virtual-environments/issues/323