### PR TITLE
Disable fail-fast in GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,7 @@ jobs:
     name: '[${{ matrix.project_tags }}@${{ matrix.os }}@${{ matrix.build_type }}]'
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         build_type: [Debug, Release]
         project_tags: [Stable, Unstable]


### PR DESCRIPTION
Due to the nature of robotology-superbuild, often the unstable branches build fails. However, it is important that even if the unstable branches build fails the stable branches build continue to build, so we are still able to detect regressions on the stable branches, and  just merge PRs if the stable branches pass.