### PR TITLE
Install all robot configuration files regardless of YARP_ROBOT_NAME

### DIFF
--- a/cmake/Buildrobots-configuration.cmake
+++ b/cmake/Buildrobots-configuration.cmake
@@ -12,9 +12,8 @@ find_or_build_package(ICUBcontrib QUIET)
 # * On iCub Head images, the behavior is to install only those specific robot files
 # * On other systems (i.e. developers laptop) all the robots configuration files are installed
 set(robots-configuration_CMAKE_ARGS "")
-if("$ENV{YARP_ROBOT_NAME}" STREQUAL "")
-    list(APPEND robots-configuration_CMAKE_ARGS "-DINSTALL_ALL_ROBOTS:BOOL=ON")
-endif()
+list(APPEND robots-configuration_CMAKE_ARGS "-DINSTALL_ALL_ROBOTS:BOOL=ON")
+
 
 
 ycm_ep_helper(robots-configuration TYPE GIT


### PR DESCRIPTION
To solve problems such as https://github.com/robotology/robotology-superbuild/issues/223, it is easier to always install all the robot configuration files. If this creates problems on systems such as pc104, we can always go back.

Fix https://github.com/robotology/robotology-superbuild/issues/223 .