### PR TITLE
Create 2020.05.feat-01.yaml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,7 +71,7 @@ jobs:
       matrix:
         build_type: [Release]
         os: [ubuntu-latest, macOS-latest, windows-2019]
-        project_tags: [Default, Unstable, Release202008]
+        project_tags: [Default, Unstable, Release202005feat01, Release202008]
         include:
           - os: ubuntu-latest
             build_type: Debug
@@ -89,9 +89,10 @@ jobs:
             project_tags_cmake_options: ""
           - project_tags: Unstable
             project_tags_cmake_options: "-DROBOTOLOGY_PROJECT_TAGS=Unstable"
+          - project_tags: Release202005feat01
+            project_tags_cmake_options: "-DROBOTOLOGY_PROJECT_TAGS=Custom -DROBOTOLOGY_PROJECT_TAGS_CUSTOM_FILE=${GITHUB_WORKSPACE}/releases/2020.05.feat-01.yaml"
           - project_tags: Release202008
             project_tags_cmake_options: "-DROBOTOLOGY_PROJECT_TAGS=Custom -DROBOTOLOGY_PROJECT_TAGS_CUSTOM_FILE=${GITHUB_WORKSPACE}/releases/2020.08.yaml"
-
     steps:
     - uses: actions/checkout@master
     

--- a/releases/2020.05.feat-01.yaml
+++ b/releases/2020.05.feat-01.yaml
@@ -1,0 +1,125 @@
+repositories:
+  qpOASES:
+    type: git
+    url: https://github.com/robotology-dependencies/qpOASES.git
+    version: v3.2.0.1
+  osqp:
+    type: git
+    url: https://github.com/oxfordcontrol/osqp.git
+    version: v0.6.0
+  ycm:
+    type: git
+    url: https://github.com/robotology/ycm.git
+    version: v0.11.1
+  YARP:
+    type: git
+    url: https://github.com/robotology/yarp.git
+    version: v3.3.2
+  ICUB:
+    type: git
+    url: https://github.com/robotology/icub-main.git
+    version: v1.16.1
+  ICUBcontrib:
+    type: git
+    url: https://github.com/robotology/icub-contrib-common.git
+    version: v1.16.0
+  robots-configuration:
+    type: git
+    url: https://github.com/robotology/robots-configuration.git
+    version: iCubGenova08
+  GazeboYARPPlugins:
+    type: git
+    url: https://github.com/robotology/gazebo-yarp-plugins.git
+    version: v3.4.0
+  icub-gazebo:
+    type: git
+    url: https://github.com/robotology/icub-gazebo.git
+    version: v1.16.0
+  yarp-matlab-bindings:
+    type: git
+    url: https://github.com/robotology/yarp-matlab-bindings.git
+    version: v3.3.0
+  RobotTestingFramework:
+    type: git
+    url: https://github.com/robotology/robot-testing-framework.git
+    version: v2.0.1
+  icub-tests:
+    type: git
+    url: https://github.com/robotology/icub-tests.git
+    version: v1.16.0
+  iDynTree:
+    type: git
+    url: https://github.com/robotology/idyntree.git
+    version: v1.0.2
+  BlockFactory:
+    type: git
+    url: https://github.com/robotology/blockfactory.git
+    version: v0.8.1
+  WBToolbox:
+    type: git
+    url: https://github.com/robotology/wb-toolbox.git
+    version: v5.1
+  OsqpEigen:
+    type: git
+    url: https://github.com/robotology/osqp-eigen.git
+    version: v0.5.2
+  UnicyclePlanner:
+    type: git
+    url: https://github.com/robotology/unicycle-footstep-planner.git
+    version: v0.2.0
+  walking-controllers:
+    type: git
+    url: https://github.com/robotology/walking-controllers.git
+    version: v0.2.1
+  icub-gazebo-wholebody:
+    type: git
+    url: https://github.com/robotology/icub-gazebo-wholebody.git
+    version: v0.1.0
+  whole-body-controllers:
+    type: git
+    url: https://github.com/robotology/whole-body-controllers.git
+    version: v2.0
+  whole-body-estimators:
+    type: git
+    url: https://github.com/robotology/whole-body-estimators.git
+    version: v0.2.1
+  walking-teleoperation:
+    type: git
+    url: https://github.com/robotology/walking-teleoperation.git
+    version: v0.2.0
+  forcetorque-yarp-devices:
+    type: git
+    url: https://github.com/robotology/forcetorque-yarp-devices.git
+    version: v0.2.0
+  wearables:
+    type: git
+    url: https://github.com/robotology/wearables.git
+    version: v1.0.0
+  human-dynamics-estimation:
+    type: git
+    url: https://github.com/robotology/human-dynamics-estimation.git
+    version: v2.1.0
+  human-gazebo:
+    type: git
+    url: https://github.com/robotology/human-gazebo.git
+    version: v1.0
+  icub_firmware_shared:
+    type: git
+    url: https://github.com/robotology/icub-firmware-shared.git
+    version: v1.16.0
+  xsensmt-yarp-driver:
+    type: git
+    url: https://github.com/robotology/xsensmt-yarp-driver.git
+    version: v0.1.0
+  speech:
+    type: git
+    url: https://github.com/robotology/speech.git
+    version: v1.0.0
+  icub-basic-demos:
+    type: git
+    url: https://github.com/robotology/icub-basic-demos.git
+    version: v1.16.1
+  funny-things:
+    type: git
+    url: https://github.com/robotology/funny-things.git
+    version: v1.0.0

--- a/releases/2020.05.feat-01.yaml
+++ b/releases/2020.05.feat-01.yaml
@@ -50,7 +50,7 @@ repositories:
   iDynTree:
     type: git
     url: https://github.com/robotology/idyntree.git
-    version: v1.0.2
+    version: v1.0.7
   BlockFactory:
     type: git
     url: https://github.com/robotology/blockfactory.git

--- a/releases/2020.05.feat-01.yaml
+++ b/releases/2020.05.feat-01.yaml
@@ -26,11 +26,11 @@ repositories:
   robots-configuration:
     type: git
     url: https://github.com/robotology/robots-configuration.git
-    version: iCubGenova08
+    version: v1.16.1
   GazeboYARPPlugins:
     type: git
     url: https://github.com/robotology/gazebo-yarp-plugins.git
-    version: master
+    version: v3.4.1
   icub-gazebo:
     type: git
     url: https://github.com/robotology/icub-gazebo.git

--- a/releases/2020.05.feat-01.yaml
+++ b/releases/2020.05.feat-01.yaml
@@ -30,7 +30,7 @@ repositories:
   GazeboYARPPlugins:
     type: git
     url: https://github.com/robotology/gazebo-yarp-plugins.git
-    version: v3.4.0
+    version: master
   icub-gazebo:
     type: git
     url: https://github.com/robotology/icub-gazebo.git


### PR DESCRIPTION
This PR adds the files for testing the tags of the upcoming release 2020.05.feat-01.

This is a feature-based released that impacts `icub-main` `robots-configurations` and `icub-basic-demos`. It contains the changes needed by `iCub v2.7` (The first one is going to be shipped at the end of the month)

TODO:

- [x] Put tag `v1.16.1` in `robots-configuration`
- [x] Put tag `v3.4.1` in `gazebo-yarp-plugins`