### PR TITLE
Boostrap and require recent YCM v0.11.1 in the superbuild

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -113,8 +113,8 @@ endif()
 # Bootstrap YCM
 set(YCM_FOLDER robotology)
 set(YCM_COMPONENT core)
-set(YCM_TAG ad8bb257df45ffe70f949c74815bf803d7445b24)
-set(YCM_MINIMUM_VERSION 0.11.0)
+set(YCM_TAG v0.11.1)
+set(YCM_MINIMUM_VERSION 0.11.1)
 include(YCMBootstrap)
 
 include(FindOrBuildPackage)


### PR DESCRIPTION
YCM v0.11.1 ( https://github.com/robotology/ycm/releases/tag/v0.11.1 ) contains some critical bug-fixes, so it is good to require and to use them.