### PR TITLE
Temporary pin YARP stable and unstable version to a valid commit

### DIFF
--- a/cmake/ProjectsTagsStable.cmake
+++ b/cmake/ProjectsTagsStable.cmake
@@ -9,5 +9,6 @@ set_tag(osqp_TAG v0.6.0)
 
 # Robotology projects
 set_tag(YCM_TAG ycm-0.11)
-set_tag(YARP_TAG yarp-3.4)
+# set_tag(YARP_TAG yarp-3.4)
+set_tag(YARP_TAG 0328577b5f102da2875517898d8a6439ac9374d2)
 set_tag(yarp-matlab-bindings_TAG yarp-3.4)

--- a/cmake/ProjectsTagsUnstable.cmake
+++ b/cmake/ProjectsTagsUnstable.cmake
@@ -8,7 +8,8 @@ endmacro()
 set_tag(osqp_TAG v0.6.0)
 
 # Robotology projects
-set_tag(YARP_TAG master)
+# set_tag(YARP_TAG master)
+set_tag(YARP_TAG 0328577b5f102da2875517898d8a6439ac9374d2)
 set_tag(ICUB_TAG devel)
 set_tag(RobotTestingFramework_TAG devel)
 set_tag(blockTest_TAG devel)


### PR DESCRIPTION
Due to https://github.com/robotology/robotology-superbuild/issues/469, the robotology-superbuild on both Stable and Unstable branches is broken on Linux and macOs . As a temporary solution until https://github.com/robotology/yarp/pull/2356 is merged, let's pin YARP to some working commits. 