### PR TITLE
Hardcode the ROBOTOLOGY_PROJECT_TAGS_CUSTOM_FILE to 2020.02.yaml for the releases/2020.02 branch

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -87,7 +87,7 @@ endif()
 
 set(ROBOTOLOGY_PROJECT_TAGS "Stable" CACHE STRING "The tags to be used for the robotology projects: Stable, Unstable or Custom. This can be changed only before the first configuration.")
 mark_as_advanced(ROBOTOLOGY_PROJECT_TAGS)
-set(ROBOTOLOGY_PROJECT_TAGS_CUSTOM_FILE CACHE FILEPATH "If ROBOTOLOGY_PROJECT_TAGS is custom, this file will be loaded to specify the tags of the projects to use.")
+set(ROBOTOLOGY_PROJECT_TAGS_CUSTOM_FILE "${CMAKE_CURRENT_SOURCE_DIR}/releases/2020.02.yaml" CACHE FILEPATH "If ROBOTOLOGY_PROJECT_TAGS is custom, this file will be loaded to specify the tags of the projects to use.")
 mark_as_advanced(ROBOTOLOGY_PROJECT_TAGS_CUSTOM_FILE)
 set_property(CACHE ROBOTOLOGY_PROJECT_TAGS PROPERTY STRINGS "Stable" "Unstable" "Custom")
 


### PR DESCRIPTION
This commits hardcodes the ROBOTOLOGY_PROJECT_TAGS_CUSTOM_FILE to point to the  2020.02.yaml file for the `releases/2020.02` branch. The idea  is to tag the `v2020.02` tag on this branch (and eventually other patch releases of the v2020.02 series), to ensure that a user of the superbuild just needs to checkout the correct tag of the superbuild, and then the superbuild will download the correct versions of the subprojects. 

Note that is quite important to **never forward merge** the `releases/**` branches to `master`.