### PR TITLE
GitHub Actions: Disable Git symlinks on Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,6 +113,14 @@ jobs:
       run: |
         for apt_file in `grep -lr microsoft /etc/apt/sources.list.d/`; do sudo rm $apt_file; done
         
+    # symlinks disabled are the default setting on Windows, but unfortunatly GitHub Actions enabled them 
+    # See: 
+    # * https://github.com/robotology/robotology-superbuild/issues/429
+    # * https://github.com/actions/virtual-environments/pull/1186  
+    - name: Disable Git symlinks on Windows 
+      if: contains(matrix.os, 'windows')
+      run: git config --global core.symlinks false
+ 
     # ============
     # DEPENDENCIES
     # ============


### PR DESCRIPTION
Workaround for https://github.com/robotology/robotology-superbuild/issues/429