### PR TITLE
GitHub Actions: Use gazebo11 on macOS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,7 +140,7 @@ jobs:
         # ROBOTOLOGY_ENABLE_DYNAMICS dependencies 
         brew install libmatio
         # ROBOTOLOGY_USES_GAZEBO dependencies 
-        brew install osrf/simulation/gazebo10
+        brew install osrf/simulation/gazebo11
         # CI-specific dependencies 
         brew install ninja
         cmake --version


### PR DESCRIPTION
Using the latest version make sense in general (it is the version that new users will install by default) and will also help as a workaround against https://github.com/osrf/homebrew-simulation/issues/1022 .