### PR TITLE
On Debian/Ubuntu CI use python3-dev package

### DIFF
--- a/.ci/install_debian.sh
+++ b/.ci/install_debian.sh
@@ -13,7 +13,7 @@ apt-get install -y clang valgrind ccache ninja-build
 apt-get install -y libeigen3-dev build-essential cmake cmake-curses-gui coinor-libipopt-dev freeglut3-dev libboost-system-dev libboost-filesystem-dev libboost-thread-dev libtinyxml-dev libace-dev libedit-dev libgsl0-dev libopencv-dev libode-dev liblua5.1-dev lua5.1 git swig qtbase5-dev qtdeclarative5-dev qtmultimedia5-dev qml-module-qtquick2 qml-module-qtquick-window2 qml-module-qtmultimedia qml-module-qtquick-dialogs qml-module-qtquick-controls qml-module-qt-labs-folderlistmodel qml-module-qt-labs-settings libsdl1.2-dev libxml2-dev libv4l-dev
 
 # Python
-apt-get install -y python-dev
+apt-get install -y python3-dev
 
 # Octave
 apt-get install -y liboctave-dev


### PR DESCRIPTION
Python 2 is EOL since 1st of January 2020 and some projects removed support for it, so let's use Python 3 for testing.

Fix https://github.com/robotology/robotology-superbuild/issues/432 .
Related issue: https://github.com/robotology/robotology-superbuild/issues/28 .

The Windows CI jobs will probably still fail due to https://github.com/robotology/robotology-superbuild/issues/429 , so the important thing for this PR is to check that all Linux jobs succeed .