### PR TITLE
If ROBOTOLOGY_USES_OCULUS_SDK is enabled compile yarp-device-ovrheadset

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -222,6 +222,10 @@ if(ROBOTOLOGY_ENABLE_R1_ROBOT)
   find_or_build_package(cer)
 endif()
 
+if(ROBOTOLOGY_USES_OCULUS_SDK)
+  find_or_build_package(yarp-device-ovrheadset)
+endif()
+
 if(ROBOTOLOGY_USES_MATLAB)
   # The following line is to properly configure the matlab and simulink software installed by the superbuild
   configure_file(${CMAKE_CURRENT_SOURCE_DIR}/cmake/template/startup_robotology_superbuild.m.in ${CMAKE_BINARY_DIR}/startup_robotology_superbuild.m)

--- a/README.md
+++ b/README.md
@@ -661,8 +661,7 @@ To configure the Oculus SDK follow the steps for Oculus SDK mentioned [here](htt
 ## Cyberith
 Support for this dependency is enabled by the `ROBOTOLOGY_USES_CYBERITH_SDK` CMake option.
 
-**Warning: at the moment the Oculus SDK does not support macOS and Linux, so this option is only supported
-on Windows.**
+**Warning: at the moment the Cyberith SDK does not support macOS and Linux, so this option is only supported on Windows.**
 
 ### System Dependencies
 To check and install the Cyberith SDK, please follow the steps for Cyberith SDK mentioned in [here](https://github.com/robotology/walking-teleoperation/blob/master/docs/Dependencies.md).

--- a/cmake/Buildwalking-teleoperation.cmake
+++ b/cmake/Buildwalking-teleoperation.cmake
@@ -14,8 +14,6 @@ ycm_ep_helper(walking-teleoperation TYPE GIT
               TAG master
               COMPONENT teleoperation
               FOLDER robotology
-#              CMAKE_ARGS -DWALKING_TELEOPERATION_USES_CYBSDK:BOOL=${ROBOTOLOGY_USES_CYBERITH_SDK}
-#                         -DWALKING_TELEOPERATION_USES_OCULUSSDK:BOOL=${ROBOTOLOGY_USES_OCULUS_SDK}
               DEPENDS iDynTree
                       ICUB
                       YARP)

--- a/cmake/Buildyarp-device-ovrheadset.cmake
+++ b/cmake/Buildyarp-device-ovrheadset.cmake
@@ -1,0 +1,16 @@
+# Copyright (C) 2020 Fondazione Istituto Italiano di Tecnologia
+# CopyPolicy: Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
+
+include(YCMEPHelper)
+include(FindOrBuildPackage)
+
+find_or_build_package(YCM QUIET)
+find_or_build_package(YARP QUIET)
+
+ycm_ep_helper(yarp-device-ovrheadset TYPE GIT
+              STYLE GITHUB
+              REPOSITORY robotology/yarp-device-ovrheadset.git
+              TAG master
+              COMPONENT iCub
+              FOLDER robotology
+              DEPENDS YARP)


### PR DESCRIPTION
Fix https://github.com/robotology/robotology-superbuild/issues/511 .