### PR TITLE
Add portaudio dependency and enable audio-related devices in YARP

### DIFF
--- a/.ci/install_debian.sh
+++ b/.ci/install_debian.sh
@@ -10,7 +10,7 @@ export DEBIAN_FRONTEND=noninteractive
 apt-get install -y clang valgrind ccache ninja-build
 
 # Core dependencies
-apt-get install -y build-essential cmake cmake-curses-gui coinor-libipopt-dev freeglut3-dev git libace-dev libboost-filesystem-dev libboost-system-dev libboost-thread-dev libdc1394-22-dev libedit-dev libeigen3-dev libgsl0-dev libjpeg-dev liblua5.1-dev libode-dev libopencv-dev libsdl1.2-dev libtinyxml-dev libv4l-dev libxml2-dev lua5.1 qml-module-qt-labs-folderlistmodel qml-module-qt-labs-settings qml-module-qtmultimedia qml-module-qtquick-controls qml-module-qtquick-dialogs qml-module-qtquick-window2 qml-module-qtquick2 qtbase5-dev qtdeclarative5-dev qtmultimedia5-dev swig
+apt-get install -y build-essential cmake cmake-curses-gui coinor-libipopt-dev freeglut3-dev git libace-dev libboost-filesystem-dev libboost-system-dev libboost-thread-dev libdc1394-22-dev libedit-dev libeigen3-dev libgsl0-dev libjpeg-dev liblua5.1-dev libode-dev libopencv-dev libsdl1.2-dev libtinyxml-dev libv4l-dev libxml2-dev lua5.1 portaudio19-dev qml-module-qt-labs-folderlistmodel qml-module-qt-labs-settings qml-module-qtmultimedia qml-module-qtquick-controls qml-module-qtquick-dialogs qml-module-qtquick-window2 qml-module-qtquick2 qtbase5-dev qtdeclarative5-dev qtmultimedia5-dev swig
 
 # Python
 apt-get install -y python3-dev python3-numpy

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -218,7 +218,7 @@ jobs:
         brew update
         brew upgrade
         # Core dependencies 
-        brew install ace boost cmake eigen gsl ipopt jpeg libedit opencv pkg-config qt5 sqlite swig tinyxml
+        brew install ace boost cmake eigen gsl ipopt jpeg libedit opencv pkg-config portaudio qt5 sqlite swig tinyxml
         # ROBOTOLOGY_ENABLE_DYNAMICS dependencies 
         brew install libmatio
         # ROBOTOLOGY_USES_GAZEBO dependencies

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ Complete documentation on how to use a YCM-based superbuild is available in the 
 ### System Dependencies
 On Debian based systems (as Ubuntu) you can install the C++ toolchain, Git, CMake and Eigen (and other dependencies necessary for the software include in `robotology-superbuild`) using `apt-get`:
 ```
-sudo apt-get install build-essential cmake cmake-curses-gui coinor-libipopt-dev freeglut3-dev git libace-dev libboost-filesystem-dev libboost-system-dev libboost-thread-dev libdc1394-22-dev libedit-dev libeigen3-dev libgsl0-dev libjpeg-dev liblua5.1-dev libode-dev libopencv-dev libsdl1.2-dev libtinyxml-dev libv4l-dev libxml2-dev lua5.1 qml-module-qt-labs-folderlistmodel qml-module-qt-labs-settings qml-module-qtmultimedia qml-module-qtquick-controls qml-module-qtquick-dialogs qml-module-qtquick-window2 qml-module-qtquick2 qtbase5-dev qtdeclarative5-dev qtmultimedia5-dev swig
+sudo apt-get install build-essential cmake cmake-curses-gui coinor-libipopt-dev freeglut3-dev git libace-dev libboost-filesystem-dev libboost-system-dev libboost-thread-dev libdc1394-22-dev libedit-dev libeigen3-dev libgsl0-dev libjpeg-dev liblua5.1-dev libode-dev libopencv-dev libsdl1.2-dev libtinyxml-dev libv4l-dev libxml2-dev lua5.1 portaudio19-dev qml-module-qt-labs-folderlistmodel qml-module-qt-labs-settings qml-module-qtmultimedia qml-module-qtquick-controls qml-module-qtquick-dialogs qml-module-qtquick-window2 qml-module-qtquick2 qtbase5-dev qtdeclarative5-dev qtmultimedia5-dev swig
 ```
 
 For what regards CMake, the robotology-superbuild requires CMake 3.16 . If you are using a recent Debian-based system such as Ubuntu 20.04, the default CMake is recent enough and you do not need to do further steps.
@@ -167,7 +167,7 @@ If for any reason you do not want to use the provided `setup.sh` script and you 
 ### System Dependencies
 To install the system dependencies, it is possible to use [Homebrew](http://brew.sh/):
 ```
-brew install ace boost cmake eigen gsl ipopt jpeg libedit opencv pkg-config qt5 sqlite swig tinyxml
+brew install ace boost cmake eigen gsl ipopt jpeg libedit opencv pkg-config portaudio qt5 sqlite swig tinyxml
 ```
 
 Since Qt5 is not symlinked in `/usr/local` by default in the homebrew formula, `Qt5_DIR` needs to be properly set to make sure that CMake-based projects are able to find Qt5.

--- a/cmake/BuildYARP.cmake
+++ b/cmake/BuildYARP.cmake
@@ -75,6 +75,11 @@ ycm_ep_helper(YARP TYPE GIT
                               -DENABLE_yarpmod_imuBosch_BNO055:BOOL=${ROBOTOLOGY_ENABLE_ICUB_HEAD}
                               -DENABLE_yarpmod_SDLJoypad:BOOL=ON
                               -DENABLE_yarpmod_serialport:BOOL=${ROBOTOLOGY_ENABLE_ICUB_HEAD}
+                              -DENABLE_yarpmod_AudioPlayerWrapper:BOOL=ON
+                              -DENABLE_yarpmod_AudioRecorderWrapper:BOOL=ON
+                              -DENABLE_yarpmod_portaudio:BOOL=ON
+                              -DENABLE_yarpmod_portaudioPlayer:BOOL=ON
+                              -DENABLE_yarpmod_portaudioRecorder:BOOL=ON
                               -DYARP_COMPILE_EXPERIMENTAL_WRAPPERS:BOOL=ON
                               -DYARP_COMPILE_RobotTestingFramework_ADDONS:BOOL=${ROBOTOLOGY_ENABLE_ROBOT_TESTING}
                               -DYARP_COMPILE_BINDINGS:BOOL=${YARP_COMPILE_BINDINGS}

--- a/cmake/ProjectsTagsStable.cmake
+++ b/cmake/ProjectsTagsStable.cmake
@@ -8,6 +8,6 @@ endmacro()
 set_tag(osqp_TAG v0.6.0)
 
 # Robotology projects
-set_tag(YCM_TAG ycm-0.11)
+set_tag(YCM_TAG ycm-0.12)
 set_tag(YARP_TAG yarp-3.4)
 set_tag(yarp-matlab-bindings_TAG yarp-3.4)

--- a/releases/2020.11.yaml
+++ b/releases/2020.11.yaml
@@ -10,11 +10,11 @@ repositories:
   ycm:
     type: git
     url: https://github.com/robotology/ycm.git
-    version: e68db4421d1282db5b90428c517f8bd63b38cb56
+    version: c3242e8a2d6b50d7ba9642783820a426d2bffa84
   YARP:
     type: git
     url: https://github.com/robotology/yarp.git
-    version: v3.4.1
+    version: b26668b161832ddfebe3089f6b494549b6462fb1
   ICUB:
     type: git
     url: https://github.com/robotology/icub-main.git


### PR DESCRIPTION
This PR add the dependency on portaudio on Linux, macOS and Windows, and enable by default the compilation of the YARP devices related to audio. Fix https://github.com/robotology/robotology-superbuild/issues/284 .
