### PR TITLE
Create 2020.08.yaml for 2020.08 release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,7 +71,7 @@ jobs:
       matrix:
         build_type: [Release]
         os: [ubuntu-latest, macOS-latest, windows-2019]
-        project_tags: [Default, Unstable, Release202005]
+        project_tags: [Default, Unstable, Release202008]
         include:
           - os: ubuntu-latest
             build_type: Debug
@@ -89,8 +89,8 @@ jobs:
             project_tags_cmake_options: ""
           - project_tags: Unstable
             project_tags_cmake_options: "-DROBOTOLOGY_PROJECT_TAGS=Unstable"
-          - project_tags: Release202005
-            project_tags_cmake_options: "-DROBOTOLOGY_PROJECT_TAGS=Custom -DROBOTOLOGY_PROJECT_TAGS_CUSTOM_FILE=${GITHUB_WORKSPACE}/releases/2020.05.yaml"
+          - project_tags: Release202008
+            project_tags_cmake_options: "-DROBOTOLOGY_PROJECT_TAGS=Custom -DROBOTOLOGY_PROJECT_TAGS_CUSTOM_FILE=${GITHUB_WORKSPACE}/releases/2020.08.yaml"
 
     steps:
     - uses: actions/checkout@master

--- a/releases/2020.08.yaml
+++ b/releases/2020.08.yaml
@@ -50,11 +50,11 @@ repositories:
   blockTest:
     type: git
     url: https://github.com/robotology/blocktest.git
-    version: v2.2.0
+    version: d490bd018cf6c40e0a2e37650943d43de23751a0
   blocktest-yarp-plugins:
     type: git
     url: https://github.com/robotology/blocktest-yarp-plugins.git
-    version: v1.0.0
+    version: 78eacbf220a1c6db6d1bac68e4b51ab4a3a55142
   iDynTree:
     type: git
     url: https://github.com/robotology/idyntree.git

--- a/releases/2020.08.yaml
+++ b/releases/2020.08.yaml
@@ -58,7 +58,7 @@ repositories:
   iDynTree:
     type: git
     url: https://github.com/robotology/idyntree.git
-    version: v1.0.2
+    version: v1.1.0
   BlockFactory:
     type: git
     url: https://github.com/robotology/blockfactory.git

--- a/releases/2020.08.yaml
+++ b/releases/2020.08.yaml
@@ -38,7 +38,7 @@ repositories:
   yarp-matlab-bindings:
     type: git
     url: https://github.com/robotology/yarp-matlab-bindings.git
-    version: v3.3.0
+    version: master
   RobotTestingFramework:
     type: git
     url: https://github.com/robotology/robot-testing-framework.git

--- a/releases/2020.08.yaml
+++ b/releases/2020.08.yaml
@@ -47,6 +47,14 @@ repositories:
     type: git
     url: https://github.com/robotology/icub-tests.git
     version: v1.16.0
+  blockTest:
+    type: git
+    url: https://github.com/robotology/blocktest.git
+    version: v2.2.0
+  blocktest-yarp-plugins:
+    type: git
+    url: https://github.com/robotology/blocktest-yarp-plugins.git
+    version: v1.0.0
   iDynTree:
     type: git
     url: https://github.com/robotology/idyntree.git

--- a/releases/2020.08.yaml
+++ b/releases/2020.08.yaml
@@ -1,0 +1,125 @@
+repositories:
+  qpOASES:
+    type: git
+    url: https://github.com/robotology-dependencies/qpOASES.git
+    version: v3.2.0.1
+  osqp:
+    type: git
+    url: https://github.com/oxfordcontrol/osqp.git
+    version: v0.6.0
+  ycm:
+    type: git
+    url: https://github.com/robotology/ycm.git
+    version: v0.11.1
+  YARP:
+    type: git
+    url: https://github.com/robotology/yarp.git
+    version: master
+  ICUB:
+    type: git
+    url: https://github.com/robotology/icub-main.git
+    version: devel
+  ICUBcontrib:
+    type: git
+    url: https://github.com/robotology/icub-contrib-common.git
+    version: v1.16.0
+  robots-configuration:
+    type: git
+    url: https://github.com/robotology/robots-configuration.git
+    version: v1.16.0
+  GazeboYARPPlugins:
+    type: git
+    url: https://github.com/robotology/gazebo-yarp-plugins.git
+    version: devel
+  icub-gazebo:
+    type: git
+    url: https://github.com/robotology/icub-gazebo.git
+    version: v1.16.0
+  yarp-matlab-bindings:
+    type: git
+    url: https://github.com/robotology/yarp-matlab-bindings.git
+    version: v3.3.0
+  RobotTestingFramework:
+    type: git
+    url: https://github.com/robotology/robot-testing-framework.git
+    version: v2.0.1
+  icub-tests:
+    type: git
+    url: https://github.com/robotology/icub-tests.git
+    version: v1.16.0
+  iDynTree:
+    type: git
+    url: https://github.com/robotology/idyntree.git
+    version: v1.0.2
+  BlockFactory:
+    type: git
+    url: https://github.com/robotology/blockfactory.git
+    version: v0.8.1
+  WBToolbox:
+    type: git
+    url: https://github.com/robotology/wb-toolbox.git
+    version: v5.1
+  OsqpEigen:
+    type: git
+    url: https://github.com/robotology/osqp-eigen.git
+    version: v0.5.2
+  UnicyclePlanner:
+    type: git
+    url: https://github.com/robotology/unicycle-footstep-planner.git
+    version: v0.2.0
+  walking-controllers:
+    type: git
+    url: https://github.com/robotology/walking-controllers.git
+    version: v0.2.1
+  icub-gazebo-wholebody:
+    type: git
+    url: https://github.com/robotology/icub-gazebo-wholebody.git
+    version: v0.1.0
+  whole-body-controllers:
+    type: git
+    url: https://github.com/robotology/whole-body-controllers.git
+    version: v2.0
+  whole-body-estimators:
+    type: git
+    url: https://github.com/robotology/whole-body-estimators.git
+    version: v0.2.1
+  walking-teleoperation:
+    type: git
+    url: https://github.com/robotology/walking-teleoperation.git
+    version: v0.2.0
+  forcetorque-yarp-devices:
+    type: git
+    url: https://github.com/robotology/forcetorque-yarp-devices.git
+    version: v0.2.0
+  wearables:
+    type: git
+    url: https://github.com/robotology/wearables.git
+    version: v1.0.0
+  human-dynamics-estimation:
+    type: git
+    url: https://github.com/robotology/human-dynamics-estimation.git
+    version: v2.1.0
+  human-gazebo:
+    type: git
+    url: https://github.com/robotology/human-gazebo.git
+    version: v1.0
+  icub-firmware-shared:
+    type: git
+    url: https://github.com/robotology/icub-firmware-shared.git
+    version: devel
+  xsensmt-yarp-driver:
+    type: git
+    url: https://github.com/robotology/xsensmt-yarp-driver.git
+    version: v0.1.0
+  speech:
+    type: git
+    url: https://github.com/robotology/speech.git
+    version: v1.0.0
+  icub-basic-demos:
+    type: git
+    url: https://github.com/robotology/icub-basic-demos.git
+    version: master
+  funny-things:
+    type: git
+    url: https://github.com/robotology/funny-things.git
+    version: v1.0.0


### PR DESCRIPTION
It contains the tag as released in 2020.05, with some projects bumped to use thee branches on which the release contained in 2020.08 will be tagged.

See https://github.com/robotology/robotology-superbuild/blob/master/doc/developers-faqs.md#how-to-do-a-new-release for more details.