### PR TITLE
GitHub Actions: install python3-numpy

### DIFF
--- a/.ci/install_debian.sh
+++ b/.ci/install_debian.sh
@@ -13,7 +13,7 @@ apt-get install -y clang valgrind ccache ninja-build
 apt-get install -y libeigen3-dev build-essential cmake cmake-curses-gui coinor-libipopt-dev freeglut3-dev libboost-system-dev libboost-filesystem-dev libboost-thread-dev libtinyxml-dev libace-dev libedit-dev libgsl0-dev libopencv-dev libode-dev liblua5.1-dev lua5.1 git swig qtbase5-dev qtdeclarative5-dev qtmultimedia5-dev qml-module-qtquick2 qml-module-qtquick-window2 qml-module-qtmultimedia qml-module-qtquick-dialogs qml-module-qtquick-controls qml-module-qt-labs-folderlistmodel qml-module-qt-labs-settings libsdl1.2-dev libxml2-dev libv4l-dev
 
 # Python
-apt-get install -y python3-dev
+apt-get install -y python3-dev python3-numpy
 
 # Octave
 apt-get install -y liboctave-dev


### PR DESCRIPTION
This is now required since https://github.com/robotology/idyntree/pull/726 .

Without this fix, the unstable CI is failing with the error: 
~~~
2020-09-01T14:03:36.5315042Z CMake Error at /usr/share/cmake-3.16/Modules/FindPackageHandleStandardArgs.cmake:146 (message):
2020-09-01T14:03:36.5315306Z   Could NOT find Python3 (missing: Python3_NumPy_INCLUDE_DIRS NumPy) (found
2020-09-01T14:03:36.5315430Z   version "3.8.2")
2020-09-01T14:03:36.5315536Z Call Stack (most recent call first):
2020-09-01T14:03:36.5315828Z   /usr/share/cmake-3.16/Modules/FindPackageHandleStandardArgs.cmake:393 (_FPHSA_FAILURE_MESSAGE)
2020-09-01T14:03:36.5316211Z   /usr/share/cmake-3.16/Modules/FindPython/Support.cmake:2214 (find_package_handle_standard_args)
2020-09-01T14:03:36.5316487Z   /usr/share/cmake-3.16/Modules/FindPython3.cmake:300 (include)
2020-09-01T14:03:36.5316611Z   bindings/python/CMakeLists.txt:3 (find_package)
~~~