### PR TITLE
GitHub Actions: Switch Debian stable testing to use backports

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,7 @@ jobs:
     - name: Install CMake 3.16 [Docker/Debian Buster] 
       if: matrix.docker_image == 'debian:buster-backports'
       run: |
-        apt-get -t buster-backports install cmake
+        apt-get -y -t buster-backports install cmake
         
     - name: Configure [Docker]
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
           - "Ninja"
         docker_image: 
           - "ubuntu:focal"
-          - "debian:stable"
+          - "debian:stable-backports"
           # Workaround for https://github.com/robotology/robotology-superbuild/issues/383
           # - "debian:sid"
         project_tags:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
           - "Ninja"
         docker_image: 
           - "ubuntu:focal"
-          - "debian:stable-backports"
+          - "debian:buster-backports"
           # Workaround for https://github.com/robotology/robotology-superbuild/issues/383
           # - "debian:sid"
         project_tags:
@@ -51,6 +51,11 @@ jobs:
         chmod +x ./.ci/install_debian.sh
         ./.ci/install_debian.sh
 
+    - name: Install CMake 3.16 [Docker/Debian Buster] 
+      if: matrix.docker_image == 'debian:buster-backports'
+      run: |
+        apt-get -t buster-backports install cmake
+        
     - name: Configure [Docker]
       run: |
         mkdir -p build


### PR DESCRIPTION
This fixes the same problem as https://github.com/robotology/robotology-superbuild/pull/458 but for Debian Stable.