### PR TITLE
Update README to point to the latest version of robotology-superbuild-dependencies-vcpkg

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,7 +253,7 @@ The software in the superbuild depends on several C++  libraries: to install the
 For this reason, we provide a ready to use `vcpkg` workspace at https://github.com/robotology/robotology-superbuild-dependencies-vcpkg/releases, that you can download and unzip in `C:/` and use directly from there, for example executing the following commands from the Git Bash shell:
 ~~~
 cd C:/
-wget https://github.com/robotology/robotology-superbuild-dependencies-vcpkg/releases/download/v0.3.0/vcpkg-robotology.zip
+wget https://github.com/robotology/robotology-superbuild-dependencies-vcpkg/releases/latest/download/vcpkg-robotology.zip
 unzip vcpkg-robotology.zip -d C:/
 rm vcpkg-robotology.zip
 ~~~


### PR DESCRIPTION
For example, right now it points to the 0.3.0 version, which is not the latest. This would avoid us to update this README every time we have a new release.