### PR TITLE
Remove Debian Sid workaround related to libdart-external-odelcpsolver-dev

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,12 +116,6 @@ jobs:
       run: |
         apt-get -y -t buster-backports install cmake
         
-    - name: Install additional packages for Debian Sid [Debian Sid]
-      if: matrix.docker_image == 'debian:sid'
-      run: |
-        # Workaround for https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=967008
-        apt-get -y install libdart-external-odelcpsolver-dev
-        
     - name: Configure [Docker]
       run: |
         mkdir -p build


### PR DESCRIPTION
The problem was discussed in https://github.com/robotology/robotology-superbuild/issues/383, and was solved in https://salsa.debian.org/science-team/ignition-common/-/commit/872e3013cbde7815445d71ac75464b441647946f . 

Now some time has passed, so the change should have been propagated to the Docker Debian sid images generated in https://hub.docker.com/_/debian and we can remove the workaround.