### PR TITLE
GitHub Actions: Bump used vcpkg-robotology archive to v0.5.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -230,11 +230,11 @@ jobs:
       if: matrix.os == 'windows-2019'
       run: |
         # To avoid spending a huge time compiling vcpkg dependencies, we download an archive  that comes precompiled with all the ports that we need 
-        choco install -y unzip
+        choco install -y wget unzip
         # To avoid problems with non-relocatable packages, we unzip the archive exactly in the same directory
         # that has been used to create the pre-compiled archive
         cd C:/
-        curl https://github.com/robotology/robotology-superbuild-dependencies-vcpkg/releases/download/v0.5.0/vcpkg-robotology-with-gazebo.zip -o vcpkg-robotology-with-gazebo.zip
+        wget https://github.com/robotology/robotology-superbuild-dependencies-vcpkg/releases/download/v0.5.0/vcpkg-robotology-with-gazebo.zip
         unzip vcpkg-robotology-with-gazebo.zip -d C:/
         rm vcpkg-robotology-with-gazebo.zip
         

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -230,11 +230,11 @@ jobs:
       if: matrix.os == 'windows-2019'
       run: |
         # To avoid spending a huge time compiling vcpkg dependencies, we download an archive  that comes precompiled with all the ports that we need 
-        choco install -y wget unzip
+        choco install -y unzip
         # To avoid problems with non-relocatable packages, we unzip the archive exactly in the same directory
         # that has been used to create the pre-compiled archive
         cd C:/
-        wget https://github.com/robotology/robotology-superbuild-dependencies-vcpkg/releases/download/v0.3.0/vcpkg-robotology-with-gazebo.zip
+        curl https://github.com/robotology/robotology-superbuild-dependencies-vcpkg/releases/download/v0.5.0/vcpkg-robotology-with-gazebo.zip -o vcpkg-robotology-with-gazebo.zip
         unzip vcpkg-robotology-with-gazebo.zip -d C:/
         rm vcpkg-robotology-with-gazebo.zip
         


### PR DESCRIPTION
~The v0.5.0 is still a prerelease, if the compilation with these dependencies fails fixes will be deployed. Once the compilation with the new archive is working, the v0.5.0 release of robotology-superbuild-dependencies-vcpkg will be made official.~

The release is working fine, so it is now an official release: https://github.com/robotology/robotology-superbuild-dependencies-vcpkg/releases/tag/v0.5.0 .

> ~Furthermore, switch from using wget (that needs to be manually installed via `choco`) to using curl (that is already installed on Windows, see https://docs.microsoft.com/en-us/virtualization/community/team-blog/2017/20171219-tar-and-curl-come-to-windows).~

Obviously, trying to change two things at the same time always bite you back. I am reverting the wget/curl change for now.
