### PR TITLE
Update whole-body-controllers and whole-body-estimators tags for release 2020.11

### DIFF
--- a/releases/2020.11.yaml
+++ b/releases/2020.11.yaml
@@ -90,11 +90,11 @@ repositories:
   whole-body-controllers:
     type: git
     url: https://github.com/robotology/whole-body-controllers.git
-    version: v2.0
+    version: v2.5
   whole-body-estimators:
     type: git
     url: https://github.com/robotology/whole-body-estimators.git
-    version: v0.2.1
+    version: v0.3.0
   walking-teleoperation:
     type: git
     url: https://github.com/robotology/walking-teleoperation.git


### PR DESCRIPTION
The new release of `whole-body-estimators` was reported by @prashanthr05  in https://github.com/robotology/robotology-superbuild/issues/500#issuecomment-724180794 . 

For the `whole-body-controllers`, with @CarlottaSartore we noticed that the 2020.08-patch01 contained a rather old version of `whole-body-controllers`, so we bumped it. fyi @gabrielenava 