### PR TITLE
Add scripts for generating Windows installers

### DIFF
--- a/packaging/windows/CMakeLists.txt
+++ b/packaging/windows/CMakeLists.txt
@@ -1,0 +1,83 @@
+# Copyright (C) 2020 Istituto Italiano di Tecnologia (IIT)
+# All rights reserved.
+#
+# This software may be modified and distributed under the terms of the
+# BSD-3-Clause license. See the accompanying LICENSE file for details.
+
+cmake_minimum_required(VERSION 3.12)
+
+project(robotology-installer 
+        VERSION 2020.02
+        DESCRIPTION "Installer for robotology software.")
+
+if(NOT DEFINED RI_VCPKG_INSTALL_DIR)
+  set(RI_VCPKG_INSTALL_DIR_DEFAULT_VALUE "C:/robotology/vcpkg")
+  message(STATUS "RI_VCPKG_INSTALL_DIR variable is not defined, use default value of ${RI_VCPKG_INSTALL_DIR_DEFAULT_VALUE}")
+  set(RI_VCPKG_INSTALL_DIR ${RI_VCPKG_INSTALL_DIR_DEFAULT_VALUE} CACHE STRING "Location of the directory contaning the vcpkg instalation.")
+endif()
+
+if(NOT DEFINED RI_SUPERBUILD_INSTALL_DIR)
+  set(RI_SUPERBUILD_INSTALL_DIR_DEFAULT_VALUE "C:/robotology/robotology")
+  message(STATUS "RI_SUPERBUILD_INSTALL_DIR variable is not defined, use default value of ${RI_SUPERBUILD_INSTALL_DIR_DEFAULT_VALUE}")
+  set(RI_SUPERBUILD_INSTALL_DIR ${RI_SUPERBUILD_INSTALL_DIR_DEFAULT_VALUE} CACHE STRING "Location of the directory contaning the robotology-superbuild install prefix.")
+endif()
+
+if(NOT EXISTS ${RI_VCPKG_INSTALL_DIR})
+  message(FATAL_ERROR "RI_VCPKG_INSTALL_DIR variable does not contain a valid directory (${RI_VCPKG_INSTALL_DIR})")
+endif()
+if(NOT EXISTS ${RI_SUPERBUILD_INSTALL_DIR})
+  message(FATAL_ERROR "RI_SUPERBUILD_INSTALL_DIR variable does not contain a valid directory (${RI_SUPERBUILD_INSTALL_DIR})")
+endif()
+
+# Install directories 
+install(DIRECTORY ${RI_VCPKG_INSTALL_DIR}
+        DESTINATION .)
+        
+install(DIRECTORY ${RI_SUPERBUILD_INSTALL_DIR}
+        DESTINATION .)
+
+# Specify CPack generation options (it needs to be before the inclusion of CPack and CPackIFW)
+set(CPACK_GENERATOR "IFW" CACHE STRING ";-separated list of CPack generators to use (currently supported generators: IFW, ZIP)")
+
+# By default, install on C:/robotology that is the same location where the binaries have been created 
+set(CPACK_IFW_TARGET_DIRECTORY "@RootDir@/robotology")
+
+# Generate installer 
+include(CPack)
+include(CPackIFW)
+
+
+
+# Optionally update enviroment variables 
+# Create custom component to manage enviromental variables for each triplet 
+cpack_add_component(update_env_variables
+                    DISPLAY_NAME "Update Enviromental Variables."
+                    DESCRIPTION  "Update Enviromental Variables to automatically use the installed software.")
+
+
+# Add cpack generator-indipendent script to add the necessary env variables and remove them 
+install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/scripts/addPathsToUserEnvVariables.ps1 
+              ${CMAKE_CURRENT_SOURCE_DIR}/scripts/removePathsFromUserEnvVariables.ps1
+              ${CMAKE_CURRENT_SOURCE_DIR}/scripts/setup.bat
+              ${CMAKE_CURRENT_SOURCE_DIR}/scripts/addPathsToUserEnvVariables-vcpkg.ps1 
+              ${CMAKE_CURRENT_SOURCE_DIR}/scripts/removePathsFromUserEnvVariables-vcpkg.ps1
+              ${CMAKE_CURRENT_SOURCE_DIR}/scripts/setup-vcpkg.bat
+        DESTINATION scripts
+        COMPONENT update_env_variables)
+  
+# Create custom component to manage enviromental variables for each triplet 
+cpack_add_component(update_env_variables
+                    DISPLAY_NAME "Update Enviromental Variables"
+                    DESCRIPTION  "Update Enviromental Variables to automatically use the installed software.")
+
+# Note: @TargetDir@ is actually a IFW macro, and should not be substitued by configure_file 
+# As a workaround, we define the TargetDir cmake variable as "@TargetDir@", so in  the file @TargetDir@ will be substitued by @TargetDir@
+set(TargetDir "@TargetDir@")  
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/scripts/update-env-variables.qs.in ${CMAKE_CURRENT_BINARY_DIR}/update-env-variables.qs @ONLY)
+cpack_ifw_configure_component(update_env_variables
+                              NAME org.${CPACK_PACKAGE_NAME_UNDERSCORES}.installer.update_env_variables
+                              VERSION ${CPACK_PACKAGE_VERSION}
+                              SCRIPT ${CMAKE_CURRENT_BINARY_DIR}/update-env-variables.qs)
+
+message(STATUS "CPACK_SYSTEM_NAME: ${CPACK_SYSTEM_NAME}")                              
+message(STATUS "CPACK_IFW_TARGET_DIRECTORY: ${CPACK_IFW_TARGET_DIRECTORY}")

--- a/packaging/windows/README.md
+++ b/packaging/windows/README.md
@@ -1,0 +1,49 @@
+# Scripts for generating Windows installer for robotology-superbuild software
+
+Windows installer for robotology dependencies and software contained in the robotology-superbuild.
+
+## Caveats 
+The generated installer only supports Visual Studio 2019 and 64-bit binaries.
+As many of the software contained in the installer are not relocatable, at the moment it only supported to 
+install the software to the `C:\robotology` . 
+
+## Usage 
+
+### Dependencies 
+* CMake >= 3.14 
+* Qt Installer Framework >= 3.2.0 (download from https://download.qt.io/official_releases/qt-installer-framework/ and make sure that the QtIFW  binaries are in the PATH)
+
+### Generation steps 
+
+#### vcpkg
+* Install (or download from https://github.com/robotology-playground/robotology-superbuild-dependencies) a vcpkg installation with the necessary dependencies in `C:\robotology\vcpkg`.
+
+#### robotology-superbuild
+* Download the robotology-superbuild somewhere in your system (for example `C:\robotology-superbuild`) and configure to install it to `C:\robotology\robotology` via YCM_EP_INSTALL_DIR, with the option that you prefer:
+~~~
+cd C:\
+git clone -b <used_tag> https://github.com/robotology/robotology-superbuild
+cd robotology-superbuild
+mkdir build
+cd build
+cmake -A x64 -DCMAKE_TOOLCHAIN_FILE=C:\robotology\vcpkg\scripts\buildsystems\vcpkg.cmake -DYCM_EP_INSTALL_DIR=C:\robotology\robotology -DROBOTOLOGY_PROJECT_TAGS=Custom -DROBOTOLOGY_PROJECT_TAGS_CUSTOM_FILE=<CustomFile> -DROBOTOLOGY_ENABLE_DYNAMICS:BOOL=ON ..
+~~~
+* Compile the project first in Debug, and then in Release, to install both the Debug and Release version of the libraries, but shipping just the Release version of the executables:
+~~~
+cmake --build . --config Debug
+cmake --build . --config Release
+~~~
+
+#### Generate IFW installer 
+* Clone this repo, and configure it via CMake:
+~~~
+cd C:\robotology-superbuild\packaging\windows
+mkdir build 
+cd build
+cmake -A x64 ..
+~~~
+* Build the `PACKAGE` target to generate the installer: 
+~~~
+cmake --build . --target PACKAGE
+~~~
+This will create a `robotology-installer-<version>-win64.exe` installer in the build directory.

--- a/packaging/windows/scripts/addPathsToUserEnvVariables-vcpkg.ps1
+++ b/packaging/windows/scripts/addPathsToUserEnvVariables-vcpkg.ps1
@@ -1,0 +1,39 @@
+# Set a value to a given "User" enviromental variable
+function Set-ValueToUserEnvVariable ($EnvVariable, $Value, $Verbose=$TRUE) {
+  if ($Verbose) {
+    Write-Host 'Set ' $Value ' to the ' $EnvVariable ' User enviroment variable.'
+  }
+  [System.Environment]::SetEnvironmentVariable($EnvVariable, $Value, 'User');
+}
+
+# Add a value to a given "User" enviromental variable
+function Add-ValueToUserEnvVariable ($EnvVariable, $Value, $Verbose=$TRUE) {
+  if ($Verbose) {
+    Write-Host 'Appending ' $Value ' to the ' $EnvVariable ' User enviroment variable.'
+  }
+  $currVar = [System.Environment]::GetEnvironmentVariable($EnvVariable, 'User');
+  # If the enviromental variable is currently empty, do not add an initial ";"
+  if ([string]::IsNullOrEmpty($currVar)) {
+    $newVar = $Value;
+  } else {
+    $newVar = $currVar + ';' + $Value;
+  }
+  [System.Environment]::SetEnvironmentVariable($EnvVariable, $newVar, 'User');
+}
+
+$parentPath = Split-Path -Path $PSCommandPath;
+$vcpkgTriplet = 'x64-windows';
+$vcpkgInstallDir = (Split-Path -parent $parentPath) + '\vcpkg\installed\' + $vcpkgTriplet;
+
+# This logic mimics part of the logic contained in vcpkg\scripts\buildsystems\vcpkg.cmake
+# to user enviroment variables. It has been tested only for a limited amount of vcpkg ports,
+# and it is not officially maintained by the vcpkg team. To make sure that a dependency is correctly 
+# found by CMake, use the official CMake vcpkg toolchain as documented in vcpkg docs.
+
+# Extend PATH
+Add-ValueToUserEnvVariable PATH ($VcpkgInstallDir + "\bin");
+Add-ValueToUserEnvVariable PATH ($VcpkgInstallDir + "\debug\bin");
+
+# Extend CMAKE_PREFIX_PATH
+Add-ValueToUserEnvVariable CMAKE_PREFIX_PATH ($VcpkgInstallDir);
+Add-ValueToUserEnvVariable CMAKE_PREFIX_PATH ($VcpkgInstallDir + "\debug");

--- a/packaging/windows/scripts/addPathsToUserEnvVariables.ps1
+++ b/packaging/windows/scripts/addPathsToUserEnvVariables.ps1
@@ -1,0 +1,10 @@
+$installerRootPath = (Split-Path -parent (Split-Path -Path $PSCommandPath));
+
+# Call the script to update the env variables of vcpkg 
+$vcpkgTriplet = 'x64-windows';
+$vcpkgScript = $installerRootPath + '\scripts\addPathsToUserEnvVariables-vcpkg.ps1'
+Invoke-Expression $vcpkgScript
+
+# Call robotology-superbuild script to update enviroment variables to find robotology-superbuild-installed software
+$robotologyScript = $installerRootPath + '\robotology\share\robotology-superbuild\addPathsToUserEnvVariables.ps1'
+Invoke-Expression $robotologyScript

--- a/packaging/windows/scripts/removePathsFromUserEnvVariables-vcpkg.ps1
+++ b/packaging/windows/scripts/removePathsFromUserEnvVariables-vcpkg.ps1
@@ -1,0 +1,37 @@
+# Remove a given "User" enviromental variable
+function Remove-UserEnvVariable ($EnvVariable, $Verbose=$TRUE) {
+  if ($Verbose) {
+    Write-Host 'Removing ' $EnvVariable ' User enviroment variable.'
+  }
+  [System.Environment]::SetEnvironmentVariable($EnvVariable, $null, 'User');
+}
+
+# Remove a value from a given "User" enviromental variable
+function Remove-ValueFromUserEnvVariable ($EnvVariable, $Value, $Verbose=$TRUE) {
+  if ($Verbose) {
+    Write-Host 'Removing ' $Value ' from the ' $EnvVariable ' User enviroment variable.'
+  }
+  $currVar = [System.Environment]::GetEnvironmentVariable($EnvVariable, 'User');
+  # If the env variable is already empty, do not do anything
+  if (-Not [string]::IsNullOrEmpty($currVar)) {
+    $newVar = ($currVar.Split(';') | Where-Object { $_ -ne $Value }) -join ';';
+    # If the resulting final variable is empty, delete the enviromental variable
+    if ([string]::IsNullOrEmpty($newVar)) {
+      [System.Environment]::SetEnvironmentVariable($EnvVariable, $null, 'User');
+    } else {
+      [System.Environment]::SetEnvironmentVariable($EnvVariable, $newVar, 'User');
+    }
+  }
+}
+
+$parentPath = Split-Path -Path $PSCommandPath;
+$vcpkgTriplet = 'x64-windows';
+$vcpkgInstallDir = (Split-Path -parent $parentPath) + '\vcpkg\installed\' + $vcpkgTriplet;
+
+# Cleanup PATH
+Remove-ValueFromUserEnvVariable PATH ($VcpkgInstallDir + "\bin");
+Remove-ValueFromUserEnvVariable PATH ($VcpkgInstallDir + "\debug\bin");
+
+# Cleanup CMAKE_PREFIX_PATH
+Remove-ValueFromUserEnvVariable CMAKE_PREFIX_PATH ($VcpkgInstallDir);
+Remove-ValueFromUserEnvVariable CMAKE_PREFIX_PATH ($VcpkgInstallDir + "\debug");

--- a/packaging/windows/scripts/removePathsFromUserEnvVariables.ps1
+++ b/packaging/windows/scripts/removePathsFromUserEnvVariables.ps1
@@ -1,0 +1,10 @@
+$installerRootPath = (Split-Path -parent (Split-Path -Path $PSCommandPath));
+
+# Call the script to cleanup the env variables of vcpkg 
+$vcpkgTriplet = 'x64-windows';
+$vcpkgScript = $installerRootPath + '\scripts\removePathsFromUserEnvVariables-vcpkg.ps1'
+Invoke-Expression $vcpkgScript
+
+# Call robotology-superbuild script to cleanup enviroment variables
+$robotologyScript = $installerRootPath + '\robotology\share\robotology-superbuild\removePathsFromUserEnvVariables.ps1'
+Invoke-Expression $robotologyScript

--- a/packaging/windows/scripts/setup-vcpkg.bat
+++ b/packaging/windows/scripts/setup-vcpkg.bat
@@ -1,0 +1,14 @@
+pushd %~dp0..
+set "installerRootPath=%cd%"
+popd
+
+set "vcpkgTriplet=windows-x64"
+set "vcpkgInstallDir=%installerRootPath%\vcpkg\installed\%vcpkgTriplet%"
+
+rem Update PATH 
+set "PATH=%PATH%;%vcpkgInstallDir%\bin"
+set "PATH=%PATH%;%vcpkgInstallDir%\debug\bin"
+
+rem Update CMAKE_PREFIX_PATH
+set "CMAKE_PREFIX_PATH=%CMAKE_PREFIX_PATH%;%vcpkgInstallDir%"
+set "CMAKE_PREFIX_PATH=%CMAKE_PREFIX_PATH%;%vcpkgInstallDir%\debug"

--- a/packaging/windows/scripts/setup.bat
+++ b/packaging/windows/scripts/setup.bat
@@ -1,0 +1,9 @@
+pushd %~dp0..
+set installerRootPath=%cd%
+popd
+
+rem Call vcpkg script
+call %installerRootPath%\scripts\setup-vcpkg.bat 
+
+rem Call robotology-superbuild script
+call %installerRootPath%\robotology\share\robotology-superbuild\setup.bat

--- a/packaging/windows/scripts/update-env-variables.qs.in
+++ b/packaging/windows/scripts/update-env-variables.qs.in
@@ -1,0 +1,15 @@
+function Component()
+{
+}
+
+Component.prototype.createOperations = function()
+{
+    console.log("component: " + component.displayName + ", createOperations called");
+     
+    component.createOperations();	 
+	   
+    // Add mantainance of Path variables 
+	oper = [ "powershell", "-ExecutionPolicy", "ByPass", "-File", "@TargetDir@\\scripts\\addPathsToUserEnvVariables.ps1"];
+    undoOper = [ "powershell", "-ExecutionPolicy", "ByPass", "-File", "@TargetDir@\\scripts\\removePathsFromUserEnvVariables.ps1"];
+    component.addOperation("Execute", oper, "UNDOEXECUTE", undoOper);                         
+}


### PR DESCRIPTION
This PR adds a script that uses [CPack](https://cmake.org/cmake/help/v3.12/module/CPack.html), [Qt Installer Framework](https://doc.qt.io/qtinstallerframework/index.html) and [vcpkg](https://github.com/microsoft/vcpkg)-provided dependencies to  generate a self-contained executable for the software contained in the robotology-superbuild. 

The limitations are currently the following: 
* Support only for 64-bit shared binaries, i.e. `x64-windows` 
* Due to the fact that several software in the robotology-superbuild are not relocatable, only support installation in `C:\robotology` prefix. 
* All the software needs to be installed, it is not possible to manually select which sofware to install. 

With some work, it will be possible to remove some of this limitations in the future. However, I think that the installer will be useful also in the current form. 