### PR TITLE
GitHub Actions: Add check on free space

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,6 +95,11 @@ jobs:
             project_tags_cmake_options: "-DROBOTOLOGY_PROJECT_TAGS=Custom -DROBOTOLOGY_PROJECT_TAGS_CUSTOM_FILE=${GITHUB_WORKSPACE}/releases/2020.08.yaml"
     steps:
     - uses: actions/checkout@master
+
+    - name: Check free space 
+      shell: bash 
+      run: |
+        df -h
     
     # Workaround for https://github.com/actions/virtual-environments/issues/10
     - name: Avoid to use GitHub Actions-installed boost


### PR DESCRIPTION
This is useful to monitor regressions due to missing disk space, see for example https://github.com/robotology/robotology-superbuild/issues/456 .