### PR TITLE
BuildICUB: Remove options related to GTK2 GUIs

### DIFF
--- a/cmake/BuildICUB.cmake
+++ b/cmake/BuildICUB.cmake
@@ -44,9 +44,7 @@ ycm_ep_helper(ICUB TYPE GIT
                    COMPONENT iCub
                    FOLDER robotology
                    CMAKE_ARGS -DICUB_INSTALL_WITH_RPATH:BOOL=ON
-                   # Workaround for https://github.com/robotology/icub-main/issues/606
-                   CMAKE_CACHE_ARGS -DICUB_USE_GTK2:BOOL=OFF
-                                    -DENABLE_icubmod_cartesiancontrollerserver:BOOL=ON
+                   CMAKE_CACHE_ARGS -DENABLE_icubmod_cartesiancontrollerserver:BOOL=ON
                                     -DENABLE_icubmod_cartesiancontrollerclient:BOOL=ON
                                     -DENABLE_icubmod_gazecontrollerclient:BOOL=ON
                                     -DENABLE_icubmod_serial:BOOL=${ROBOTOLOGY_ENABLE_ICUB_HEAD}


### PR DESCRIPTION
The option was removed in https://github.com/robotology/icub-main/pull/659 .