### PR TITLE
[CI] Remove Debug builds on Ubuntu 18.04, macOS and Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,7 +66,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        build_type: [Debug, Release]
+        build_type: [Release]
         os: [ubuntu-latest, macOS-latest, windows-2019]
         project_tags: [Default, Unstable, Release202005]
         include:


### PR DESCRIPTION
As we recently have added in  our GitHub Actions script: 
* Builds using the latest Debian stable and Ubuntu 20.04 ( https://github.com/RobotLocomotion/drake/issues/13173 ) 
* Builds against the candidate tags for the next release ( https://github.com/robotology/robotology-superbuild/pull/386 )

the number of jobs  has grown a lot. To decrease the number of jobs, I think it is safe to remove the Debug jobs for Ubuntu 18.04, macOS and Windows. The amount of failures that affect only Debug jobs and not Release jobs is quite limited (typically just some code that was not updated in a `ifndef NDEBUG` or in an `assert`), and we still use the Debug build mode in Docker builds.