### PR TITLE
YARP: Set ENABLE_yarpcar_mjpeg, ENABLE_yarpcar_portmonitor, ENABLE_yarpcar_depthimage and ENABLE_yarpcar_depthimage2 to ON by default

### DIFF
--- a/.ci/install_debian.sh
+++ b/.ci/install_debian.sh
@@ -10,7 +10,7 @@ export DEBIAN_FRONTEND=noninteractive
 apt-get install -y clang valgrind ccache ninja-build
 
 # Core dependencies
-apt-get install -y libeigen3-dev build-essential cmake cmake-curses-gui coinor-libipopt-dev freeglut3-dev libboost-system-dev libboost-filesystem-dev libboost-thread-dev libtinyxml-dev libace-dev libedit-dev libgsl0-dev libopencv-dev libode-dev liblua5.1-dev lua5.1 git swig qtbase5-dev qtdeclarative5-dev qtmultimedia5-dev qml-module-qtquick2 qml-module-qtquick-window2 qml-module-qtmultimedia qml-module-qtquick-dialogs qml-module-qtquick-controls qml-module-qt-labs-folderlistmodel qml-module-qt-labs-settings libsdl1.2-dev libxml2-dev libv4l-dev
+apt-get install -y libeigen3-dev build-essential cmake cmake-curses-gui coinor-libipopt-dev freeglut3-dev libboost-system-dev libboost-filesystem-dev libboost-thread-dev libtinyxml-dev libace-dev libedit-dev libgsl0-dev libopencv-dev libode-dev liblua5.1-dev lua5.1 git swig qtbase5-dev qtdeclarative5-dev qtmultimedia5-dev qml-module-qtquick2 qml-module-qtquick-window2 qml-module-qtmultimedia qml-module-qtquick-dialogs qml-module-qtquick-controls qml-module-qt-labs-folderlistmodel qml-module-qt-labs-settings libsdl1.2-dev libxml2-dev libv4l-dev libjpeg-dev
 
 # Python
 apt-get install -y python3-dev python3-numpy

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -155,7 +155,7 @@ jobs:
         brew update
         brew upgrade
         # Core dependencies 
-        brew install ace boost cmake eigen gsl ipopt jpeg libedit opencv pkg-config qt5 sqlite swig tinyxml
+        brew install ace boost cmake eigen gsl ipopt jpeg-turbo libedit opencv pkg-config qt5 sqlite swig tinyxml
         # ROBOTOLOGY_ENABLE_DYNAMICS dependencies 
         brew install libmatio
         # ROBOTOLOGY_USES_GAZEBO dependencies 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -155,7 +155,7 @@ jobs:
         brew update
         brew upgrade
         # Core dependencies 
-        brew install ace boost cmake eigen gsl ipopt jpeg-turbo libedit opencv pkg-config qt5 sqlite swig tinyxml
+        brew install ace boost cmake eigen gsl ipopt jpeg libedit opencv pkg-config qt5 sqlite swig tinyxml
         # ROBOTOLOGY_ENABLE_DYNAMICS dependencies 
         brew install libmatio
         # ROBOTOLOGY_USES_GAZEBO dependencies 

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ Complete documentation on how to use a YCM-based superbuild is available in the 
 ### System Dependencies
 On Debian based systems (as Ubuntu) you can install the C++ toolchain, Git, CMake and Eigen (and other dependencies necessary for the software include in `robotology-superbuild`) using `apt-get`:
 ```
-sudo apt-get install libeigen3-dev build-essential cmake cmake-curses-gui coinor-libipopt-dev freeglut3-dev libboost-system-dev libboost-filesystem-dev libboost-thread-dev libtinyxml-dev libedit-dev libace-dev libgsl0-dev libopencv-dev libode-dev liblua5.1-dev lua5.1 git swig qtbase5-dev qtdeclarative5-dev qtmultimedia5-dev qml-module-qtquick2 qml-module-qtquick-window2 qml-module-qtmultimedia qml-module-qtquick-dialogs qml-module-qtquick-controls qml-module-qt-labs-folderlistmodel qml-module-qt-labs-settings libsdl1.2-dev libxml2-dev libv4l-dev
+sudo apt-get install libeigen3-dev build-essential cmake cmake-curses-gui coinor-libipopt-dev freeglut3-dev libboost-system-dev libboost-filesystem-dev libboost-thread-dev libtinyxml-dev libedit-dev libace-dev libgsl0-dev libopencv-dev libode-dev liblua5.1-dev lua5.1 git swig qtbase5-dev qtdeclarative5-dev qtmultimedia5-dev qml-module-qtquick2 qml-module-qtquick-window2 qml-module-qtmultimedia qml-module-qtquick-dialogs qml-module-qtquick-controls qml-module-qt-labs-folderlistmodel qml-module-qt-labs-settings libsdl1.2-dev libxml2-dev libv4l-dev libjpeg-dev
 ```
 
 For what regards CMake, the robotology-superbuild requires CMake 3.12 . If you are using a recent Debian-based system such as Debian 10 or Ubuntu 20.04, the default CMake is recent enough and you do not need to do further steps.

--- a/cmake/BuildYARP.cmake
+++ b/cmake/BuildYARP.cmake
@@ -59,6 +59,7 @@ ycm_ep_helper(YARP TYPE GIT
                               -DENABLE_yarpcar_xmlrpc:BOOL=ON
                               -DENABLE_yarpcar_priority:BOOL=ON
                               -DENABLE_yarpcar_bayer:BOOL=ON
+                              -DENABLE_yarpcar_mjpeg:BOOL=ON
                               -DENABLE_yarpidl_thrift:BOOL=ON
                               -DYARP_COMPILE_DEVICE_PLUGINS:BOOL=ON
                               -DENABLE_yarpcar_human:BOOL=ON

--- a/cmake/BuildYARP.cmake
+++ b/cmake/BuildYARP.cmake
@@ -37,8 +37,12 @@ else()
   set(ENABLE_USBCAMERA ${ROBOTOLOGY_ENABLE_ICUB_HEAD})
 endif()
 
-
-
+# Workaround for https://github.com/robotology/yarp/issues/2353
+if(APPLE)
+  set(ENABLE_yarpcar_mjpeg OFF)
+else()
+  set(ENABLE_yarpcar_mjpeg ON)
+endif()
 
 ycm_ep_helper(YARP TYPE GIT
                    STYLE GITHUB
@@ -59,7 +63,10 @@ ycm_ep_helper(YARP TYPE GIT
                               -DENABLE_yarpcar_xmlrpc:BOOL=ON
                               -DENABLE_yarpcar_priority:BOOL=ON
                               -DENABLE_yarpcar_bayer:BOOL=ON
-                              -DENABLE_yarpcar_mjpeg:BOOL=ON
+                              -DENABLE_yarpcar_mjpeg:BOOL=${ENABLE_yarpcar_mjpeg}
+                              -DENABLE_yarpcar_portmonitor:BOOL=ON
+                              -DENABLE_yarpcar_depthimage:BOOL=ON
+                              -DENABLE_yarpcar_depthimage2:BOOL=ON
                               -DENABLE_yarpidl_thrift:BOOL=ON
                               -DYARP_COMPILE_DEVICE_PLUGINS:BOOL=ON
                               -DENABLE_yarpcar_human:BOOL=ON

--- a/doc/vcpkg-dependencies.md
+++ b/doc/vcpkg-dependencies.md
@@ -3,7 +3,7 @@
 If you prefer to install dependencies of the `robotology-superbuild` on your own existing [`vcpkg`](https://github.com/microsoft/vcpkg) installation,
 the ports that are required are the following: 
 ~~~
-./vcpkg.exe install --triplet x64-windows ace asio boost-asio boost-any boost-bind boost-date-time boost-filesystem boost-format boost-interprocess boost-iostreams boost-program-options boost-property-tree boost-regex boost-smart-ptr boost-system boost-thread boost-variant boost-uuid freeglut gsl eigen3 glew glfw3 ode openssl libxml2 eigen3 opencv portaudio matio sdl1 sdl2 qt5-base[latest] qt5-declarative qt5-multimedia qt5-quickcontrols qt5-quickcontrols2 sqlite3[core,tool]
+./vcpkg.exe install --triplet x64-windows ace asio boost-asio boost-any boost-bind boost-date-time boost-filesystem boost-format boost-interprocess boost-iostreams boost-program-options boost-property-tree boost-regex boost-smart-ptr boost-system boost-thread boost-variant boost-uuid freeglut gsl eigen3 glew glfw3 ode openssl libxml2 libjpeg-turbo eigen3 opencv portaudio matio sdl1 sdl2 qt5-base[latest] qt5-declarative qt5-multimedia qt5-quickcontrols qt5-quickcontrols2 sqlite3[core,tool]
 ~~~
 
 Furthermore, we also require the custom `ipopt-binary` and `esdcan-binary` ports that are available in the [`robotology/robotology-vcpkg-binary-ports`](https://github.com/robotology/robotology-vcpkg-binary-ports) repo.


### PR DESCRIPTION
The `mjpeg` carrier is used in the Oculus driver, and in general it is a small component with limited dependencies (just libjpeg that is already installed in almost all systems), so I think it make sense to enable it.

Similarly, also the `portmonitor`, `depthimage` and `depthimage2` carriers are also minimal components that is convenient to enable to simplify the use of depth image related functionalities. 