### PR TITLE
Add ycm_load_vcs_yaml_info CMake function

### DIFF
--- a/cmake/YCMLoadVcsYamlInfo.cmake
+++ b/cmake/YCMLoadVcsYamlInfo.cmake
@@ -1,0 +1,108 @@
+#.rst:
+# YCMLoadVcsYamlInfo
+# -------
+#
+# Load YCM project variables for a YCM superbuild from a VCS yaml file.
+#
+# .. command :: ycm_load_vcs_yaml_info
+#
+#  Extract information about one commit from one git repository in
+#  ``SOURCE DIR``::
+#
+#    ycm_load_vcs_yaml_info(YAML_FILE <yaml_file>]
+#                           <VERBOSE>)
+#
+#  ``YAML_FILE`` should point to a yaml file in the format supported by 
+#  vcstool ( https://github.com/dirk-thomas/vcstool ). To simplify parsing
+#  at the CMake level, arbitrary yaml files are not supported, but the current
+#  subset is supported: 
+#  * Two spaces indentation
+#  * No comments
+#  * Just GitHub repositories 
+# 
+#  If the VERBOSE option is passed, ycm_load_vcs_yaml_info will print all the variable
+#  that it sets.
+#  
+
+if(DEFINED __YCM_LOAD_VCS_YAML_INFO)
+  return()
+endif()
+set(__YCM_LOAD_VCS_YAML_INFO 1)
+
+include(CMakeParseArguments)
+
+function(ycm_load_vcs_yaml_info)
+
+  # Parse arguments and check values
+  set(_options VERBOSE)
+  set(_oneValueArgs YAML_FILE)
+  set(_multiValueArgs)
+  cmake_parse_arguments(_ylvyi "${_options}" "${_oneValueArgs}" "${_multiValueArgs}" "${ARGN}")
+
+  if(NOT DEFINED _ylvyi_YAML_FILE)
+    message(FATAL_ERROR "ycm_load_vcs_yaml_info: YAML_FILE parameter.")
+  endif()
+  
+  # Load file and split in lines (see https://cmake.org/pipermail/cmake/2007-May/014222.html)
+  file(READ "${_ylvyi_YAML_FILE}" contents)
+
+  # Convert file contents into a CMake list (where each element in the list
+  # is one line of the file)
+  string(REGEX REPLACE ";" "\\\\;" contents "${contents}")
+  string(REGEX REPLACE "\n" ";" contents "${contents}")
+
+  # True if the initial repositories: key was found
+  set(_ylvyi_REPO_KEY_FOUND FALSE)
+  # Name of the package info currently being parsed
+  set(_ylvyi_PACKAGE_CURRENTLY_PARSED "")
+  foreach(line ${contents})
+    # Parse the initial repositories: line
+    if(NOT ${_ylvyi_REPO_KEY_FOUND})
+      if(${line} STREQUAL "repositories:")
+        set(_ylvyi_REPO_KEY_FOUND TRUE)
+        continue()
+      else()
+        message(FATAL_ERROR "ycm_load_vcs_yaml_info: unexpected first line \"${line}\" instead of \"repository:\"")
+      endif()
+    endif()
+
+    # If the line has the form "  <package>:", start to parse info for a new package
+    if(${line} MATCHES "^  ([a-zA-Z0-9_.-]+):")
+      set(_ylvyi_PACKAGE_CURRENTLY_PARSED ${CMAKE_MATCH_1})
+    else()
+      # Otherwise, the line must have the form "    <key>: <value>"    
+      if(${line} MATCHES "^    ([a-zA-Z0-9_.-]+): ([a-zA-Z0-9_.:/\-]+)")
+        set(_ylvyi_KEY_CURRENTLY_PARSED ${CMAKE_MATCH_1})
+        set(_ylvyi_VALUE_CURRENTLY_PARSED ${CMAKE_MATCH_2})
+
+        # Handle the possible keys
+        if(_ylvyi_KEY_CURRENTLY_PARSED STREQUAL "type")
+          if(NOT _ylvyi_VALUE_CURRENTLY_PARSED STREQUAL "git")
+            message(FATAL_ERROR "ycm_load_vcs_yaml_info: type \"${_ylvyi_VALUE_CURRENTLY_PARSED}\" in line \"${line}\" not supported, only type \"git\" is currently supported.")
+          endif()
+        elseif(_ylvyi_KEY_CURRENTLY_PARSED STREQUAL "url")
+          # For now we only support GitHub Style repositories, but adding other repository is just a matter of adding a new if here
+          if(${_ylvyi_VALUE_CURRENTLY_PARSED} MATCHES "https://github.com/([a-zA-Z0-9/_.-]+.git)")
+            set(${_ylvyi_PACKAGE_CURRENTLY_PARSED}_REPOSITORY ${CMAKE_MATCH_1} PARENT_SCOPE)
+            if(_ylvyi_VERBOSE)
+              message(STATUS "ycm_load_vcs_yaml_info: setting ${_ylvyi_PACKAGE_CURRENTLY_PARSED}_REPOSITORY to ${CMAKE_MATCH_1}")
+            endif()
+          else()
+            message(FATAL_ERROR "ycm_load_vcs_yaml_info: not supported repo \"${_ylvyi_VALUE_CURRENTLY_PARSED}\" in line \"${line}\".")
+          endif()
+        elseif(_ylvyi_KEY_CURRENTLY_PARSED STREQUAL "version")
+          # version is either a branch, a tag or a commit
+          set(${_ylvyi_PACKAGE_CURRENTLY_PARSED}_TAG ${_ylvyi_VALUE_CURRENTLY_PARSED} PARENT_SCOPE)
+          if(_ylvyi_VERBOSE)
+            message(STATUS "ycm_load_vcs_yaml_info: setting ${_ylvyi_PACKAGE_CURRENTLY_PARSED}_TAG to ${_ylvyi_VALUE_CURRENTLY_PARSED}")
+          endif()
+        else()
+          message(FATAL_ERROR "ycm_load_vcs_yaml_info: unexpected key \"${_ylvyi_KEY_CURRENTLY_PARSED}\" in line \"${line}\".")
+        endif()
+      else() 
+        message(FATAL_ERROR "ycm_load_vcs_yaml_info: unexpected package info ${line} instead of a two or four space indented line.")
+      endif()
+    endif()    
+  endforeach()
+
+endfunction()


### PR DESCRIPTION
This function permits to load the `<package>_TAG` and `<package>_REPOSITORY` variables from a YAML file.

In particular, the YAML format used is the one produced and consumed by the [`vcstool`](https://github.com/dirk-thomas/vcstool) command line tool, that is used in ROS2 tutorials to manage groups of repositories. 

For example, the existing  file `ProjectsTagsStable.cmake` (see https://github.com/robotology/robotology-superbuild/blob/34325b12084672d1869695366ca53bb4ffe83a7f/cmake/ProjectsTagsStable.cmake) file could be refactored in:
~~~cmake
include(YCMLoadVcsYamlInfo)

ycm_load_vcs_yaml_info(YAML_FILE project_tags_stable.repos)
~~~ 

With `project_tags_stable.repos` being: 
~~~yaml
repositories:
  osqp:
    type: git
    url: https://github.com/oxfordcontrol/osqp.git
    version: v0.6.0
  YARP:
    type: git
    url: https://github.com/robotology/yarp.git
    version: yarp-3.3
~~~

The main advantages of this are two: 
* yaml file can be easily parsed also by non-CMake based software @vtikha @valegagge 
* once all the source repos are contained in the same directory (https://github.com/robotology/robotology-superbuild/issues/333) yaml files  corresponding to a precise set of commits can be easily created with `vcs export --exact > my.repos` @CarlottaSartore 

The script currently supports just a limited subset of the possible repos supported by YCM superbuilds, but once we test it a bit it could then make sense to move it in YCM @drdanz 