### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -378,7 +378,7 @@ make
 ~~~
 using make on Linux or macOS or
 ~~~
-cmake --build . --target UPDATE_ALL
+cmake --build . --target ALL_UPDATE
 cmake --build .
 ~~~
 using Visual Studio on Windows or


### PR DESCRIPTION
Fix wrong documentation in the robotology-superbuild update.

I've just tried on a windows and the right target seems to be `ALL_UPDATE`