### PR TITLE
Add initial files for the 2020.11 release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,7 +142,7 @@ jobs:
       matrix:
         build_type: [Release]
         os: [ubuntu-latest, macOS-latest, windows-2019]
-        project_tags: [Default, Unstable, Release202005feat01, Release202008patch01]
+        project_tags: [Default, Unstable, Release202011]
         include:
           - os: ubuntu-latest
             build_type: Debug

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -160,10 +160,8 @@ jobs:
             project_tags_cmake_options: ""
           - project_tags: Unstable
             project_tags_cmake_options: "-DROBOTOLOGY_PROJECT_TAGS=Unstable"
-          - project_tags: Release202005feat01
-            project_tags_cmake_options: "-DROBOTOLOGY_PROJECT_TAGS=Custom -DROBOTOLOGY_PROJECT_TAGS_CUSTOM_FILE=${GITHUB_WORKSPACE}/releases/2020.05.feat-01.yaml"
-          - project_tags: Release202008patch01
-            project_tags_cmake_options: "-DROBOTOLOGY_PROJECT_TAGS=Custom -DROBOTOLOGY_PROJECT_TAGS_CUSTOM_FILE=${GITHUB_WORKSPACE}/releases/2020.08.patch-01.yaml"
+          - project_tags: Release202011
+            project_tags_cmake_options: "-DROBOTOLOGY_PROJECT_TAGS=Custom -DROBOTOLOGY_PROJECT_TAGS_CUSTOM_FILE=${GITHUB_WORKSPACE}/releases/2020.11.yaml"
     steps:
     - uses: actions/checkout@master
 

--- a/releases/2020.11.yaml
+++ b/releases/2020.11.yaml
@@ -1,0 +1,137 @@
+repositories:
+  qpOASES:
+    type: git
+    url: https://github.com/robotology-dependencies/qpOASES.git
+    version: v3.2.0.1
+  osqp:
+    type: git
+    url: https://github.com/oxfordcontrol/osqp.git
+    version: v0.6.0
+  ycm:
+    type: git
+    url: https://github.com/robotology/ycm.git
+    version: v0.11.4
+  YARP:
+    type: git
+    url: https://github.com/robotology/yarp.git
+    version: v3.4.1
+  ICUB:
+    type: git
+    url: https://github.com/robotology/icub-main.git
+    version: v1.17.0
+  ICUBcontrib:
+    type: git
+    url: https://github.com/robotology/icub-contrib-common.git
+    version: v1.17.0
+  robots-configuration:
+    type: git
+    url: https://github.com/robotology/robots-configuration.git
+    version: v1.17.0
+  GazeboYARPPlugins:
+    type: git
+    url: https://github.com/robotology/gazebo-yarp-plugins.git
+    version: v3.5.1
+  icub-gazebo:
+    type: git
+    url: https://github.com/robotology/icub-gazebo.git
+    version: v1.17.0
+  icub-models:
+    type: git
+    url: https://github.com/robotology/icub-models.git
+    version: v1.17.1
+  yarp-matlab-bindings:
+    type: git
+    url: https://github.com/robotology/yarp-matlab-bindings.git
+    version: v3.4.0
+  RobotTestingFramework:
+    type: git
+    url: https://github.com/robotology/robot-testing-framework.git
+    version: v2.0.1
+  icub-tests:
+    type: git
+    url: https://github.com/robotology/icub-tests.git
+    version: v1.17.0
+  blocktestcore:
+    type: git
+    url: https://github.com/robotology/blocktest.git
+    version: v2.3.0
+  blocktest-yarp-plugins:
+    type: git
+    url: https://github.com/robotology/blocktest-yarp-plugins.git
+    version: v1.1.0
+  iDynTree:
+    type: git
+    url: https://github.com/robotology/idyntree.git
+    version: v1.1.0
+  BlockFactory:
+    type: git
+    url: https://github.com/robotology/blockfactory.git
+    version: v0.8.1
+  WBToolbox:
+    type: git
+    url: https://github.com/robotology/wb-toolbox.git
+    version: v5.1
+  OsqpEigen:
+    type: git
+    url: https://github.com/robotology/osqp-eigen.git
+    version: v0.5.2
+  UnicyclePlanner:
+    type: git
+    url: https://github.com/robotology/unicycle-footstep-planner.git
+    version: v0.2.0
+  walking-controllers:
+    type: git
+    url: https://github.com/robotology/walking-controllers.git
+    version: v0.2.1
+  icub-gazebo-wholebody:
+    type: git
+    url: https://github.com/robotology/icub-gazebo-wholebody.git
+    version: v0.1.0
+  whole-body-controllers:
+    type: git
+    url: https://github.com/robotology/whole-body-controllers.git
+    version: v2.0
+  whole-body-estimators:
+    type: git
+    url: https://github.com/robotology/whole-body-estimators.git
+    version: v0.2.1
+  walking-teleoperation:
+    type: git
+    url: https://github.com/robotology/walking-teleoperation.git
+    version: v0.2.0
+  forcetorque-yarp-devices:
+    type: git
+    url: https://github.com/robotology/forcetorque-yarp-devices.git
+    version: v0.2.0
+  wearables:
+    type: git
+    url: https://github.com/robotology/wearables.git
+    version: v1.0.0
+  human-dynamics-estimation:
+    type: git
+    url: https://github.com/robotology/human-dynamics-estimation.git
+    version: v2.1.0
+  human-gazebo:
+    type: git
+    url: https://github.com/robotology/human-gazebo.git
+    version: v1.0
+  icub_firmware_shared:
+    type: git
+    url: https://github.com/robotology/icub-firmware-shared.git
+    version: v1.17.0
+  xsensmt-yarp-driver:
+    type: git
+    url: https://github.com/robotology/xsensmt-yarp-driver.git
+    version: v0.1.0
+  speech:
+    type: git
+    url: https://github.com/robotology/speech.git
+    version: v1.0.0
+  icub-basic-demos:
+    type: git
+    url: https://github.com/robotology/icub-basic-demos.git
+    version: v1.17.0
+  funny-things:
+    type: git
+    url: https://github.com/robotology/funny-things.git
+    version: v1.0.0

--- a/releases/2020.11.yaml
+++ b/releases/2020.11.yaml
@@ -10,7 +10,7 @@ repositories:
   ycm:
     type: git
     url: https://github.com/robotology/ycm.git
-    version: v0.11.4
+    version: e68db4421d1282db5b90428c517f8bd63b38cb56
   YARP:
     type: git
     url: https://github.com/robotology/yarp.git


### PR DESCRIPTION
First step for https://github.com/robotology/robotology-superbuild/issues/500 .
This PR adds a `2020.11.yaml` file, bump it the YCM version to an unreleased commit from the 0.12 branch. Furthermore, the 2020.11 release is added to the CI, while the older relase are removed.
The rationale is that old releases will be broken by the enabling of portaudio dependencies, see  https://github.com/robotology/robotology-superbuild/pull/499#issuecomment-712121774  . 
For use old releases, it is still possible to checkout the relative tag, as discussed in the release notes (see for example https://github.com/robotology/robotology-superbuild/releases/tag/v2020.08).