### PR TITLE
conda-forge CI: Use mamba instead of conda

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,10 +48,12 @@ jobs:
     - name: Dependencies [Conda]
       shell: bash -l {0}
       run: |
+        # Install mamba (https://github.com/mamba-org/mamba) as first step 
+        conda install -c conda-forge mamba
         # Compilation related dependencies 
-        conda install -c conda-forge cmake compilers make ninja pkg-config
+        mamba install -c conda-forge cmake compilers make ninja pkg-config
         # Actual dependencies
-        conda install -c conda-forge ace asio boost eigen freeglut gazebo glew glfw gsl ipopt libjpeg-turbo libmatio libode libxml2 opencv pkg-config portaudio qt sdl sdl2 sqlite tinyxml
+        mamba install -c conda-forge ace asio boost eigen freeglut gazebo glew glfw gsl ipopt libjpeg-turbo libmatio libode libxml2 opencv pkg-config portaudio qt sdl sdl2 sqlite tinyxml
 
     # Additional dependencies useful only on Linux
     - name: Dependencies [Conda/Linux]
@@ -59,7 +61,7 @@ jobs:
       run: |
         # Additional dependencies only useful on Linux
         # See https://github.com/robotology/robotology-superbuild/issues/477
-        conda install -c conda-forge expat-cos6-x86_64 libselinux-cos6-x86_64 libxau-cos6-x86_64 libxcb-cos6-x86_64 libxdamage-cos6-x86_64 libxext-cos6-x86_64 libxfixes-cos6-x86_64 libxxf86vm-cos6-x86_64 mesalib mesa-libgl-cos6-x86_64
+        mamba install -c conda-forge expat-cos6-x86_64 libselinux-cos6-x86_64 libxau-cos6-x86_64 libxcb-cos6-x86_64 libxdamage-cos6-x86_64 libxext-cos6-x86_64 libxfixes-cos6-x86_64 libxxf86vm-cos6-x86_64 mesalib mesa-libgl-cos6-x86_64
 
     - name: Configure [Conda]
       # ROBOTOLOGY_ENABLE_ICUB_HEAD is disabled due to https://github.com/robotology/icub-main/issues/685


### PR DESCRIPTION
This is a workaround for https://github.com/robotology/robotology-superbuild/issues/495, but as [mamba](https://github.com/mamba-org/mamba) is faster and with less dependencies, it is also a step forward to what we would like to offer to the users in the future. 