### PR TITLE
Backport latest version updated for 2020.02

### DIFF
--- a/releases/2020.02.yaml
+++ b/releases/2020.02.yaml
@@ -50,7 +50,7 @@ repositories:
   iDynTree:
     type: git
     url: https://github.com/robotology/idyntree.git
-    version: v1.0.1
+    version: v1.0.2
   wholeBodyInterface:
     type: git
     url: https://github.com/robotology/wholebodyinterface.git
@@ -106,7 +106,7 @@ repositories:
   human-dynamics-estimation:
     type: git
     url: https://github.com/robotology/human-dynamics-estimation.git
-    version: v2.0.0
+    version: v2.1.0
   human-gazebo:
     type: git
     url: https://github.com/robotology/human-gazebo.git


### PR DESCRIPTION
Version bumped in https://github.com/robotology/robotology-superbuild/pull/352 .