### PR TITLE
Use version 0.0.3 of the pre-compiled vcpkg workspace in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,11 +96,13 @@ jobs:
       run: |
         # To avoid spending a huge time compiling vcpkg dependencies, we download a root that comes precompiled with all the ports that we need 
         choco install -y wget unzip
-        # To avoid problems with non-relocatable packages, we unzip the archive exactly in the same C:/vcpkg-robotology 
+        # To avoid problems with non-relocatable packages, we unzip the archive exactly in the same C:/robotology/vcpkg 
         # that has been used to create the pre-compiled archive
         cd C:/
-        wget https://github.com/robotology-playground/robotology-superbuild-dependencies/releases/download/v0.0.2/vcpkg-robotology.zip
-        unzip vcpkg-robotology.zip        
+        md C:/robotology
+        md C:/robotology/vcpkg
+        wget https://github.com/robotology-playground/robotology-superbuild-dependencies/releases/download/v0.0.3/vcpkg-robotology.zip
+        unzip vcpkg-robotology.zip -d C:/robotology/vcpkg       
         
     # ===================
     # CMAKE-BASED PROJECT
@@ -127,7 +129,7 @@ jobs:
       run: |
         mkdir -p build
         cd build
-        cmake -A x64 -DCMAKE_TOOLCHAIN_FILE=C:/vcpkg-robotology/scripts/buildsystems/vcpkg.cmake -DROBOTOLOGY_USES_GAZEBO:BOOL=OFF -DROBOTOLOGY_USES_OCTAVE:BOOL=OFF -DROBOTOLOGY_USES_PYTHON:BOOL=OFF -DROBOTOLOGY_ENABLE_ROBOT_TESTING:BOOL=ON -DROBOTOLOGY_ENABLE_DYNAMICS:BOOL=ON -DROBOTOLOGY_ENABLE_HUMAN_DYNAMICS:BOOL=ON -DROBOTOLOGY_ENABLE_ICUB_HEAD:BOOL=ON -DROBOTOLOGY_ENABLE_ICUB_BASIC_DEMOS:BOOL=ON -DNON_INTERACTIVE_BUILD:BOOL=TRUE -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}  -DROBOTOLOGY_PROJECT_TAGS=${{ matrix.project_tags }} ..
+        cmake -A x64 -DCMAKE_TOOLCHAIN_FILE=C:/robotology/vcpkg/scripts/buildsystems/vcpkg.cmake -DROBOTOLOGY_USES_GAZEBO:BOOL=OFF -DROBOTOLOGY_USES_OCTAVE:BOOL=OFF -DROBOTOLOGY_USES_PYTHON:BOOL=OFF -DROBOTOLOGY_ENABLE_ROBOT_TESTING:BOOL=ON -DROBOTOLOGY_ENABLE_DYNAMICS:BOOL=ON -DROBOTOLOGY_ENABLE_HUMAN_DYNAMICS:BOOL=ON -DROBOTOLOGY_ENABLE_ICUB_HEAD:BOOL=ON -DROBOTOLOGY_ENABLE_ICUB_BASIC_DEMOS:BOOL=ON -DNON_INTERACTIVE_BUILD:BOOL=TRUE -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}  -DROBOTOLOGY_PROJECT_TAGS=${{ matrix.project_tags }} ..
 
 
     - name: Build  [Ubuntu&macOS]
@@ -147,5 +149,5 @@ jobs:
       run: |
         cd build
         # yarp's rosmsgs generator links ACE, so it needs to find ACE dll in the path to run 
-        export PATH=$PATH:/c/vcpkg-robotology/installed/x64-windows/bin:/c/vcpkg-robotology/installed/x64-windows/debug/bin
+        export PATH=$PATH:/c/robotology/vcpkg/installed/x64-windows/bin:/c/robotology/vcpkg/installed/x64-windows/debug/bin
         cmake --build . --config ${{ matrix.build_type }}  


### PR DESCRIPTION
This is required to be compatible with the installer scripts provided in https://github.com/robotology/robotology-superbuild/pull/334 .
Other related issue: https://github.com/robotology-playground/robotology-superbuild-dependencies-vcpkg/pull/5 .