### PR TITLE
Fix setup-vcpkg.bat

### DIFF
--- a/packaging/windows/scripts/setup-vcpkg.bat
+++ b/packaging/windows/scripts/setup-vcpkg.bat
@@ -2,7 +2,7 @@ pushd %~dp0..
 set "installerRootPath=%cd%"
 popd
 
-set "vcpkgTriplet=windows-x64"
+set "vcpkgTriplet=x64-windows"
 set "vcpkgInstallDir=%installerRootPath%\vcpkg\installed\%vcpkgTriplet%"
 
 rem Update PATH 


### PR DESCRIPTION
The correct name of triplet in vcpkg is x64-windows, not windows-x64 .