### PR TITLE
[WIP] Experimental bootstrap using FetchContent

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -116,6 +116,7 @@ else()
 endif()
 
 # Bootstrap YCM
+set(YCM_BOOTSTRAP_VERBOSE ON)
 set(YCM_FOLDER robotology)
 set(YCM_COMPONENT core)
 set(YCM_MINIMUM_VERSION 0.11.1)

--- a/cmake/YCMBootstrap.cmake
+++ b/cmake/YCMBootstrap.cmake
@@ -137,7 +137,7 @@ if(NOT ycm_POPULATED)
 
   # FIXME Where is YCM_EP_INSTALL_DIR defined?
   if (DEFINED YCM_EP_INSTALL_DIR)
-    set(YCM_INSTALL_DIR ${YCM_INSTALL_DIR})
+    set(YCM_INSTALL_DIR ${YCM_EP_INSTALL_DIR})
   else()
     set(YCM_INSTALL_DIR "${CMAKE_BINARY_DIR}/install")
   endif()

--- a/cmake/YCMBootstrap.cmake
+++ b/cmake/YCMBootstrap.cmake
@@ -135,7 +135,12 @@ if(NOT ycm_POPULATED)
     set(_quiet_args )
   endif()
 
-  set(YCM_INSTALL_DIR "${CMAKE_BINARY_DIR}/install")
+  # FIXME Where is YCM_EP_INSTALL_DIR defined?
+  if (DEFINED YCM_EP_INSTALL_DIR)
+    set(YCM_INSTALL_DIR ${YCM_INSTALL_DIR})
+  else()
+    set(YCM_INSTALL_DIR "${CMAKE_BINARY_DIR}/install")
+  endif()
 
   execute_process(
     COMMAND ${CMAKE_COMMAND} ${build_generator} -S${ycm_SOURCE_DIR} -B${ycm_BINARY_DIR} -DCMAKE_INSTALL_PREFIX:PATH=${YCM_INSTALL_DIR}


### PR DESCRIPTION
This is an experiment where I'm using a customized version of the `YCMBootstrap.cmake` module, that removes a lot of madness, `include_url`, etc., and instead it uses `FetchContent` to download YCM.

These are a few open points to discuss and/or to fix:

- [ ] YCM is no longer handled by `ExternalProject` like all the other projects.
- [ ] Where is `USE_SYSTEM_YCM` defined?
- [ ] We might also want to consider that using FetchContent we could avoid having the YCMBootstrap.cmake file in the repository.
- [ ] `YCM_TAG` must now be defined somewhere.
- [ ] The check on the YCMBootstrap version is no longer performed
- [ ] Where is `YCM_EP_INSTALL_DIR` defined?

@traversaro what do you think?