### PR TITLE
Set YCM option YCM_DISABLE_SYSTEM_PACKAGES to ON

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,7 +26,8 @@ include(FeatureSummary)
 
 set(YCM_USE_CMAKE_PROPOSED TRUE CACHE BOOL "Use files including unmerged cmake patches")
 
-# Compilation options
+# YCM options 
+option(YCM_DISABLE_SYSTEM_PACKAGES "Disable use of all the system installed packages" ON)
 
 # Dependencies options 
 ## Matlab related options


### PR DESCRIPTION
During the past years, we experienced quite a lot of times that for some reason on a setup 
the superbuild was finding its own installed packages, or finding the one of a similar superbuild 
installed on another setup. As recovering from this kind of errors is tricky for users, and as 
most of robotology-superbuild users do not need to find  the packages installed by the superbuild in  their system, the YCM_DISABLE_SYSTEM_PACKAGES option was introduced in YCM 
( see https://github.com/robotology/ycm/pull/332 )  to disable the use of  any system installed package if the same package can be installed by the superbuild (equivalent of setting  all the USE_SYSTEM_<project> options to OFF). 

This option is set by default to `OFF` on YCM for backward compatibility, but to avoid all the problems in the superbuild we set it to `ON` by default. If an expert user want to be able to find system-installed packages (for example because he has a  system-installed YARP) he just need to set it at `OFF`. 

The option is still not supported in the stable released version of YCM, so I will not update the README for now, but  it will be already effective if a users specifies uses `Unstable` `ROBOTOLOGY_PROJECT_TAGS`, so for example it  will be  already useful  for the iCubGenova01 setup @randaz81 @xEnVrE .

Related issues: 
* https://github.com/robotology/robotology-superbuild/issues/121
* https://github.com/robotology/robotology-superbuild/issues/174
* https://github.com/robotology/robotology-superbuild/issues/92