### PR TITLE
GitHub Action: remove build directories on Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -220,6 +220,8 @@ jobs:
         # Make sure that vcpkg's ace .dll are on the PATH
         source /c/robotology/scripts/setup-deps.sh
         cmake --build . --config Debug
+        # Cleanup build directories to avoid to fill the disk
+        rm -rf ./robotology
 
     - name: Build (Release) [Windows]
       if: matrix.os == 'windows-2019'
@@ -229,6 +231,8 @@ jobs:
         # Make sure that vcpkg's ace .dll are on the PATH
         source /c/robotology/scripts/setup-deps.sh
         cmake --build . --config Release
+        # Cleanup build directories to avoid to fill the disk
+        rm -rf ./robotology
 
     # Just for release builds we gerate the installer
     - name: Generate installer [Windows]


### PR DESCRIPTION
This should mitigate problems due to low space available in CI machine such as the one reported in https://github.com/robotology/robotology-superbuild/issues/456 .