### PR TITLE
Add support for Ubuntu 20.04 in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,9 +109,11 @@ On Debian based systems (as Ubuntu) you can install the C++ toolchain, Git, CMak
 sudo apt-get install libeigen3-dev build-essential cmake cmake-curses-gui coinor-libipopt-dev libboost-system-dev libboost-filesystem-dev libboost-thread-dev libtinyxml-dev libedit-dev libace-dev libgsl0-dev libopencv-dev libode-dev liblua5.1-dev lua5.1 git swig qtbase5-dev qtdeclarative5-dev qtmultimedia5-dev qml-module-qtquick2 qml-module-qtquick-window2 qml-module-qtmultimedia qml-module-qtquick-dialogs qml-module-qtquick-controls qml-module-qt-labs-folderlistmodel qml-module-qt-labs-settings libsdl1.2-dev libxml2-dev libv4l-dev
 ```
 
-For what regards CMake, the robotology-superbuild requires CMake 3.12 . If you are using a system in which the default version of CMake is older, you can easily install a newer CMake version in several ways. For the following distributions, we recommend the following methods:  
+For what regards CMake, the robotology-superbuild requires CMake 3.12 . If you are using a recent Debian-based system such as Debian 10 or Ubuntu 20.04, the default CMake is recent enough and you do not need to do further steps.
+
+If instead you use an older distro in which the default version of CMake is older, you can easily install a newer CMake version in several ways. For the following distributions, we recommend the following methods:  
 * Ubuntu 18.04 : use the latest CMake release in the [Kitware APT repository](https://apt.kitware.com/). You can find the full instructions for the installation on the website.
-* Debian 9 : use the CMake 3.13.2 in the `stretch-backports` repository, following the instructions to install from backports available in  [Debian documentation](https://backports.debian.org/Instructions/).
+* Debian 9 : use the CMake in the `stretch-backports` repository, following the instructions to install from backports available in  [Debian documentation](https://backports.debian.org/Instructions/).
 More details can be found at https://github.com/robotology/QA/issues/364 .
 
 If you enabled any [profile](#profile-cmake-options) or [dependency](#dependencies-cmake-options) specific CMake option you may need to install additional system dependencies, following the dependency-specific documentation (in particular, the `ROBOTOLOGY_USES_GAZEBO` option is enabled by default, so you should install Gazebo unless you plan to disable this option):


### PR DESCRIPTION
It is only necessary to specify that the default CMake is enough.

I also removed the info that CMake in stretch-backports is 3.13, as it has been updated instead to 3.16 . 