### PR TITLE
Add documentation on using the ROBOTOLOGY_ENABLE_ICUB_HEAD on Windows  and macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -423,8 +423,12 @@ or if you are a developer that needs to access iCub hardware devices directly wi
 that your iCub still needs to be migrated. For any doubt, please get in contact with [icub-support](https://github.com/robotology/icub-support).**
 
 The configuration and compilation of this profile is supported on Linux, macOS and Windows systems. 
-However, to communicate with CAN devices on Windows you need to also enable the `ROBOTOLOGY_ENABLE_ESDCAN` option, 
-and communication with CAN devices is not supported at all on macOS. 
+
+On Linux all the software necessary to communicate with boards contained in the robot, including CAN devices via [esd's CAN USB bridges](https://esd.eu/en/products/can-usb2), is already included. 
+
+On Windows to communicate with CAN devices via [esd's CAN USB bridges](https://esd.eu/en/products/can-usb2) you need to set to ON the Windows-only CMake option [`ROBOTOLOGY_ENABLE_ESDCAN`](#esdcan).
+
+On macOS, communication with [esd's CAN USB bridges](https://esd.eu/en/products/can-usb2) is not supported.
 
 This section documents the iCub Head profile as any other profile, in a way agnostic of the specific machine in which it is installed. To get information on how to use the robotology-superbuild to install software on the machine mounted in the head of physical iCub robots, please check the documentation in [`doc/use-on-icub-head.md`](doc/use-on-icub-head.md).
 

--- a/README.md
+++ b/README.md
@@ -422,7 +422,9 @@ or if you are a developer that needs to access iCub hardware devices directly wi
 **Warning: the migration of existing iCub setups to use the robotology-superbuild is an ongoing process, and it is possible
 that your iCub still needs to be migrated. For any doubt, please get in contact with [icub-support](https://github.com/robotology/icub-support).**
 
-The configuration and compilation of this profile is supported only on Linux systems.
+The configuration and compilation of this profile is supported on Linux, macOS and Windows systems. 
+However, to communicate with CAN devices on Windows you need to also enable the `ROBOTOLOGY_ENABLE_ESDCAN` option, 
+and communication with CAN devices is not supported at all on macOS. 
 
 This section documents the iCub Head profile as any other profile, in a way agnostic of the specific machine in which it is installed. To get information on how to use the robotology-superbuild to install software on the machine mounted in the head of physical iCub robots, please check the documentation in [`doc/use-on-icub-head.md`](doc/use-on-icub-head.md).
 


### PR DESCRIPTION
Fix https://github.com/robotology/robotology-superbuild/issues/236 .

If one of the main users of the `ROBOTOLOGY_ENABLE_ICUB_HEAD` option wants to check this text (such as @valegagge @davidetome @julijenv @marcoaccame @kouroshD @Yeshasvitvs @lrapetti @claudia-lat ) would want to check this docs, it would be great! 