### PR TITLE
Enable Debian Sid testing in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,7 @@ jobs:
         apt-get -y -t buster-backports install cmake
         
     - name: Install additional packages for Debian Sid [Debian Sid]
-      if: matrix.docker_image == 'debian:sid`
+      if: matrix.docker_image == 'debian:sid'
       run: |
         # Workaround for https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=967008
         apt-get -y install libdart-external-odelcpsolver-dev

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,8 +29,8 @@ jobs:
         docker_image: 
           - "ubuntu:focal"
           - "debian:buster-backports"
-          # Workaround for https://github.com/robotology/robotology-superbuild/issues/383
-          # - "debian:sid"
+          - "debian:sid"
+
         project_tags:
           - Default
           - Unstable

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,6 +56,12 @@ jobs:
       run: |
         apt-get -y -t buster-backports install cmake
         
+    - name: Install additional packages for Debian Sid [Debian Sid]
+      if: matrix.docker_image == 'debian:sid`
+      run: |
+        # Workaround for https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=967008
+        apt-get -y install libdart-external-odelcpsolver-dev
+        
     - name: Configure [Docker]
       run: |
         mkdir -p build


### PR DESCRIPTION
This should permit to early catch compilation problems due to new version of Debian packages, before they end in a Ubuntu LTS release.

In particular, let's see if https://github.com/robotology/robotology-superbuild/issues/383 is now solved.