### PR TITLE
Propagate name update of icub_firmware_shared and blocktest core to release .yml files

### DIFF
--- a/releases/2020.02.yaml
+++ b/releases/2020.02.yaml
@@ -111,7 +111,7 @@ repositories:
     type: git
     url: https://github.com/robotology/human-gazebo.git
     version: v1.0
-  icub-firmware-shared:
+  icub_firmware_shared:
     type: git
     url: https://github.com/robotology/icub-firmware-shared.git
     version: v1.15.0

--- a/releases/2020.05.yaml
+++ b/releases/2020.05.yaml
@@ -103,7 +103,7 @@ repositories:
     type: git
     url: https://github.com/robotology/human-gazebo.git
     version: v1.0
-  icub-firmware-shared:
+  icub_firmware_shared:
     type: git
     url: https://github.com/robotology/icub-firmware-shared.git
     version: v1.16.0

--- a/releases/2020.08.yaml
+++ b/releases/2020.08.yaml
@@ -111,7 +111,7 @@ repositories:
     type: git
     url: https://github.com/robotology/human-gazebo.git
     version: v1.0
-  icub-firmware-shared:
+  icub_firmware_shared:
     type: git
     url: https://github.com/robotology/icub-firmware-shared.git
     version: devel

--- a/releases/2020.08.yaml
+++ b/releases/2020.08.yaml
@@ -47,7 +47,7 @@ repositories:
     type: git
     url: https://github.com/robotology/icub-tests.git
     version: v1.16.0
-  blockTest:
+  blocktestcore:
     type: git
     url: https://github.com/robotology/blocktest.git
     version: v2.3.0


### PR DESCRIPTION
The PRs https://github.com/robotology/robotology-superbuild/pull/438 and https://github.com/robotology/robotology-superbuild/pull/437 changed the name of some superbuild subprojects `icub_firmware_shared` and `blocktestcore`, but as part of those PR the `yml` releases files were not updated, and so the wrong version of those dependencies was used. 

Fix https://github.com/robotology/robotology-superbuild/issues/441 .