### PR TITLE
Enable ROBOTOLOGY_USES_GAZEBO option on Windows CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -152,9 +152,9 @@ jobs:
         # To avoid problems with non-relocatable packages, we unzip the archive exactly in the same directory
         # that has been used to create the pre-compiled archive
         cd C:/
-        wget https://github.com/robotology/robotology-superbuild-dependencies-vcpkg/releases/download/v0.2.0/vcpkg-robotology.zip
-        unzip vcpkg-robotology.zip -d C:/
-        rm vcpkg-robotology.zip
+        wget https://github.com/robotology/robotology-superbuild-dependencies-vcpkg/releases/download/v0.3.0/vcpkg-robotology-with-gazebo.zip
+        unzip vcpkg-robotology-with-gazebo.zip -d C:/
+        rm vcpkg-robotology-with-gazebo.zip
         
     # ===================
     # CMAKE-BASED PROJECT
@@ -179,9 +179,11 @@ jobs:
       if: matrix.os == 'windows-2019'
       shell: bash
       run: |
+        # Make sure that Gazebo packages can be found by CMake
+        source /c/robotology/scripts/setup-deps.sh
         mkdir -p build
         cd build
-        cmake -A x64 -DCMAKE_TOOLCHAIN_FILE=C:/robotology/vcpkg/scripts/buildsystems/vcpkg.cmake -DYCM_EP_INSTALL_DIR=C:/robotology/robotology -DROBOTOLOGY_USES_GAZEBO:BOOL=OFF -DROBOTOLOGY_USES_OCTAVE:BOOL=OFF -DROBOTOLOGY_USES_PYTHON:BOOL=OFF -DROBOTOLOGY_USES_ESDCAN:BOOL=OFF -DROBOTOLOGY_ENABLE_ROBOT_TESTING:BOOL=ON -DROBOTOLOGY_ENABLE_DYNAMICS:BOOL=ON -DROBOTOLOGY_ENABLE_HUMAN_DYNAMICS:BOOL=ON -DROBOTOLOGY_ENABLE_ICUB_HEAD:BOOL=ON -DROBOTOLOGY_ENABLE_ICUB_BASIC_DEMOS:BOOL=ON -DNON_INTERACTIVE_BUILD:BOOL=TRUE -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}  ${{ matrix.project_tags_cmake_options }} ..
+        cmake -A x64 -DCMAKE_TOOLCHAIN_FILE=C:/robotology/vcpkg/scripts/buildsystems/vcpkg.cmake -DYCM_EP_INSTALL_DIR=C:/robotology/robotology -DROBOTOLOGY_USES_GAZEBO:BOOL=ON -DROBOTOLOGY_USES_OCTAVE:BOOL=OFF -DROBOTOLOGY_USES_PYTHON:BOOL=OFF -DROBOTOLOGY_USES_ESDCAN:BOOL=OFF -DROBOTOLOGY_ENABLE_ROBOT_TESTING:BOOL=ON -DROBOTOLOGY_ENABLE_DYNAMICS:BOOL=ON -DROBOTOLOGY_ENABLE_HUMAN_DYNAMICS:BOOL=ON -DROBOTOLOGY_ENABLE_ICUB_HEAD:BOOL=ON -DROBOTOLOGY_ENABLE_ICUB_BASIC_DEMOS:BOOL=ON -DNON_INTERACTIVE_BUILD:BOOL=TRUE -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}  ${{ matrix.project_tags_cmake_options }} ..
 
 
     - name: Build  [Ubuntu&macOS]
@@ -200,8 +202,8 @@ jobs:
       shell: bash
       run: |
         cd build
-        # yarp's rosmsgs generator links ACE, so it needs to find ACE dll in the path to run
-        export PATH=$PATH:/c/robotology/vcpkg/installed/x64-windows/bin:/c/robotology/vcpkg/installed/x64-windows/debug/bin
+        # Make sure that vcpkg's ace .dll are on the PATH
+        source /c/robotology/scripts/setup-deps.sh
         cmake --build . --config Debug
 
     - name: Build (Release) [Windows]
@@ -209,8 +211,8 @@ jobs:
       shell: bash
       run: |
         cd build
-        # yarp's rosmsgs generator links ACE, so it needs to find ACE dll in the path to run 
-        export PATH=$PATH:/c/robotology/vcpkg/installed/x64-windows/bin:/c/robotology/vcpkg/installed/x64-windows/debug/bin
+        # Make sure that vcpkg's ace .dll are on the PATH
+        source /c/robotology/scripts/setup-deps.sh
         cmake --build . --config Release
 
     # Just for release builds we gerate the installer

--- a/releases/2020.05.yaml
+++ b/releases/2020.05.yaml
@@ -42,7 +42,7 @@ repositories:
   RobotTestingFramework:
     type: git
     url: https://github.com/robotology/robot-testing-framework.git
-    version: v2.0.0
+    version: v2.0.1
   icub-tests:
     type: git
     url: https://github.com/robotology/icub-tests.git

--- a/releases/2020.05.yaml
+++ b/releases/2020.05.yaml
@@ -30,7 +30,7 @@ repositories:
   GazeboYARPPlugins:
     type: git
     url: https://github.com/robotology/gazebo-yarp-plugins.git
-    version: v3.3.0
+    version: v3.3.2
   icub-gazebo:
     type: git
     url: https://github.com/robotology/icub-gazebo.git


### PR DESCRIPTION
Using the Gazebo binaries produced in https://github.com/robotology/robotology-superbuild-dependencies-vcpkg/pull/17 . 