### PR TITLE
CI: Add conda-forge based builds on Linux

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,8 @@ jobs:
       matrix:
         build_type: [Release]
         # Windows is disabled due to the missing ipopt package
-        os: [ubuntu-latest, macOS-latest]
+        # macOS is disabled due to the missing freeglut package
+        os: [ubuntu-latest]
         cmake_generator: 
           - "Ninja"
         project_tags:
@@ -58,7 +59,7 @@ jobs:
       run: |
         # Additional dependencies only useful on Linux
         # See https://github.com/robotology/robotology-superbuild/issues/477
-        conda install -c conda-forge expat-cos6-x86_64 libselinux-cos6-x86_64 libxau-cos6-x86_64 libxdamage-cos6-x86_64 libxfixes-cos6-x86_64 libxxf86vm-cos6-x86_64 mesalib mesa-libgl-cos6-x86_64
+        conda install -c conda-forge expat-cos6-x86_64 libselinux-cos6-x86_64 libxau-cos6-x86_64 libxcb-cos6-x86_64 libxdamage-cos6-x86_64 libxext-cos6-x86_64 libxfixes-cos6-x86_64 libxxf86vm-cos6-x86_64 mesalib mesa-libgl-cos6-x86_64
 
     - name: Configure [Conda]
       # ROBOTOLOGY_ENABLE_ICUB_HEAD is disabled due to https://github.com/robotology/icub-main/issues/685

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,13 +62,14 @@ jobs:
 
     - name: Configure [Conda]
       # ROBOTOLOGY_ENABLE_ICUB_HEAD is disabled due to https://github.com/robotology/icub-main/issues/685
-      shell: bash
+      shell: bash -l {0}
       run: |
         mkdir -p build
         cd build
         cmake -G"${{ matrix.cmake_generator }}" -DROBOTOLOGY_USES_GAZEBO:BOOL=ON -DROBOTOLOGY_USES_OCTAVE:BOOL=OFF -DROBOTOLOGY_USES_PYTHON:BOOL=OFF -DROBOTOLOGY_ENABLE_ROBOT_TESTING:BOOL=ON  -DROBOTOLOGY_ENABLE_DYNAMICS:BOOL=ON -DROBOTOLOGY_ENABLE_HUMAN_DYNAMICS:BOOL=ON -DROBOTOLOGY_ENABLE_ICUB_HEAD:BOOL=OFF -DROBOTOLOGY_ENABLE_ICUB_BASIC_DEMOS:BOOL=ON -DROBOTOLOGY_ENABLE_TELEOPERATION:BOOL=ON -DNON_INTERACTIVE_BUILD:BOOL=TRUE -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}  ${{ matrix.project_tags_cmake_options }}  ..
 
     - name: Build  [Conda]
+      shell: bash -l {0}
       run: |
         cd build
         cmake --build . --config ${{ matrix.build_type }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,61 @@ on:
 
 
 jobs:
+  conda-build:    
+    name: '[conda:Tags:${{ matrix.project_tags }}@${{ matrix.os }}@${{ matrix.build_type }}]'
+    # Windows is disabled due to the missing ipopt package
+    runs-on: [ubuntu-latest, macos-latest]
+    strategy:
+      fail-fast: false
+      matrix:
+        build_type: [Release]
+        cmake_generator: 
+          - "Ninja"
+        project_tags:
+          - Default
+          - Unstable
+        include:
+          - project_tags: Default
+            project_tags_cmake_options: ""
+          - project_tags: Unstable
+            project_tags_cmake_options: "-DROBOTOLOGY_PROJECT_TAGS=Unstable"
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - uses: conda-incubator/setup-miniconda@v1
+        with:
+          auto-update-conda: true
+
+    - name: Dependencies [Conda]
+      shell: bash -l {0}
+      run: |
+        # Compilation related dependencies 
+        conda install -c conda-forge cmake compilers ninja pkg-config
+        # Actual dependencies
+        conda install -c conda-forge ace asio boost eigen freeglut gazebo glew glfw gsl ipopt libjpeg-turbo libmatio libode libxml2 opencv pkg-config portaudio qt sdl sdl2 sqlite tinyxml
+
+    # Additional dependencies useful only on Linux
+    - name: Dependencies [Conda/Linux]
+      shell: bash -l {0}
+      run: |
+        # Additional dependencies only useful on Linux
+        # See https://github.com/robotology/robotology-superbuild/issues/477
+        conda install -c conda-forge expat-cos6-x86_64 libselinux-cos6-x86_64 libxau-cos6-x86_64 libxdamage-cos6-x86_64 libxfixes-cos6-x86_64 libxxf86vm-cos6-x86_64 mesalib
+
+    - name: Configure [Conda]
+      # ROBOTOLOGY_ENABLE_ICUB_HEAD is disabled due to https://github.com/robotology/icub-main/issues/685
+      shell: bash
+      run: |
+        mkdir -p build
+        cd build
+        cmake -G"${{ matrix.cmake_generator }}" -DROBOTOLOGY_USES_GAZEBO:BOOL=ON -DROBOTOLOGY_USES_OCTAVE:BOOL=OFF -DROBOTOLOGY_USES_PYTHON:BOOL=OFF -DROBOTOLOGY_ENABLE_ROBOT_TESTING:BOOL=ON  -DROBOTOLOGY_ENABLE_DYNAMICS:BOOL=ON -DROBOTOLOGY_ENABLE_HUMAN_DYNAMICS:BOOL=ON -DROBOTOLOGY_ENABLE_ICUB_HEAD:BOOL=OFF -DROBOTOLOGY_ENABLE_ICUB_BASIC_DEMOS:BOOL=ON -DROBOTOLOGY_ENABLE_TELEOPERATION:BOOL=ON -DNON_INTERACTIVE_BUILD:BOOL=TRUE -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}  ${{ matrix.project_tags_cmake_options }}  ..
+
+    - name: Build  [Conda]
+      run: |
+        cd build
+        cmake --build . --config ${{ matrix.build_type }}
+
   docker-build:    
     name: '[docker:Tags:${{ matrix.project_tags }}@${{ matrix.docker_image }}@${{ matrix.build_type }}]'
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,12 +19,13 @@ on:
 jobs:
   conda-build:    
     name: '[conda:Tags:${{ matrix.project_tags }}@${{ matrix.os }}@${{ matrix.build_type }}]'
-    # Windows is disabled due to the missing ipopt package
-    runs-on: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
         build_type: [Release]
+        # Windows is disabled due to the missing ipopt package
+        os: [ubuntu-latest, macOS-latest]
         cmake_generator: 
           - "Ninja"
         project_tags:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,7 @@ jobs:
       run: |
         # Additional dependencies only useful on Linux
         # See https://github.com/robotology/robotology-superbuild/issues/477
-        conda install -c conda-forge expat-cos6-x86_64 libselinux-cos6-x86_64 libxau-cos6-x86_64 libxdamage-cos6-x86_64 libxfixes-cos6-x86_64 libxxf86vm-cos6-x86_64 mesalib
+        conda install -c conda-forge expat-cos6-x86_64 libselinux-cos6-x86_64 libxau-cos6-x86_64 libxdamage-cos6-x86_64 libxfixes-cos6-x86_64 libxxf86vm-cos6-x86_64 mesalib mesa-libgl-cos6-x86_64
 
     - name: Configure [Conda]
       # ROBOTOLOGY_ENABLE_ICUB_HEAD is disabled due to https://github.com/robotology/icub-main/issues/685

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,8 +40,8 @@ jobs:
     - uses: actions/checkout@v2
 
     - uses: conda-incubator/setup-miniconda@v1
-        with:
-          auto-update-conda: true
+      with:
+        auto-update-conda: true
 
     - name: Dependencies [Conda]
       shell: bash -l {0}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
       shell: bash -l {0}
       run: |
         # Compilation related dependencies 
-        conda install -c conda-forge cmake compilers ninja pkg-config
+        conda install -c conda-forge cmake compilers make ninja pkg-config
         # Actual dependencies
         conda install -c conda-forge ace asio boost eigen freeglut gazebo glew glfw gsl ipopt libjpeg-turbo libmatio libode libxml2 opencv pkg-config portaudio qt sdl sdl2 sqlite tinyxml
 


### PR DESCRIPTION
See https://github.com/robotology/robotology-superbuild/issues/477 for more details. For now, only Linux is added, because some dependencies are still missing on macOS (freeglut) and Windows (ipopt).
 
In a nutshell conda is a package manager (originally for Python, but now quite language agnostic) that works on Linux, macOS and Windows. `conda-forge`  is a channel for the conda package manager that provides many dependency, in particular all the one that are required by the robotology-superbuild .

The use of conda is complementary to the compilation modes that we already use and are not substituted by conda, but its advantages are: 
* Updated dependencies: conda-forge tipically has relatively recent version of the dependencies, so if you want to use a recent vtk or pcl on an old distro such as Ubuntu 16.04, you can. This permits us to support older distributions even when the packages that install via apt are relatively old. 
* No need for root permissions: all the software installed by conda is installed and used in a user directory, so even if you are on a system in which you do not have root access (such as a shared workstation) you can still install all you required dependencies
* Use of binaries: conda distributes its packages as binaries, so even to download heavy dependencies such as OpenCV, PCL, Qt and Gazebo on Windows it just takes a few minutes, as opposed to hours necessary to compile them when using vcpkg. This is also useful when producing Docker images that require a recent version of PCL or VTK: installing them via conda takes a few seconds, and this would cut the time necessary to regenerate Docker images. 
* Reproducible enviroments: conda has built in support for installing exactly the same version of the packages you were using in the past, up to the patch version. This is quite important for reproducibility in scientific research. 
* On macOS and Windows, conda is also the package manager for which it is more easily possible to obtain working binaries of ROS1 and in the future of ROS2, thanks to the work of the [RoboStack project](https://github.com/RoboStack)

This PR does not add a build on Windows as ipopt binaries are still missing on that platform (see https://github.com/conda-forge/ipopt-feedstock/issues/1), and on macOS as freeglut binaries are missing (https://github.com/conda-forge/freeglut-feedstock/pull/24). The first practical use of this conda-based CI builds (once mac is added) is to quickly understand if any regression in the regular homebrew-based macOS CI builds is due to software regressions in the robotology-superbuild software, or in some enviroment failures (that is what happens most of the time).