### PR TITLE
 Disable YCM-created install target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,6 +24,10 @@ list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake")
 include(CTest)
 include(FeatureSummary)
 
+# Disable YCM-created install/INSTALL target (see https://github.com/robotology/robotology-superbuild/issues/356)
+macro(install)
+endmacro()
+
 set(YCM_USE_CMAKE_PROPOSED TRUE CACHE BOOL "Use files including unmerged cmake patches")
 
 # Compilation options


### PR DESCRIPTION
The `install` target of the superbuild is not supported for several reason, and users that want to install their project in a specific directory can use  the existing YCM variable YCM_EP_INSTALL_DIR  (see https://github.com/robotology/ycm/pull/289 ).

However, to avoid that some user that does not read the docs runs the install target, let's disable it. 

Fix https://github.com/robotology/robotology-superbuild/issues/356 .