### PR TITLE
Use fixed ICUB and icub-firmware-shared commits

### DIFF
--- a/cmake/ProjectsTagsUnstable.cmake
+++ b/cmake/ProjectsTagsUnstable.cmake
@@ -8,15 +8,16 @@ endmacro()
 set_tag(osqp_TAG v0.6.0)
 
 # Robotology projects
+# Custom commits are a workaround for https://github.com/robotology/robotology-superbuild/issues/372
 set_tag(YARP_TAG master)
-set_tag(ICUB_TAG devel)
+set_tag(ICUB_TAG 4839050fde87ddbf3572b98d608f74097aacbfd6)
 set_tag(RobotTestingFramework_TAG devel)
 set_tag(WBToolbox_TAG devel)
 set_tag(BlockFactory_TAG devel)
 set_tag(codyco-modules_TAG devel)
 set_tag(icub-tests_TAG devel)
 set_tag(iDynTree_TAG devel)
-set_tag(icub-firmware-shared_TAG devel)
+set_tag(icub-firmware-shared_TAG 41bf5c1db3aa83808c401f608932373fcbba944d)
 set_tag(yarp-matlab-bindings_TAG master)
 set_tag(GazeboYARPPlugins_TAG devel)
 set_tag(robots-configuration_TAG devel)


### PR DESCRIPTION
This is a workaround for  https://github.com/robotology/robotology-superbuild/issues/372