### PR TITLE
Migrate YCMBootstrap to use CMake's FetchContent 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -119,7 +119,7 @@ endif()
 set(YCM_FOLDER robotology)
 set(YCM_COMPONENT core)
 set(YCM_MINIMUM_VERSION 0.11.1)
-include(YCMBootstrap)
+include(YCMBootstrapFetchContent)
 
 include(FindOrBuildPackage)
 include(YCMEPHelper)

--- a/cmake/BuildICUB.cmake
+++ b/cmake/BuildICUB.cmake
@@ -5,9 +5,11 @@
 include(YCMEPHelper)
 include(FindOrBuildPackage)
 
+find_or_build_package(YCM QUIET)
 find_or_build_package(YARP QUIET)
 
 set(ICUB_DEPENDS "")
+list(APPEND ICUB_DEPENDS YCM)
 list(APPEND ICUB_DEPENDS YARP)
 
 if(ROBOTOLOGY_ENABLE_ICUB_HEAD)

--- a/cmake/BuildYARP.cmake
+++ b/cmake/BuildYARP.cmake
@@ -9,6 +9,8 @@ find_package(ACE QUIET)
 find_package(SQLite QUIET)
 find_package(Eigen3 QUIET)
 
+find_or_build_package(YCM QUIET)
+
 set(YARP_OPTIONAL_DEPS "")
 if(ROBOTOLOGY_ENABLE_ROBOT_TESTING)
   find_or_build_package(RobotTestingFramework QUIET)

--- a/cmake/YCMBootstrapFetchContent.cmake
+++ b/cmake/YCMBootstrapFetchContent.cmake
@@ -109,5 +109,10 @@ if(NOT ycm_POPULATED)
   # failures, we just add to CMAKE_MODULE_PATH the directory with the 
   # CMake modules used by a superbuild
   list(APPEND CMAKE_MODULE_PATH ${ycm_SOURCE_DIR}/find-modules)
+  # cmake-next/proposed is used by YCMEPHelper 
+  list(APPEND CMAKE_MODULE_PATH ${ycm_SOURCE_DIR}/cmake-next/proposed)
   list(APPEND CMAKE_MODULE_PATH ${ycm_SOURCE_DIR}/modules)
+  # We set YCM_FOUND to avoid that YCMEPHelper tries do download files 
+  # in the _ycm_include macro
+  set(YCM_FOUND ON)
 endif()

--- a/cmake/YCMBootstrapFetchContent.cmake
+++ b/cmake/YCMBootstrapFetchContent.cmake
@@ -1,6 +1,5 @@
 #=============================================================================
-# Copyright 2013-2014 Istituto Italiano di Tecnologia (IIT)
-#   Authors: Daniele E. Domenichelli <daniele.domenichelli@iit.it>
+# Copyright 2013-2020 Istituto Italiano di Tecnologia (IIT)
 #
 # Distributed under the OSI-approved BSD License (the "License");
 # see accompanying file Copyright.txt for details.
@@ -15,9 +14,6 @@
 
 # This module is intentionally kept as small as possible in order to
 # avoid the spreading of different modules.
-#
-# The real bootstrap is performed by the ycm_bootstrap macro from the
-# YCMEPHelper module that is downloaded from the YCM package.
 
 # CMake variables read as input by this module:
 # YCM_MINIMUM_VERSION : minimum version of YCM requested to use a system YCM 
@@ -25,12 +21,14 @@
 #             : TAG (either branch, commit or tag) of YCM repository 
 # USE_SYSTEM_YCM : if defined and set FALSE, skip searching for a system 
 #                  YCM and always bootstrap
+# YCM_DISABLE_SYSTEM_PACKAGES: if  defined and set TRUE, skip searching for a system 
+#                  YCM and always bootstrap
 
 
-if(DEFINED __YCMBOOTSTRAP_INCLUDED)
+if(DEFINED __YCMBOOTSTRAP_FETCHCONTENT_INCLUDED)
   return()
 endif()
-set(__YCMBOOTSTRAP_INCLUDED TRUE)
+set(__YCMBOOTSTRAP_FETCHCONTENT_INCLUDED TRUE)
 
 
 ########################################################################
@@ -76,8 +74,9 @@ _ycm_clean_path("${CMAKE_BINARY_DIR}/install" CMAKE_PREFIX_PATH)
 _ycm_clean_path("${CMAKE_BINARY_DIR}/install" PATH)
 
 
-# If the USE_SYSTEM_YCM is explicitly set to false, we just skip to bootstrap.
-if(NOT DEFINED USE_SYSTEM_YCM OR USE_SYSTEM_YCM)
+# If the USE_SYSTEM_YCM is explicitly set to false or 
+# YCM_DISABLE_SYSTEM_PACKAGES is explicitly set to true we just skip to bootstrap.
+if((NOT DEFINED USE_SYSTEM_YCM OR USE_SYSTEM_YCM) AND (NOT DEFINED YCM_DISABLE_SYSTEM_PACKAGES OR NOT YCM_DISABLE_SYSTEM_PACKAGES))
     find_package(YCM ${YCM_MINIMUM_VERSION} QUIET)
     if(COMMAND set_package_properties)
         set_package_properties(YCM PROPERTIES TYPE RECOMMENDED
@@ -92,23 +91,24 @@ endif()
 
 message(STATUS "YCM not found. Bootstrapping it.")
 
-set(YCM_BOOTSTRAP_BASE_ADDRESS "https://raw.githubusercontent.com/robotology/ycm/HEAD" CACHE STRING "Base address of YCM repository")
-# Replace old raw.github address to support existing builds
-if("${YCM_BOOTSTRAP_BASE_ADDRESS}" MATCHES "raw.github.com")
-    string(REPLACE "raw.github.com" "raw.githubusercontent.com" _tmp ${YCM_BOOTSTRAP_BASE_ADDRESS})
-    set_property(CACHE YCM_BOOTSTRAP_BASE_ADDRESS PROPERTY VALUE "${_tmp}")
-endif()
-# New github address does not accept "//" in the path, therefore we remove the last slash
-if("${YCM_BOOTSTRAP_BASE_ADDRESS}" MATCHES "/$")
-    string(REGEX REPLACE "/$" "" _tmp ${_tmp})
-    set_property(CACHE YCM_BOOTSTRAP_BASE_ADDRESS PROPERTY VALUE "${_tmp}")
-endif()
-mark_as_advanced(YCM_BOOTSTRAP_BASE_ADDRESS)
-
-if("${YCM_BOOTSTRAP_BASE_ADDRESS}" MATCHES "/HEAD$" AND YCM_TAG)
-    string(REGEX REPLACE "/HEAD$" "/${YCM_TAG}" YCM_BOOTSTRAP_BASE_ADDRESS ${YCM_BOOTSTRAP_BASE_ADDRESS})
+if(NOT DEFINED YCM_TAG)
+  set(YCM_TAG master)
 endif()
 
-include(IncludeUrl)
-include_url(${YCM_BOOTSTRAP_BASE_ADDRESS}/modules/YCMEPHelper.cmake)
-ycm_bootstrap()
+include(FetchContent)
+FetchContent_Declare(
+  YCM
+  GIT_REPOSITORY https://github.com/robotology/ycm.git
+  GIT_TAG        ${YCM_TAG}
+)
+
+FetchContent_GetProperties(YCM)
+if(NOT ycm_POPULATED)
+  FetchContent_Populate(YCM)
+  # The YCM build system downloads modules from several websites, 
+  # and this makes it quite prone to failures. To avoid this kind of 
+  # failures, we just add to CMAKE_MODULE_PATH the directory with the 
+  # CMake modules used by a superbuild
+  list(APPEND CMAKE_MODULE_PATH ${ycm_SOURCE_DIR}/find-modules)
+  list(APPEND CMAKE_MODULE_PATH ${ycm_SOURCE_DIR}/modules)
+endif()

--- a/cmake/YCMBootstrapFetchContent.cmake
+++ b/cmake/YCMBootstrapFetchContent.cmake
@@ -11,7 +11,6 @@
 # (To distribute this file outside of YCM, substitute the full
 #  License text for the above reference.)
 
-
 # This module is intentionally kept as small as possible in order to
 # avoid the spreading of different modules.
 

--- a/cmake/YCMBootstrapFetchContent.cmake
+++ b/cmake/YCMBootstrapFetchContent.cmake
@@ -111,6 +111,7 @@ if(NOT ycm_POPULATED)
   list(APPEND CMAKE_MODULE_PATH ${ycm_SOURCE_DIR}/find-modules)
   # cmake-next/proposed is used by YCMEPHelper 
   list(APPEND CMAKE_MODULE_PATH ${ycm_SOURCE_DIR}/cmake-next/proposed)
+  list(APPEND CMAKE_MODULE_PATH ${ycm_SOURCE_DIR}/style-modules)
   list(APPEND CMAKE_MODULE_PATH ${ycm_SOURCE_DIR}/modules)
   # We set YCM_FOUND to avoid that YCMEPHelper tries do download files 
   # in the _ycm_include macro


### PR DESCRIPTION
The YCMBootstrap process has been historically quite error-prone. This PR substitute this process by a more straightforward use of the CMake's FetchContent  repo. 

With respect to the past, the main difference is the superbuild will not use exactly the same `YCM` downloaded in `robotology-superbuild/robotology/YCM` , as a private copy of YCM used only for the robotology-superbuild configuration will be downloaded in `build/_deps/ycm-src`  . However, as the new script still observers the `YCM_TAG`  variable, the version downloaded in `build/_deps/ycm-src`  will be exactly the same version of YCM that will be downloaded in  `robotology-superbuild/robotology/YCM` .

On my Windows machine, this decreases the time spent in the YCM  bootstrap to ~5 seconds from ~20 seconds of the previous procedure. 

If this new module will work fine, it will be proposed in YCM to fix  https://github.com/robotology/ycm/issues/138 .