### PR TITLE
 Add missing dependencies of iDynTree on OsqpEigen 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,7 @@ jobs:
     name: '[docker:Tags:${{ matrix.project_tags }}@${{ matrix.docker_image }}@${{ matrix.build_type }}]'
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         build_type: [Debug]
         cmake_generator: 

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 This is a meta repository (so-called "superbuild") that uses [CMake](https://cmake.org/) and [YCM](https://github.com/robotology/ycm) to automatically
 download and compile software developed in the robotology GitHub organization, such as the YARP middleware or software used to run the iCub humanoid robot.
 
+
 [CMake](https://cmake.org/) is an open-source, cross-platform family of tools designed to build, test and package software.
 A [YCM Superbuild](http://robotology.github.io/ycm/gh-pages/git-master/index.html#superbuild) is a CMake project whose only goal is to download and build several other projects.
 If you are familiar with ROS, it is something similar to [catkin](http://wiki.ros.org/catkin/workspaces) or [colcon workspace](https://colcon.readthedocs.io/en/released/user/quick-start.html), but using pure CMake for portability reasons and for customizing the build via CMake options.

--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@
 This is a meta repository (so-called "superbuild") that uses [CMake](https://cmake.org/) and [YCM](https://github.com/robotology/ycm) to automatically
 download and compile software developed in the robotology GitHub organization, such as the YARP middleware or software used to run the iCub humanoid robot.
 
-
 [CMake](https://cmake.org/) is an open-source, cross-platform family of tools designed to build, test and package software.
 A [YCM Superbuild](http://robotology.github.io/ycm/gh-pages/git-master/index.html#superbuild) is a CMake project whose only goal is to download and build several other projects.
 If you are familiar with ROS, it is something similar to [catkin](http://wiki.ros.org/catkin/workspaces) or [colcon workspace](https://colcon.readthedocs.io/en/released/user/quick-start.html), but using pure CMake for portability reasons and for customizing the build via CMake options.

--- a/cmake/BuildiDynTree.cmake
+++ b/cmake/BuildiDynTree.cmake
@@ -7,10 +7,12 @@ include(FindOrBuildPackage)
 
 find_or_build_package(YARP QUIET)
 find_or_build_package(ICUB QUIET)
+find_or_build_package(OsqpEigen QUIET)
 
 set(iDynTree_DEPENDS "")
 list(APPEND iDynTree_DEPENDS YARP)
 list(APPEND iDynTree_DEPENDS ICUB)
+list(APPEND iDynTree_DEPENDS OsqpEigen)
 
 ycm_ep_helper(iDynTree TYPE GIT
               STYLE GITHUB
@@ -19,7 +21,11 @@ ycm_ep_helper(iDynTree TYPE GIT
               COMPONENT dynamics
               FOLDER robotology
               CMAKE_ARGS -DIDYNTREE_USES_IPOPT:BOOL=ON
+                         -DIDYNTREE_USES_YARP:BOOL=ON
+                         -DIDYNTREE_USES_ICUB_MAIN:BOOL=ON
+                         -DIDYNTREE_USES_OSQPEIGEN:BOOL=ON
                          -DIDYNTREE_USES_MATLAB:BOOL=${ROBOTOLOGY_USES_MATLAB}
                          -DIDYNTREE_USES_PYTHON:BOOL=${ROBOTOLOGY_USES_PYTHON}
                          -DIDYNTREE_USES_OCTAVE:BOOL=${ROBOTOLOGY_USES_OCTAVE}
+                         
               DEPENDS ${iDynTree_DEPENDS})


### PR DESCRIPTION
Before this fix, whetever iDynTree was compiled or not with OsqpEigen support was non 
deterministic, and based on wheter OsqpEigen  was already compiled and  installed when
iDynTree was configured. With  this fix, the dependency of iDynTree on OsqpEigen is explicitly 
indicated, and the IDYNTREE_USES_* options are explicity set, so that if for some reason one
of the dependency is not installed correctly, iDynTree configuration will fail.

Also add Add fail-fast: false also to Docker-based GitHub Actions jobs, that had the nice side effect: of helping in debug the problems discussed in https://github.com/robotology/osqp-eigen/pull/62 .