### PR TITLE
GitHub Actions: Fix Homebrew problem

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -211,6 +211,8 @@ jobs:
         cmake --version
         brew cask install xquartz
         # Update homebrew 
+        # Workaround for https://github.com/actions/virtual-environments/issues/1811#issuecomment-718475660
+        brew unlink python@3.8
         brew update
         brew upgrade
         # Core dependencies 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -209,10 +209,6 @@ jobs:
       if: matrix.os == 'macOS-latest'
       run: |
         cmake --version
-        brew uninstall openssl@1.0.2t
-        brew uninstall python@2.7.17
-        brew untap local/openssl
-        brew untap local/python2
         brew cask install xquartz
         # Update homebrew 
         brew update


### PR DESCRIPTION
A lot of repo are failing on `brew upgrade` with error: 
~~~
==> Pouring python@3.9-3.9.0_1.catalina.bottle.tar.gz
Error: The `brew link` step did not complete successfully
Warning: These files were overwritten during `brew link` step:
The formula built, but is not symlinked into /usr/local
Could not symlink lib/pkgconfig/python3-embed.pc
Target /usr/local/lib/pkgconfig/python3-embed.pc
is a symlink belonging to python@3.8. You can unlink it:
  brew unlink python@3.8
~~~

Let's try to fix those. As first step, let's try to remove the workaround added for https://github.com/actions/virtual-environments/issues/1811 .