### PR TITLE
Update wearables tag for release 2020.11

### DIFF
--- a/releases/2020.11.yaml
+++ b/releases/2020.11.yaml
@@ -106,7 +106,7 @@ repositories:
   wearables:
     type: git
     url: https://github.com/robotology/wearables.git
-    version: v1.0.0
+    version: v1.1.0
   human-dynamics-estimation:
     type: git
     url: https://github.com/robotology/human-dynamics-estimation.git


### PR DESCRIPTION
After release of wearables `v1.1.0`, I am updating the tag for Release 2020.11.

cc @Yeshasvitvs 