### PR TITLE
Configure setup scripts directly in YCM_EP_INSTALL_DIR instead of hardcoding ${CMAKE_BINARY_DIR}/install

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -219,13 +219,13 @@ endif()
 
 include(ConfigureFileWithCMakeIf)
 if(NOT WIN32)
-  configure_file_with_cmakeif(${CMAKE_CURRENT_SOURCE_DIR}/cmake/template/setup.sh.in ${CMAKE_BINARY_DIR}/install/share/${PROJECT_NAME}/setup.sh @ONLY)
+  configure_file_with_cmakeif(${CMAKE_CURRENT_SOURCE_DIR}/cmake/template/setup.sh.in ${YCM_EP_INSTALL_DIR}/share/${PROJECT_NAME}/setup.sh @ONLY)
 else()
-  configure_file_with_cmakeif(${CMAKE_CURRENT_SOURCE_DIR}/cmake/template/setup.bat.in ${CMAKE_BINARY_DIR}/install/share/${PROJECT_NAME}/setup.bat @ONLY)
+  configure_file_with_cmakeif(${CMAKE_CURRENT_SOURCE_DIR}/cmake/template/setup.bat.in ${YCM_EP_INSTALL_DIR}/share/${PROJECT_NAME}/setup.bat @ONLY)
   configure_file_with_cmakeif(${CMAKE_CURRENT_SOURCE_DIR}/cmake/template/addPathsToUserEnvVariables.ps1.in
-                              ${CMAKE_BINARY_DIR}/install/share/${PROJECT_NAME}/addPathsToUserEnvVariables.ps1 @ONLY)
+                              ${YCM_EP_INSTALL_DIR}/share/${PROJECT_NAME}/addPathsToUserEnvVariables.ps1 @ONLY)
   configure_file_with_cmakeif(${CMAKE_CURRENT_SOURCE_DIR}/cmake/template/removePathsFromUserEnvVariables.ps1.in
-                              ${CMAKE_BINARY_DIR}/install/share/${PROJECT_NAME}/removePathsFromUserEnvVariables.ps1 @ONLY)
+                              ${YCM_EP_INSTALL_DIR}/share/${PROJECT_NAME}/removePathsFromUserEnvVariables.ps1 @ONLY)
 endif()
 
 ycm_write_dot_file(${CMAKE_CURRENT_BINARY_DIR}/robotology-superbuild.dot)


### PR DESCRIPTION
This may require that `cmake` is executed as `sudo` if `YCM_EP_INSTALL_DIR` points to `/usr/local`, but in any case the use of `YCM_EP_INSTALL_DIR` is an experimental feature reserved only to advanced setups, so I do not think it is a big problem.