### PR TITLE
Remove workaround for brew install with taps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -221,8 +221,6 @@ jobs:
         # ROBOTOLOGY_ENABLE_DYNAMICS dependencies 
         brew install libmatio
         # ROBOTOLOGY_USES_GAZEBO dependencies
-        # Workaround for https://github.com/robotology/robotology-superbuild/issues/479
-        brew tap osrf/simulation
         brew install osrf/simulation/gazebo11
         # CI-specific dependencies 
         brew install ninja


### PR DESCRIPTION
Remove workaround for https://github.com/robotology/robotology-superbuild/issues/479 . To be merged after https://github.com/robotology/robotology-superbuild/pull/493 .