### PR TITLE
Update versions in 2020.08.patch-01

### DIFF
--- a/releases/2020.08.patch-01.yaml
+++ b/releases/2020.08.patch-01.yaml
@@ -10,7 +10,7 @@ repositories:
   ycm:
     type: git
     url: https://github.com/robotology/ycm.git
-    version: v0.11.3
+    version: v0.11.4
   YARP:
     type: git
     url: https://github.com/robotology/yarp.git
@@ -30,7 +30,7 @@ repositories:
   GazeboYARPPlugins:
     type: git
     url: https://github.com/robotology/gazebo-yarp-plugins.git
-    version: v3.5.0
+    version: v3.5.1
   icub-gazebo:
     type: git
     url: https://github.com/robotology/icub-gazebo.git
@@ -38,11 +38,11 @@ repositories:
   icub-models:
     type: git
     url: https://github.com/robotology/icub-models.git
-    version: v1.17.0
+    version: v1.17.1
   yarp-matlab-bindings:
     type: git
     url: https://github.com/robotology/yarp-matlab-bindings.git
-    version: master
+    version: v3.4.0
   RobotTestingFramework:
     type: git
     url: https://github.com/robotology/robot-testing-framework.git


### PR DESCRIPTION
See discussion in https://github.com/robotology/robotology-superbuild/issues/485 . Furthermore, I also set yarp-matlab-bindings to v3.4.0 that for an error was still pointing to `master` . 