### PR TITLE
Do not consider YCM_TAG differently from the rest of <package>_TAG options

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -113,7 +113,6 @@ endif()
 # Bootstrap YCM
 set(YCM_FOLDER robotology)
 set(YCM_COMPONENT core)
-set(YCM_TAG v0.11.1)
 set(YCM_MINIMUM_VERSION 0.11.1)
 include(YCMBootstrap)
 

--- a/cmake/ProjectsTagsStable.cmake
+++ b/cmake/ProjectsTagsStable.cmake
@@ -8,5 +8,6 @@ endmacro()
 set_tag(osqp_TAG v0.6.0)
 
 # Robotology projects
+set(YCM_TAG ycm-0.11)
 set(YARP_TAG yarp-3.3)
 set(yarp-matlab-bindings_TAG yarp-3.3)


### PR DESCRIPTION
For historical reason, `YCM_TAG` was hard-coded and it was not possible to change it as  for the rest of the projects, this PR fixes this. 

Fix https://github.com/robotology/robotology-superbuild/issues/283