### PR TITLE
Restructure README moving CMake options documentation in separate file

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,82 +15,26 @@ You can read more about the superbuild concept in [YCM documentation](http://rob
 Table of Contents
 =================
   * [Superbuild structure](#superbuild-structure)
-    * [Profile CMake options](#profile-cmake-options)
-    * [Dependencies CMake options](#dependencies-cmake-options)
   * [Installation](#installation)
     * [Linux](#linux)
     * [macOS](#macos)
     * [Windows](#windows)
     * [Windows Subsystem For Linux](#windows-subsystem-for-linux)
   * [Update](#update)
-  * [Profile-specific documentation](#profile-specific-documentation)
-    * [Core profile](#core)
-    * [Robot Testing profile](#robot-testing)
-    * [Dynamics profile](#dynamics)
-    * [iCub Head profile](#icub-head)
-    * [iCub Basic Demos profile](#icub-basic-demos)
-    * [Teleoperation profile](#teleoperation)
-    * [Human Dynamics profile](#human-dynamics)
-    * [Event-driven profile](#event-driven)
-  * [Dependencies-specific documentation](#dependencies-specific-documentation)
-    * [Gazebo simulator](#gazebo)
-    * [MATLAB](#matlab)
-    * [Octave](#octave)
-    * [Python](#python)
-    * [Oculus](#oculus)
-    * [Cyberith](#cyberith)
-    * [Xsens](#xsens)
-    * [ESDCAN](#esdcan)
   * [FAQs](#faqs)
   * [Mantainers](#mantainers)
 
-Superbuild structure
+Superbuild structure 
 ====================
 
 `robotology-superbuild` will download and build a number of software.
-For each project, the repository will be downloaded in the `robotology/<package_name>` subdirectory
-of the superbuild root. The build directory for a given project will be instead the `robotology/<package_name>` subdirectory
-of the superbuild build directory. All the software packages are installed using the `install` directory of the build as installation prefix.
+For each project, the repository will be downloaded in the `robotology/<package_name>` subdirectory of the superbuild root. 
+The build directory for a given project will be instead the `robotology/<package_name>` subdirectory of the superbuild build directory. 
+All the software packages are installed using the `install` directory of the build as installation prefix.
+
 If there is any non-robotology dependency handled by the superbuild as it is not easily in the system, it will located in the `external` directory instead of the `robotology` one.
 
-
-## Superbuild CMake options
-As a huge number of software projects are developed in the `robotology` organization,
-and a tipical user is only interested in some of them, there are several options to
-instruct  the superbuild on which packages should be built and which one should not be built.
-
-### Profile CMake options
-The profile CMake options specify which subset of the robotology packages will be built by the superbuild.
-Note that any dependencies of the included packages that is not available in the system will be downloaded, compiled and installed as well. All these options are named `ROBOTOLOGY_ENABLE_<profile>` .
-
-| CMake Option | Description | Main packages included | Default Value | Profile-specific documentation |
-|:------------:|:-----------:|:---------------------:|:-------------:|:----:|
-| `ROBOTOLOGY_ENABLE_CORE` | The core robotology software packages, necessary for most users. | [`YARP`](https://github.com/robotology/yarp), [`ICUB`](https://github.com/robotology/icub-main), [`ICUBcontrib`](https://github.com/robotology/icub-contrib-common), [`icub-models`](https://github.com/robotology/icub-models) and  [`robots-configurations`](https://github.com/robotology/robots-configuration). [`GazeboYARPPlugins`](https://github.com/robotology/GazeboYARPPlugins) and [`icub-gazebo`](https://github.com/robotology/icub-gazebo) if the `ROBOTOLOGY_USES_GAZEBO` option is enabled. | `ON` | [Documentation on Core profile.](#core) |
-| `ROBOTOLOGY_ENABLE_ROBOT_TESTING` | The robotology software packages related to robot testing. |  [`RobotTestingFramework`](https://github.com/robotology/robot-testing-framework), [`icub-tests`](https://github.com/robotology/icub-tests), [`blocktest`](https://github.com/robotology/blocktest) and [`blocktest-yarp-plugins`](https://github.com/robotology/blocktest-yarp-plugins) | `OFF` | [Documentation on Robot Testing profile.](#robot-testing)  |
-| `ROBOTOLOGY_ENABLE_DYNAMICS` | The robotology software packages related to balancing, walking and force control. | [`iDynTree`](https://github.com/robotology/idyntree), [`blockfactory`](https://github.com/robotology/blockfactory), [`wb-Toolbox`](https://github.com/robotology/wb-Toolbox), [`whole-body-controllers`](https://github.com/robotology/whole-body-controllers), [`walking-controllers`](https://github.com/robotology/walking-controllers). [`icub-gazebo-wholebody`](https://github.com/robotology-playground/icub-gazebo-wholebody) if the `ROBOTOLOGY_USES_GAZEBO` option is enabled. | `OFF` | [Documentation on Dynamics profile.](#dynamics)  |
-| `ROBOTOLOGY_ENABLE_ICUB_HEAD` | The robotology software packages needed on the system that is running on the head of the iCub robot, or in general to communicate directly with iCub low-level devices. | [`icub-firmware`](https://github.com/robotology/icub-firmware), [`icub-firmware-shared`](https://github.com/robotology/icub-firmware-shared), [`diagnostic-daemon`](https://github.com/robotology/diagnostic-daemon). Furthermore, several additional devices are compiled in `YARP` and `ICUB` if this option is enabled. | `OFF` | [Documentation on iCub Head profile.](#icub-head)  |
-| `ROBOTOLOGY_ENABLE_ICUB_BASIC_DEMOS` | The robotology software packages needed to run basic demonstrations with the iCub robot. | [`icub-basic-demos`](https://github.com/robotology/icub-basic-demos), [`speech`](https://github.com/robotology/speech),  [`funny-things`](https://github.com/robotology/funny-things). | `OFF` | [Documentation on iCub Basic Demos profile.](#icub-basic-demos)  |
-| `ROBOTOLOGY_ENABLE_TELEOPERATION` | The robotology software packages related to teleoperation. | [`walking-teleoperation`](https://github.com/robotology/walking-teleoperation). To use Oculus or Cyberith Omnidirectional Treadmill enable `ROBOTOLOGY_USES_OCULUS_SDK` and `ROBOTOLOGY_USES_CYBERITH_SDK` options. | `OFF` | [Documentation on teleoperation profile.](#teleoperation)  |
-| `ROBOTOLOGY_ENABLE_HUMAN_DYNAMICS` | The robotology software packages related to human dynamics estimation. | [`human-dynamics-estimation`](https://github.com/robotology/human-dynamics-estimation), [`wearables`](https://github.com/robotology/wearables), [`forcetorque-yarp-devices`](https://github.com/robotology/forcetorque-yarp-devices). For options check the profile documentation. | `OFF` | [Documentation on human dynamics profile.](#human-dynamics)  |
-| `ROBOTOLOGY_ENABLE_EVENT_DRIVEN` | The robotology software packages related to event-driven. | [`event-driven`](https://github.com/robotology/event-driven) | `OFF` | [Documentation on event-driven profile.](#event-driven)  |
-
-If any of the packages required by the selected profiles is already available in the system (i.e. it can be found by the [`find_package` CMake command](https://cmake.org/cmake/help/v3.5/command/find_package.html) ), it will be neither downloaded, nor compiled, nor installed. In `robotology-superbuild`, this check is done by the [`find_or_build_package` YCM command](http://robotology.github.io/ycm/gh-pages/git-master/module/FindOrBuildPackage.html) in the main [`CMakeLists.txt`](https://github.com/robotology/robotology-superbuild/blob/db0f68300439ccced8497db4c321cd63416cf1c0/CMakeLists.txt#L108) of the superbuild.
-
-By default, the superbuild will use the package already available in the system. If the user wants to ignore those packages and have two different versions of them, then he/she should set the CMake variable `USE_SYSTEM_<PACKAGE>` to `FALSE.` For further details, please refer to [YCM Superbuild Manual for Developers](http://robotology.github.io/ycm/gh-pages/git-master/manual/ycm-superbuild.7.html#ycm-superbuild-manual-for-developers).
-
-### Dependencies CMake options
-The dependencies CMake options specify if the packages dependending on something installed in the system should be installed or not. All these options are named `ROBOTOLOGY_USES_<dependency>`.
-
-| CMake Option | Description | Default Value | Dependency-specific documentation |
-|:------------:|:-----------:|:-------------:|:---------------------------------:|
-| `ROBOTOLOGY_USES_GAZEBO`  | Include software and plugins that depend on the [Gazebo simulator](http://gazebosim.org/).  | `ON` on Linux and macOS, `OFF` on Windows   | [Documentation on Gazebo dependency.](#gazebo) |
-| `ROBOTOLOGY_USES_MATLAB`  | Include software and plugins that depend on the [Matlab](https://mathworks.com/products/matlab.html). | `OFF` | [Documentation on MATLAB dependency.](#matlab) |
-| `ROBOTOLOGY_USES_OCTAVE`  | Include software and plugins that depend on [Octave](https://www.gnu.org/software/octave/).  | `OFF` |  [Documentation on Octave dependency.](#octave) |
-| `ROBOTOLOGY_USES_OCULUS_SDK`  | Include software and plugins that depend on [Oculus](https://www.oculus.com/).  | `OFF` |  [Documentation on Oculus dependency.](#oculus) |
-| `ROBOTOLOGY_USES_CYBERITH_SDK`  | Include software and plugins that depend on [Cyberith](https://www.cyberith.com/).  | `OFF` |  [Documentation on Cyberith dependency.](#cyberith) |
-| `ROBOTOLOGY_USES_CFW2CAN`  | Include software and plugins that depend on [CFW2 CAN custom board](http://wiki.icub.org/wiki/CFW_card).  | `OFF` | No specific documentation is available for this  option, as it is just used with the [iCub Head profile](#icub-head), in which the related documentation can be found.  |
-| `ROBOTOLOGY_USES_XSENS_MVN_SDK`  | Include software and plugins that depend on [Xsens MVN SDK](https://www.xsens.com/products/).  | `OFF` | [Documentation on Xsens MVN dependency](#xsens)  |
-| `ROBOTOLOGY_USES_ESDCAN`  | Include software and plugins that depend on [Esd Can bus](http://wiki.icub.org/wiki/Esd_Can_Bus).  | `OFF` | [Documentation on ESDCAN dependency](#esdcan)  |
+As a huge number of software projects are developed in the **robotology organization**, and a tipical user is only interested in some of them, there are several **CMake options** to instruct the superbuild on which packages should be built and which one should not be built. In particular, the robotology-superbuild is divided in different **profiles**, that specify the specific subset of robotology packages to build. You can read more on the available **profiles** and how to enabled them in the [`doc/profiles.md` documentation](doc/profiles.md). 
 
 
 Installation
@@ -118,8 +62,8 @@ If instead you use an older distro in which the default version of CMake is olde
 * Debian 10 : use the CMake in the `buster-backports` repository, following the instructions to install from backports available in  [Debian documentation](https://backports.debian.org/Instructions/).
 More details can be found at https://github.com/robotology/QA/issues/364 .
 
-If you enabled any [profile](#profile-cmake-options) or [dependency](#dependencies-cmake-options) specific CMake option you may need to install additional system dependencies, following the dependency-specific documentation (in particular, the `ROBOTOLOGY_USES_GAZEBO` option is enabled by default, so you should install Gazebo unless you plan to disable this option):
-* [`ROBOTOLOGY_USES_GAZEBO`](#gazebo)
+If you enabled any [profile](doc/profiles.md#profile-cmake-options) or [dependency](doc/profiles.md#dependencies-cmake-options) specific CMake option you may need to install additional system dependencies, following the dependency-specific documentation (in particular, the `ROBOTOLOGY_USES_GAZEBO` option is enabled by default, so you should install Gazebo unless you plan to disable this option):
+* [`ROBOTOLOGY_USES_GAZEBO`](doc/profiles.md#gazebo)
 
 
 ### Superbuild
@@ -141,12 +85,7 @@ You can configure the ccmake environment if you know you will use some particula
 See [Superbuild CMake options](#superbuild-cmake-options) for a list of available options.
 
 ### Configure your environment
-Currently the YCM superbuild does not support building a global install target, so all binaries are installed in `robotology-superbuild/build/install/bin` and all libraries in `robotology-superbuild/build/install/lib`.
-
-To use the binaries and libraries installed by the robotology-superbuild, you should update the enviroment variables of your process such as `PATH` and `CMAKE_PREFIX_PATH`.
-
-The superbuild provides an automatically generated `setup.sh` sh script that will set
-all the necessary enviromental variables. To do so automatically for any new terminal that you open, append the following line to the `.bashrc` file:
+The superbuild provides an automatically generated `setup.sh` sh script that will set all the necessary enviromental variables to use the software installed in the robotology-superbuild. To do so automatically for any new terminal that you open, append the following line to the `.bashrc` file:
 ```
 source <directory-where-you-downloaded-robotology-superbuild>/build/install/share/robotology-superbuild/setup.sh
 ```
@@ -175,8 +114,8 @@ Since Qt5 is not symlinked in `/usr/local` by default in the homebrew formula, `
 export Qt5_DIR=/usr/local/opt/qt5/lib/cmake/Qt5
 ```
 
-If you want to enable a [profile](#profile-cmake-options) or a [dependency](#dependencies-cmake-options) specific CMake option, you may need to install additional system dependencies following the dependency-specific documentation (in particular, the `ROBOTOLOGY_USES_GAZEBO` option is enabled by default, so you should install Gazebo unless you plan to disable this option):
-* [`ROBOTOLOGY_USES_GAZEBO`](#gazebo)
+If you want to enable a [profile](doc/profiles.md#profile-cmake-options) or a [dependency](doc/profiles.md#dependencies-cmake-options) specific CMake option, you may need to install additional system dependencies following the dependency-specific documentation (in particular, the `ROBOTOLOGY_USES_GAZEBO` option is enabled by default, so you should install Gazebo unless you plan to disable this option):
+* [`ROBOTOLOGY_USES_GAZEBO`](doc/profiles.md#gazebo)
 
 ### Superbuild
 If you didn't already configured your git, you have to set your name and email to sign your commits:
@@ -204,12 +143,7 @@ xcodebuild [-configuration Release|Debug] [-jobs <n>] [-list | -target <target_n
 `-list` gives the list of available targets.
 
 ### Configure your environment
-Currently the YCM superbuild does not support building a global install target, so all binaries are installed in `robotology-superbuild/build/install/bin` and all libraries in `robotology-superbuild/build/install/lib`.
-
-To use the binaries and libraries installed by the robotology-superbuild, you should update the enviroment variables of your process such as `PATH` and `CMAKE_PREFIX_PATH`.
-
-The superbuild provides an automatically generated `setup.sh` sh script that will set
-all the necessary enviromental variables. To do so automatically for any new terminal that you open, append the following line to the `.bash_profile` file:
+The superbuild provides an automatically generated `setup.sh` sh script that will set all the necessary enviromental variables to use the software installed in the robotology-superbuild. To do so automatically for any new terminal that you open, append the following line to the `.bash_profile` file:
 ```
 source <directory-where-you-downloaded-robotology-superbuild>/build/install/share/robotology-superbuild/setup.sh
 ```
@@ -223,12 +157,6 @@ or simply open a new terminal.
 If for any reason you do not want to use the provided `setup.sh` script and you want to manage your enviroment variables manually, please refer to the documentation available at [`doc/environment-variables-configuration.md `](doc/environment-variables-configuration.md).
 
 ## Windows
-### Disclaimer
-While the robotology software is tested to be fully compatible with Windows,
-the Gazebo simulator that is widely used for simulation with robotology software [does not support Windows](https://github.com/robotology/gazebo-yarp-plugins/issues/74).
-
-For this reason if you plan to do use the robotology software with the Gazebo simulator on Windows,
-for the time being it is easier for you to use the [Windows Subsystem for Linux](#windows-subsystem-for-linux).
 
 ### System Dependencies
 
@@ -261,13 +189,13 @@ rm vcpkg-robotology.zip
 ~~~
 or creating the directories and extracting the archive through the File Explorer. If you prefer to use your own vcpkg to install the dependencies of the superbuild, please refer to the documentation available at [`doc/vcpkg-dependencies.md`](doc/vcpkg-dependencies.md).
 
-If you want to enable the `ROBOTOLOGY_USES_GAZEBO` option, you will need to download and extract the `vcpkg-robotology-with-gazebo.zip` archive. For instructions on how to correctly use this archives, please refer to documentation of the [`robotology-superbuild-dependencies-vcpkg)`](https://github.com/robotology/robotology-superbuild-dependencies-vcpkg) repo.
+If you want to enable the `ROBOTOLOGY_USES_GAZEBO` option, you will need to download and extract the `vcpkg-robotology-with-gazebo.zip` archive. For instructions on how to correctly use this archives, please refer to documentation of the [`robotology-superbuild-dependencies-vcpkg`](https://github.com/robotology/robotology-superbuild-dependencies-vcpkg) repo.
 
-If you want to enable a [profile](#profile-cmake-options) or a [dependency](#dependencies-cmake-options) specific CMake option, you may need to install additional system dependencies following the dependency-specific documentation:
-* [`ROBOTOLOGY_USES_OCULUS_SDK`](#oculus)
-* [`ROBOTOLOGY_USES_CYBERITH_SDK`](#cyberith)
-* [`ROBOTOLOGY_USES_XSENS_MVN_SDK`](#xsens)
-* [`ROBOTOLOGY_USES_ESDCAN`](#shoes)
+If you want to enable a [profile](doc/profiles.md#profile-cmake-options) or a [dependency](doc/profiles.md#dependencies-cmake-options) specific CMake option, you may need to install additional system dependencies following the dependency-specific documentation:
+* [`ROBOTOLOGY_USES_OCULUS_SDK`](doc/profiles.md#oculus)
+* [`ROBOTOLOGY_USES_CYBERITH_SDK`](doc/profiles.md#cyberith)
+* [`ROBOTOLOGY_USES_XSENS_MVN_SDK`](doc/profiles.md#xsens)
+* [`ROBOTOLOGY_USES_ESDCAN`](doc/profiles.md#shoes)
 
 ### Superbuild
 If you didn't already configured your git, you have to set your name and email to sign your commits:
@@ -292,11 +220,7 @@ cmake --build . --config Release
 ~~~
 
 ### Configure your environment
-Currently the YCM superbuild does not support building a global install target, so all binaries are installed in `robotology-superbuild/build/install/bin` and all libraries in `robotology-superbuild/build/install/lib`.
-
-To use the binaries and libraries installed by the robotology-superbuild, you should update the enviroment variables of your process such as `PATH` and `CMAKE_PREFIX_PATH`.
-
-If you are an heavy user  of the software installed by the robotology-superbuild, you may want to update your [user enviroment variables](https://docs.microsoft.com/en-us/windows/win32/shell/user-environment-variables) to permit you to use the robotology-superbuild software from any Windows process. To automatically update the user enviroment variables, the robotology-superbuild provides the `addPathsToUserEnvVariables.ps1` and `removePathsFromUserEnvVariables.ps1` available at `<directory-where-you-downloaded-robotology-superbuild>/build/install/share/robotology-superbuild/`.  As indicated by their name, `addPathsToUserEnvVariables.ps1` is used to setup the enviroment variables used by the robotology-superbuild, while `removePathsFromUserEnvVariables.ps1` permits to cleanly remove them. To configure the robotology-superbuild, just run the `addPathsToUserEnvVariables.ps1` script once in a Powershell terminal.
+If you are an heavy user of the software installed by the robotology-superbuild, you may want to update your [user enviroment variables](https://docs.microsoft.com/en-us/windows/win32/shell/user-environment-variables) to permit you to use the robotology-superbuild software from any Windows process. To automatically update the user enviroment variables, the robotology-superbuild provides the `addPathsToUserEnvVariables.ps1` and `removePathsFromUserEnvVariables.ps1` available at `<directory-where-you-downloaded-robotology-superbuild>/build/install/share/robotology-superbuild/`.  As indicated by their name, `addPathsToUserEnvVariables.ps1` is used to setup the enviroment variables used by the robotology-superbuild, while `removePathsFromUserEnvVariables.ps1` permits to cleanly remove them. To configure the robotology-superbuild, just run the `addPathsToUserEnvVariables.ps1` script once in a Powershell terminal.
 
 To check the values of the enviroment variables modified by the powershell scripts provided by the superbuild, you can use a program such as [Rapid Enviroment Editor](https://www.rapidee.com/).
 
@@ -398,306 +322,6 @@ for more details on this options.
 By default, the `robotology-superbuild` uses the latest "stable" branches of the robotology repositories, but in some cases it may be necessary to use the "unstable" active development branches,
 or use some fixed tags. For this advanced functionalities, please refer to the documentation on changing the default project tags, available at [`doc/change-project-tags.md`](doc/change-project-tags.md).
 
-
-Profile-specific documentation
-===================================
-
-## Core
-This profile is enabled by the `ROBOTOLOGY_ENABLE_CORE` CMake option.
-
-### System Dependencies
-The steps necessary to install the system dependencies of the Core profile are provided in
-operating system-specific installation documentation.
-
-### Check the installation
-Follow the steps in http://wiki.icub.org/wiki/Check_your_installation to verify if your installation was successful.
-
-## Robot Testing
-This profile is enabled by the `ROBOTOLOGY_ENABLE_ROBOT_TESTING` CMake option.
-
-On Windows, this profile creates some long paths during the build process. If you enable it, it is recommended  to
-keep the total path length of the robotology-superbuild build directory below 50 characters, or to enable the support for
-long path in Windows following the instructions in the [official Windows documentation](https://docs.microsoft.com/en-us/windows/win32/fileio/maximum-file-path-limitation#enable-long-paths-in-windows-10-version-1607-and-later).
-
-### System Dependencies
-The steps necessary to install the system dependencies of the Robot Testing profile are provided in
-operating system-specific installation documentation, and no additional required system dependency is required.
-
-### Check the installation
-If the profile has been correctly enabled and compiled, you should be able to run the `robottestingframework-testrunner` and `blocktestrunner` executable from the command line.
-
-
-## Dynamics
-This profile is enabled by the `ROBOTOLOGY_ENABLE_DYNAMICS` CMake option.
-
-### System Dependencies
-The steps necessary to install the system dependencies of the Dynamics profile are provided in
-operating system-specific installation documentation, and no additional required system dependency is required.
-
-The only optional system dependency of `wb-toolbox`, project part of this profile, is [tbeu/matio](https://github.com/tbeu/matio/).
-
-#### Linux
-
-Install matio using the following command:
-
-```
-sudo apt install libmatio-dev
-```
-
-#### macOS
-
-Install matio from `homebrew/core` using the following command:
-
-```
-brew install libmatio
-```
-
-#### Windows
-
-Install matio following the [installation instructions](https://github.com/tbeu/matio/#20-building) present in the repository.
-
-## iCub Head
-
-This profile is enabled by the `ROBOTOLOGY_ENABLE_ICUB_HEAD` CMake option. It is used in the system installed on iCub head,
-or if you are a developer that needs to access iCub hardware devices directly without passing through the iCub head.
-
-**Warning: the migration of existing iCub setups to use the robotology-superbuild is an ongoing process, and it is possible
-that your iCub still needs to be migrated. For any doubt, please get in contact with [icub-support](https://github.com/robotology/icub-support).**
-
-The configuration and compilation of this profile is supported on Linux, macOS and Windows systems.
-
-On Linux all the software necessary to communicate with boards contained in the robot, including CAN devices via [esd's CAN USB bridges](https://esd.eu/en/products/can-usb2), is already included.
-
-On Windows to communicate with CAN devices via [esd's CAN USB bridges](https://esd.eu/en/products/can-usb2) you need to set to ON the Windows-only CMake option [`ROBOTOLOGY_ENABLE_ESDCAN`](#esdcan).
-
-On macOS, communication with [esd's CAN USB bridges](https://esd.eu/en/products/can-usb2) is not supported and `diagnosticdaemon` is not available because of https://github.com/robotology/robotology-superbuild/issues/439.
-
-This section documents the iCub Head profile as any other profile, in a way agnostic of the specific machine in which it is installed. To get information on how to use the robotology-superbuild to install software on the machine mounted in the head of physical iCub robots, please check the documentation in [`doc/use-on-icub-head.md`](doc/use-on-icub-head.md).
-
-### System Dependencies
-The steps necessary to install the system dependencies of the iCub Head profile are provided in
-operating system-specific installation documentation, and no additional required system dependency is required.
-
-On old iCub systems equipped with the [CFW2 CAN board](http://wiki.icub.org/wiki/CFW_card), it may be necessary to have the cfw2can driver
-installed on the iCub head (it is tipically already pre-installed in the OS image installed in the system in the iCub head). In that
-case, you also need to enable the `ROBOTOLOGY_USES_CFW2CAN` option to compile the software that depends on cfw2can. In case of doubt,
-please always get in contact with [icub-support](https://github.com/robotology/icub-support).
-
-### Check the installation
-The `ROBOTOLOGY_ENABLE_ICUB_HEAD` installs several YARP devices for communicating directly with embedded boards of the iCub.
-To check if the installation was correct, you can list all the available YARP devices using the `yarpdev --list` command,
-and check if devices whose name is starting with `embObj` are present in the list. If those devices are present, then the installation
-should be working correctly. Furthermore, if the profile has been correctly enabled and compiled, you should be able to run the `diagnosticdaemon` executable from the command line.
-
-
-## iCub Basic Demos
-
-This profile is enabled by the `ROBOTOLOGY_ENABLE_BASIC_DEMOS` CMake option.
-
-### System Dependencies
-The steps necessary to install the system dependencies of the iCub Basic Demos profile are provided in
-operating system-specific installation documentation, and no additional required system dependency is required.
-
-### Check the installation
-If the iCub Basic Demos profile have been correctly installed, you should be able to find in your PATH and execute the `demoYoga` or `demoRedBall` executables.
-
-## Teleoperation
-This profile is enabled by the `ROBOTOLOGY_ENABLE_TELEOPERATION` CMake option.
-
-### System Dependencies
-To run a teleoperation scenario, with real robot or in simulation, at least we need a Windows machine and Linux/macOS machine. If you are using iCub, the linux/macOS source code can be placed on the robot head. The teleoperation dependencies are also related to the teleoperation scenario you want to perform.
-
-#### Teleoperation without Cyberith treadmill
-In this scenario, we only use [Oculus](#oculus) for teleoperation, and we do not use Cyberith treadmill. In this case, the user can give the command for robot walking through the Oculus joypads. The dependencies for this scenario are as following:
-* Windows: [Oculus](#oculus).
-* Linux/macOS: [walking controller](https://github.com/robotology/walking-controllers).
-
-#### Teleoperation with Cyberith treadmill
-In this scenario, we use both [Oculus](#oculus) and [cyberith treadmill](#cyberith) for teleopration. In this case, the user can give the command for robot walking through walking on cyberith treadmill. The dependencies for this scenario are as follwoing:
-* Windows: [Oculus](#oculus), [Cyberith](#cyberith).
-* Linux/macOS: [walking controller](https://github.com/robotology/walking-controllers).
-
-## Human Dynamics
-This profile is enabled by the `ROBOTOLOGY_ENABLE_HUMAN_DYNAMICS` CMake option.
-
-### System Dependencies
-To run a human dynamics estimation scenario, we need a Windows machine to install the Xsens suit SDK for getting the sensory information of the human motions from [Xsens](https://www.xsens.com/) and [ESD USB CAN driver](https://esd.eu/en/products/can-usb2) to get the FTShoes/FTSkShoes sensory information. Refer to [Xsens](#xsens) and [ESDCAN](#esdcan) for more information about the dependencies.
-
-## Event-driven
-This profile is enabled by the `ROBOTOLOGY_ENABLE_EVENT_DRIVEN` CMake option. For the moment, Windows is not a supported platform.
-
-### System Dependencies
-The steps necessary to install the system dependencies of the Event-driven profile are provided in
-operating system-specific installation documentation.
-
-Dependencies-specific documentation
-===================================
-
-## Gazebo
-Support for this dependency is enabled by the `ROBOTOLOGY_USES_GAZEBO` CMake option.
-This option is still set to `OFF` on Windows as it is still experimental.
-
-### System Dependencies
-On Linux or macOS, install Gazebo following the instructions available at http://gazebosim.org/tutorials?cat=install .
-Make sure to install also the development files, i.e. `libgazebo*-dev` on Debian/Ubuntu.
-
-On Windows, make sure that you install the Windows dependencies using the `vcpkg-robotology-with-gazebo.zip` archive and you set
-the correct enviroment variables as documented in [`robotology-superbuild-dependencies-vcpkg` documentation](https://github.com/robotology/robotology-superbuild-dependencies-vcpkg).
-
-### Check the installation
-Follow the steps in https://github.com/robotology/icub-gazebo#usage and/or https://github.com/robotology/icub-models#use-the-models-with-gazebo to check if the Gazebo-based iCub simulation works fine.
-
-## MATLAB
-Support for this dependency is enabled by the `ROBOTOLOGY_USES_MATLAB` CMake option.
-
-**Warning: differently from other optional dependencies, MATLAB is a commercial product that requires a license to be used.**
-
-### System Dependencies
-If MATLAB is not installed on your computer, install it following the instruction in https://mathworks.com/help/install/ .
-Once you installed it, make sure that the directory containing the `matlab` executable is present in the `PATH` of your system,
-as [CMake's FindMatlab module](https://cmake.org/cmake/help/v3.5/module/FindMatlab.html) relies on this to find MATLAB.
-
-**Note: tipically we assume that a user that selects the `ROBOTOLOGY_USES_MATLAB` also has Simulink installed in his computer.
-If this is not the case, you can enable the advanced CMake option `ROBOTOLOGY_NOT_USE_SIMULINK` to compile all the subprojects that depend on MATLAB, but disable the subprojecs that depend on Simulink (i.e. the
-[wb-toolbox](https://github.com/robotology/wb-toolbox) Simulink Library) if you have enabled the `ROBOTOLOGY_ENABLE_DYNAMICS` CMake options.**
-
-### Configuration
-If [MATLAB](mathworks.com/products/matlab/) is installed on your computer, the robotology-superbuild
-can install some projects that depend on MATLAB, in particular:
- * the MATLAB bindings of the [iDynTree](https://github.com/robotology/idyntree) library,
- * the native MATLAB bindings of YARP, contained in the [yarp-matlab-bindings](https://github.com/robotology-playground/yarp-matlab-bindings/) repository,
- * the MATLAB bindings of qpOASES, contained in the [robotology-dependencies/qpOASES](https://github.com/robotology-dependencies/qpOASES) fork,
- * The [WB-Toolbox](https://github.com/robotology/WB-Toolbox) Simulink toolbox,
- * The [whole-body-controllers](https://github.com/robotology/whole-body-controllers) Simulink-based balancing controllers. Note that whole-body-controllers can be installed and compiled also without MATLAB, but its functionalities are reduced.
-
-To use this software, you can simply enable its compilation using the `ROBOTOLOGY_USES_MATLAB` CMake option.
-Once this software has been compiled by the superbuild, you just need to add some directories of the robotology-superbuild install (typically `$ROBOTOLOGY_SUPERBUILD_SOURCE_DIR/build/install`) to [the MATLAB path](https://www.mathworks.com/help/matlab/matlab_env/what-is-the-matlab-search-path.html).
-In particular you need to add to the MATLAB path the `$ROBOTOLOGY_SUPERBUILD_INSTALL_PREFIX/mex` directory and all the subdirectories `$ROBOTOLOGY_SUPERBUILD_INSTALL_PREFIX/share/WBToolbox`.
-
-#### Start MATLAB from the launcher or the application menu
-
-You could add this line to your MATLAB script that uses the robotology-superbuild matlab software, substituting `<ROBOTOLOGY_SUPERBUILD_INSTALL_PREFIX>` with the `install` folder inside the build directory of the superbuild:
-
-~~~
-    addpath(['<ROBOTOLOGY_SUPERBUILD_INSTALL_PREFIX>' '/mex'])
-    addpath(['<ROBOTOLOGY_SUPERBUILD_INSTALL_PREFIX>' '/mex/+wbc/simulink'])
-    addpath(['<ROBOTOLOGY_SUPERBUILD_INSTALL_PREFIX>' '/share/WBToolbox'])
-    addpath(['<ROBOTOLOGY_SUPERBUILD_INSTALL_PREFIX>' '/share/WBToolbox/images'])
-~~~
-
-Another way is to run (only once) the script `startup_robotology_superbuild.m` in the `$ROBOTOLOGY_SUPERBUILD_SOURCE_DIR/build` folder. This should be enough to permanently add the required paths for all the toolbox that use MATLAB.
-
-#### Start MATLAB from the terminal
-
-You can add the folders by modifying the `startup.m` or the `MATLABPATH` environmental variable [as described in official MATLAB documentation](https://www.mathworks.com/help/matlab/matlab_env/add-folders-to-matlab-search-path-at-startup.html).
-If you are using the `setup.sh` or `setup.bat` script for configuring your environment, `MATLABPATH` is automatically populated with these directories.
-
-For more info on configuring MATLAB software with the robotology-superbuild, please check the [wb-toolbox README](https://github.com/robotology/wb-toolbox).
-
-### Check the installation
-To verify that the compilation of `ROBOTOLOGY_USES_MATLAB` option was successful, try to run a script that uses
-the Matlab bindings of `yarp` and see if it executes without any error, for example:
-~~~matlab
-yarpVec = yarp.Vector();
-yarpVec.fromMatlab([1;2;3]);
-yarpVec.toMatlab()
-~~~~
-This scripts should print a `1 2 3` vector, but only if the `yarp` bindings are working correctly.
-
-
-## Octave
-Support for this dependency is enabled by the `ROBOTOLOGY_USES_OCTAVE` CMake option.
-
-### System Dependencies
-
-#### Linux
-Install octave and the necessary development files using the following command:
-~~~
-sudo apt-get install liboctave-dev
-~~~
-
-#### macOS
-Install octave using the following command:
-~~~
-brew install octave
-~~~
-
-#### Windows
-The `ROBOTOLOGY_USES_OCTAVE` option is not supported on Windows, see https://github.com/robotology/robotology-superbuild/issues/139 for more info.
-
-### Configuration
-Add the `$ROBOTOLOGY_SUPERBUILD_SOURCE_DIR/build/install/octave` directory to your [Octave path](https://www.gnu.org/software/octave/doc/interpreter/Manipulating-the-Load-Path.html).
-
-### Check the installation
-To verify that the compilation of `ROBOTOLOGY_USES_OCTAVE` option was successful, try to run a script that uses
-the Octave bindings of `yarp` and see if it executes without any error, for example:
-~~~matlab
-yarpVec = yarp.Vector();
-yarpVec.fromMatlab([1;2;3]);
-yarpVec.toMatlab()
-~~~~
-This scripts should print a `1 2 3` vector, but only if the `yarp` bindings are working correctly.
-
-
-## Python
-
-Support for this dependency is enabled by the `ROBOTOLOGY_USES_PYTHON` CMake option.
-
-### Check the installation
-Open a python interpreter and try to import modules, for example verify that `import yarp` works.
-
-## Oculus
-Support for this dependency is enabled by the `ROBOTOLOGY_USES_OCULUS_SDK` CMake option.
-
-**Warning: at the moment the Oculus SDK does not support macOS and Linux, so this option is only supported
-on Windows.**
-
-### System Dependencies
-To check and install the Oculus SDK please follow the steps for Oculus SDK mentioned [here](https://github.com/robotology/walking-teleoperation/blob/master/docs/Dependencies.md).
-
-### Configuration
-To configure the Oculus SDK follow the steps for Oculus SDK mentioned [here](https://github.com/robotology/walking-teleoperation/blob/master/docs/Dependencies.md).
-
-## Cyberith
-Support for this dependency is enabled by the `ROBOTOLOGY_USES_CYBERITH_SDK` CMake option.
-
-**Warning: at the moment the Cyberith SDK does not support macOS and Linux, so this option is only supported on Windows.**
-
-### System Dependencies
-To check and install the Cyberith SDK, please follow the steps for Cyberith SDK mentioned in [here](https://github.com/robotology/walking-teleoperation/blob/master/docs/Dependencies.md).
-
-### Configuration
-To configure the Cyberith SDK please follow the steps for Cyberith SDK mentioned in [here](https://github.com/robotology/walking-teleoperation/blob/master/docs/Dependencies.md).
-
-## Xsens
-Support for `ROBOTOLOGY_USES_XSENS_MVN_SDK` option is only enabled when the `ROBOTOLOGY_ENABLE_HUMAN_DYNAMICS` CMake option is set to ON.
-
-**Warning: at the moment the Xsens MVN SDK does not support macOS and Linux, so this option is only supported
-on Windows.**
-
-### System Dependencies
-To check and install the Xsens MVN SDK, please follow the steps for Xsens MVN SDK mentioned in [here](https://github.com/robotology/human-dynamics-estimation/wiki/Set-up-Machine-for-running-HDE#xsens-only-for-windows).
-
-### Configuration
-To configure the Xsens MVN SDK please follow the steps for Xsens MVN SDK mentioned in [here](https://github.com/robotology/human-dynamics-estimation/wiki/Set-up-Machine-for-running-HDE#xsens-only-for-windows).
-
-## ESDCAN
-The `ROBOTOLOGY_USES_ESDCAN` option is used to enable support for interacting with [esd CAN devices](https://esd.eu/en/products/can-usb2) on Windows. On Linux no special option is necessary, as the interconnection with esd CAN device is supported  using the default [SocketCAN](https://www.kernel.org/doc/Documentation/networking/can.txt) Linux driver. Use of [esd CAN devices](https://esd.eu/en/products/can-usb2) is not supported in macOS .
-
-### System Dependencies
-To compile the software enabled by the `ROBOTOLOGY_USES_ESDCAN` option (such as the `icub-main`'s [`esdcan`](http://www.icub.org/software_documentation/classyarp_1_1dev_1_1EsdCan.html) YARP driver) you need to install the esd CAN C library.
-This library is already contained  in the vcpkg installation installed by the `robotology-superbuild` dependencies installer.
-If you use a custom vcpkg installation, you can install the  `esdcan-binary` custom port from the [`robotology-vcpkg-ports`](https://github.com/robotology/robotology-vcpkg-ports) repo.
-
-To actually run the software that uses the esd CAN devices, you also need to install the esd CAN Driver for your specific esd CAN device.
-The installers for the esd CAN Driver should have been provided by esd, so ask for them to who provided you with the esd CAN device you want to use.
-
-### Configuration
-No additional configuration is required to use the software installed by the  `ROBOTOLOGY_USES_ESDCAN`
-
-### Check the installation
-Open a terminal, and check that amoung the device listed by `yarpdev --list` the `esdcan` YARP device is listed.
-
 FAQs
 ====
 
@@ -716,19 +340,6 @@ This option can be used also for CMake options that are related to a single proj
 
 For more information on this option, see the [official YCM documentation](http://robotology.github.io/ycm/gh-pages/latest/manual/ycm-superbuild.7.html#specifying-additional-cmake-arguments-for-all-subprojects).
 
-### Which are the differences between the `robotology-superbuild` and the `codyco-superbuild` ?
-
-The CoDyCo European project that funded the development and the mantainance of the `codyco-superbuild` ended in 2017 .
-The robotology-superbuild is the successor of the codyco-superbuild, but it is not limited to software developed in the
-CoDyCo project, but more in general software developed in the robotology GitHub organization.
-
-Technically speaking, there are a few differences:
-* Projects in the `codyco-superbuild` were saved in the external, libraries or main directories subdirectories of the source
-and of the build directories. For the sake of simplicity, the `robotology-superbuild` just save robotology projects in the robotology
-directory and all external projects in the external directory.
-* Support for software that depends on Gazebo (gazebo-yarp-plugins, icub-gazebo, ...) is enabled by default in Linux and macOS .
-* In the `robotology-superbuild` the compilation for dynamics-related software (iDynTree, balancing and walking controllers) needs to be explicity enabled using the `ROBOTOLOGY_ENABLE_DYNAMICS` that is `OFF` by default.
-
 ### How can I check the status of each subproject?
 
 It is possible to run the bash script named ``robotologyGitStatus.sh`` in the ``scripts`` folder. For example, on linux, from the ``robotology-superbuild`` root run ``bash scripts/robotologyGitStatus.sh`` to print the status of each subproject.
@@ -745,7 +356,7 @@ The `robotology-superbuild` is based on [YCM](https://github.com/robotology/ycm)
 
 * **A Build System for Software Development in Robotic Academic Collaborative Environments**,
   D.E. Domenichelli, S. Traversaro, L. Muratore, A. Rocchi, F. Nori, L. Natale,
-  **IN PRESS** International Journal of Semantic Computing (IJSC), Vol. 13, No. 02, 2019
+  International Journal of Semantic Computing (IJSC), Vol. 13, No. 02, 2019
 
 
 Mantainers

--- a/doc/developers-faqs.md
+++ b/doc/developers-faqs.md
@@ -25,13 +25,13 @@ ycm_ep_helper(<package> TYPE GIT
                       <pkgB>
                       <pkgC>)
 ~~~
-* If the package is important "enough" (it was not added just because it is a dependency) added it to the table in https://github.com/robotology/robotology-superbuild#profile-cmake-options .
+* If the package is important "enough" (it was not added just because it is a dependency) added it to the table in [`doc/profile.md#profile-cmake-options`](profiles.md#profile-cmake-options) .
 * If the dependencies of the packages are available in `apt`, `homebrew` or Windows installers, document how to install them in the profile docs in the README. If any dependency is not available through this means, add it as a new package of the superbuid.
 * For more details, see  upstream YCM docs http://robotology.github.io/ycm/gh-pages/latest/manual/ycm-superbuild-example.7.html#superbuild-example-developer-point-of-view
 
 ## How to add a new profile 
 * Decide a name for the profile and decide who will be the mantainer of the profile 
-* Add the profile name in https://github.com/robotology/robotology-superbuild#profile-cmake-options and the mantainer name in https://github.com/robotology/robotology-superbuild#mantainers . 
+* Add the profile name in [`doc/profile.md#profile-cmake-options`](profiles.md#profile-cmake-options) and the mantainer name in https://github.com/robotology/robotology-superbuild#mantainers . 
 * Add the `ROBOTOLOGY_ENABLE_<profile>` CMake option in the main CMakeLists.txt https://github.com/robotology/robotology-superbuild/blob/master/CMakeLists.txt#L51 
 * Add any new package required by the profile to the superbuild, following the instructions in "How to add a new package" FAQ
 * Add a part of code with a `find_or_build_package(<pkg1_profile>)`  in the main CMakeLists.txt, guarded by the `if(ROBOTOLOGY_ENABLE_<profile>)` clause, something like: 
@@ -41,7 +41,7 @@ if(ROBOTOLOGY_ENABLE_<profile>)
   find_or_build_package(<pkg2_profile>)
 endif()
 ~~~
-* Add the profile documentation in https://github.com/robotology/robotology-superbuild#profile-specific-documentation . Take inspiration from the documentation of existing profiles. If the profile need a specific enviroment variable to be set of a value to be appended (such as `YARP_DATA_DIRS`), document it in the documentation and add it in the templates in https://github.com/robotology/robotology-superbuild/blob/master/cmake/template and in https://github.com/robotology/robotology-superbuild/blob/master/doc/environment-variables-configuration.md. 
+* Add the profile documentation in [`doc/profile.md#profile-specific-documentation`](profiles.md#profile-specific-documentation). Take inspiration from the documentation of existing profiles. If the profile need a specific enviroment variable to be set of a value to be appended (such as `YARP_DATA_DIRS`), document it in the documentation and add it in the templates in https://github.com/robotology/robotology-superbuild/blob/master/cmake/template and in [`doc/environment-variables-configuration.md`](environment-variables-configuration.md). 
 
 ## How to do a new release
 * Sometime before the release, add a `yyyy.mm.yaml` file in https://github.com/robotology/robotology-superbuild/tree/master/releases, containing the version of package contained in the new release.

--- a/doc/profiles.md
+++ b/doc/profiles.md
@@ -1,0 +1,367 @@
+# robotology-superbuild: Profiles
+
+Table of Contents
+=================
+  * [Superbuild CMake options](#superbuild-cmake-options)
+    * [Profile CMake options](#profile-cmake-options)
+    * [Dependencies CMake options](#dependencies-cmake-options)
+  * [Profile-specific documentation](#profile-specific-documentation)
+    * [Core profile](#core)
+    * [Robot Testing profile](#robot-testing)
+    * [Dynamics profile](#dynamics)
+    * [iCub Head profile](#icub-head)
+    * [iCub Basic Demos profile](#icub-basic-demos)
+    * [Teleoperation profile](#teleoperation)
+    * [Human Dynamics profile](#human-dynamics)
+    * [Event-driven profile](#event-driven)
+  * [Dependencies-specific documentation](#dependencies-specific-documentation)
+    * [Gazebo simulator](#gazebo)
+    * [MATLAB](#matlab)
+    * [Octave](#octave)
+    * [Python](#python)
+    * [Oculus](#oculus)
+    * [Cyberith](#cyberith)
+    * [Xsens](#xsens)
+    * [ESDCAN](#esdcan)
+    
+
+Superbuild CMake options
+========================
+
+As a huge number of software projects are developed in the `robotology` organization, and a tipical user is only interested in some of them, there are several options to
+instruct  the superbuild on which packages should be built and which one should not be built. In particular, the robotology-superbuild is divided in different "profiles", 
+that specify the specific subset of robotology packages to build. 
+
+## Profile CMake options
+The profile CMake options specify which subset of the robotology packages will be built by the superbuild.
+Note that any dependencies of the included packages that is not available in the system will be downloaded, compiled and installed as well. 
+All these options are named `ROBOTOLOGY_ENABLE_<profile>` .
+
+| CMake Option | Description | Main packages included | Default Value | Profile-specific documentation |
+|:------------:|:-----------:|:---------------------:|:-------------:|:----:|
+| `ROBOTOLOGY_ENABLE_CORE` | The core robotology software packages, necessary for most users. | [`YARP`](https://github.com/robotology/yarp), [`ICUB`](https://github.com/robotology/icub-main), [`ICUBcontrib`](https://github.com/robotology/icub-contrib-common), [`icub-models`](https://github.com/robotology/icub-models) and  [`robots-configurations`](https://github.com/robotology/robots-configuration). [`GazeboYARPPlugins`](https://github.com/robotology/GazeboYARPPlugins) and [`icub-gazebo`](https://github.com/robotology/icub-gazebo) if the `ROBOTOLOGY_USES_GAZEBO` option is enabled. | `ON` | [Documentation on Core profile.](#core) |
+| `ROBOTOLOGY_ENABLE_ROBOT_TESTING` | The robotology software packages related to robot testing. |  [`RobotTestingFramework`](https://github.com/robotology/robot-testing-framework), [`icub-tests`](https://github.com/robotology/icub-tests), [`blocktest`](https://github.com/robotology/blocktest) and [`blocktest-yarp-plugins`](https://github.com/robotology/blocktest-yarp-plugins) | `OFF` | [Documentation on Robot Testing profile.](#robot-testing)  |
+| `ROBOTOLOGY_ENABLE_DYNAMICS` | The robotology software packages related to balancing, walking and force control. | [`iDynTree`](https://github.com/robotology/idyntree), [`blockfactory`](https://github.com/robotology/blockfactory), [`wb-Toolbox`](https://github.com/robotology/wb-Toolbox), [`whole-body-controllers`](https://github.com/robotology/whole-body-controllers), [`walking-controllers`](https://github.com/robotology/walking-controllers). [`icub-gazebo-wholebody`](https://github.com/robotology-playground/icub-gazebo-wholebody) if the `ROBOTOLOGY_USES_GAZEBO` option is enabled. | `OFF` | [Documentation on Dynamics profile.](#dynamics)  |
+| `ROBOTOLOGY_ENABLE_ICUB_HEAD` | The robotology software packages needed on the system that is running on the head of the iCub robot, or in general to communicate directly with iCub low-level devices. | [`icub-firmware`](https://github.com/robotology/icub-firmware), [`icub-firmware-shared`](https://github.com/robotology/icub-firmware-shared), [`diagnostic-daemon`](https://github.com/robotology/diagnostic-daemon). Furthermore, several additional devices are compiled in `YARP` and `ICUB` if this option is enabled. | `OFF` | [Documentation on iCub Head profile.](#icub-head)  |
+| `ROBOTOLOGY_ENABLE_ICUB_BASIC_DEMOS` | The robotology software packages needed to run basic demonstrations with the iCub robot. | [`icub-basic-demos`](https://github.com/robotology/icub-basic-demos), [`speech`](https://github.com/robotology/speech),  [`funny-things`](https://github.com/robotology/funny-things). | `OFF` | [Documentation on iCub Basic Demos profile.](#icub-basic-demos)  |
+| `ROBOTOLOGY_ENABLE_TELEOPERATION` | The robotology software packages related to teleoperation. | [`walking-teleoperation`](https://github.com/robotology/walking-teleoperation). To use Oculus or Cyberith Omnidirectional Treadmill enable `ROBOTOLOGY_USES_OCULUS_SDK` and `ROBOTOLOGY_USES_CYBERITH_SDK` options. | `OFF` | [Documentation on teleoperation profile.](#teleoperation)  |
+| `ROBOTOLOGY_ENABLE_HUMAN_DYNAMICS` | The robotology software packages related to human dynamics estimation. | [`human-dynamics-estimation`](https://github.com/robotology/human-dynamics-estimation), [`wearables`](https://github.com/robotology/wearables), [`forcetorque-yarp-devices`](https://github.com/robotology/forcetorque-yarp-devices). For options check the profile documentation. | `OFF` | [Documentation on human dynamics profile.](#human-dynamics)  |
+| `ROBOTOLOGY_ENABLE_EVENT_DRIVEN` | The robotology software packages related to event-driven. | [`event-driven`](https://github.com/robotology/event-driven) | `OFF` | [Documentation on event-driven profile.](#event-driven)  |
+
+If any of the packages required by the selected profiles is already available in the system (i.e. it can be found by the [`find_package` CMake command](https://cmake.org/cmake/help/v3.5/command/find_package.html) ), it will be neither downloaded, nor compiled, nor installed. In `robotology-superbuild`, this check is done by the [`find_or_build_package` YCM command](http://robotology.github.io/ycm/gh-pages/git-master/module/FindOrBuildPackage.html) in the main [`CMakeLists.txt`](https://github.com/robotology/robotology-superbuild/blob/db0f68300439ccced8497db4c321cd63416cf1c0/CMakeLists.txt#L108) of the superbuild.
+
+By default, the superbuild will use the package already available in the system. If the user wants to ignore those packages and have two different versions of them, then he/she should set the CMake variable `USE_SYSTEM_<PACKAGE>` to `FALSE.` For further details, please refer to [YCM Superbuild Manual for Developers](http://robotology.github.io/ycm/gh-pages/git-master/manual/ycm-superbuild.7.html#ycm-superbuild-manual-for-developers).
+
+## Dependencies CMake options
+The dependencies CMake options specify if the packages dependending on something installed in the system should be installed or not. All these options are named `ROBOTOLOGY_USES_<dependency>`.
+
+| CMake Option | Description | Default Value | Dependency-specific documentation |
+|:------------:|:-----------:|:-------------:|:---------------------------------:|
+| `ROBOTOLOGY_USES_GAZEBO`  | Include software and plugins that depend on the [Gazebo simulator](http://gazebosim.org/).  | `ON` on Linux and macOS, `OFF` on Windows   | [Documentation on Gazebo dependency.](#gazebo) |
+| `ROBOTOLOGY_USES_MATLAB`  | Include software and plugins that depend on the [Matlab](https://mathworks.com/products/matlab.html). | `OFF` | [Documentation on MATLAB dependency.](#matlab) |
+| `ROBOTOLOGY_USES_OCTAVE`  | Include software and plugins that depend on [Octave](https://www.gnu.org/software/octave/).  | `OFF` |  [Documentation on Octave dependency.](#octave) |
+| `ROBOTOLOGY_USES_OCULUS_SDK`  | Include software and plugins that depend on [Oculus](https://www.oculus.com/).  | `OFF` |  [Documentation on Oculus dependency.](#oculus) |
+| `ROBOTOLOGY_USES_CYBERITH_SDK`  | Include software and plugins that depend on [Cyberith](https://www.cyberith.com/).  | `OFF` |  [Documentation on Cyberith dependency.](#cyberith) |
+| `ROBOTOLOGY_USES_CFW2CAN`  | Include software and plugins that depend on [CFW2 CAN custom board](http://wiki.icub.org/wiki/CFW_card).  | `OFF` | No specific documentation is available for this  option, as it is just used with the [iCub Head profile](#icub-head), in which the related documentation can be found.  |
+| `ROBOTOLOGY_USES_XSENS_MVN_SDK`  | Include software and plugins that depend on [Xsens MVN SDK](https://www.xsens.com/products/).  | `OFF` | [Documentation on Xsens MVN dependency](#xsens)  |
+| `ROBOTOLOGY_USES_ESDCAN`  | Include software and plugins that depend on [Esd Can bus](http://wiki.icub.org/wiki/Esd_Can_Bus).  | `OFF` | [Documentation on ESDCAN dependency](#esdcan)  |
+
+
+Profile-specific documentation
+===================================
+
+## Core
+This profile is enabled by the `ROBOTOLOGY_ENABLE_CORE` CMake option.
+
+### System Dependencies
+The steps necessary to install the system dependencies of the Core profile are provided in
+operating system-specific installation documentation.
+
+### Check the installation
+Follow the steps in http://wiki.icub.org/wiki/Check_your_installation to verify if your installation was successful.
+
+## Robot Testing
+This profile is enabled by the `ROBOTOLOGY_ENABLE_ROBOT_TESTING` CMake option.
+
+On Windows, this profile creates some long paths during the build process. If you enable it, it is recommended  to
+keep the total path length of the robotology-superbuild build directory below 50 characters, or to enable the support for
+long path in Windows following the instructions in the [official Windows documentation](https://docs.microsoft.com/en-us/windows/win32/fileio/maximum-file-path-limitation#enable-long-paths-in-windows-10-version-1607-and-later).
+
+### System Dependencies
+The steps necessary to install the system dependencies of the Robot Testing profile are provided in
+operating system-specific installation documentation, and no additional required system dependency is required.
+
+### Check the installation
+If the profile has been correctly enabled and compiled, you should be able to run the `robottestingframework-testrunner` and `blocktestrunner` executable from the command line.
+
+
+## Dynamics
+This profile is enabled by the `ROBOTOLOGY_ENABLE_DYNAMICS` CMake option.
+
+### System Dependencies
+The steps necessary to install the system dependencies of the Dynamics profile are provided in
+operating system-specific installation documentation, and no additional required system dependency is required.
+
+The only optional system dependency of `wb-toolbox`, project part of this profile, is [tbeu/matio](https://github.com/tbeu/matio/).
+
+#### Linux
+
+Install matio using the following command:
+
+```
+sudo apt install libmatio-dev
+```
+
+#### macOS
+
+Install matio from `homebrew/core` using the following command:
+
+```
+brew install libmatio
+```
+
+#### Windows
+
+Install matio following the [installation instructions](https://github.com/tbeu/matio/#20-building) present in the repository.
+
+## iCub Head
+
+This profile is enabled by the `ROBOTOLOGY_ENABLE_ICUB_HEAD` CMake option. It is used in the system installed on iCub head,
+or if you are a developer that needs to access iCub hardware devices directly without passing through the iCub head.
+
+**Warning: the migration of existing iCub setups to use the robotology-superbuild is an ongoing process, and it is possible
+that your iCub still needs to be migrated. For any doubt, please get in contact with [icub-support](https://github.com/robotology/icub-support).**
+
+The configuration and compilation of this profile is supported on Linux, macOS and Windows systems.
+
+On Linux all the software necessary to communicate with boards contained in the robot, including CAN devices via [esd's CAN USB bridges](https://esd.eu/en/products/can-usb2), is already included.
+
+On Windows to communicate with CAN devices via [esd's CAN USB bridges](https://esd.eu/en/products/can-usb2) you need to set to ON the Windows-only CMake option [`ROBOTOLOGY_ENABLE_ESDCAN`](#esdcan).
+
+On macOS, communication with [esd's CAN USB bridges](https://esd.eu/en/products/can-usb2) is not supported and `diagnosticdaemon` is not available because of https://github.com/robotology/robotology-superbuild/issues/439.
+
+This section documents the iCub Head profile as any other profile, in a way agnostic of the specific machine in which it is installed. To get information on how to use the robotology-superbuild to install software on the machine mounted in the head of physical iCub robots, please check the documentation in [`doc/use-on-icub-head.md`](doc/use-on-icub-head.md).
+
+### System Dependencies
+The steps necessary to install the system dependencies of the iCub Head profile are provided in
+operating system-specific installation documentation, and no additional required system dependency is required.
+
+On old iCub systems equipped with the [CFW2 CAN board](http://wiki.icub.org/wiki/CFW_card), it may be necessary to have the cfw2can driver
+installed on the iCub head (it is tipically already pre-installed in the OS image installed in the system in the iCub head). In that
+case, you also need to enable the `ROBOTOLOGY_USES_CFW2CAN` option to compile the software that depends on cfw2can. In case of doubt,
+please always get in contact with [icub-support](https://github.com/robotology/icub-support).
+
+### Check the installation
+The `ROBOTOLOGY_ENABLE_ICUB_HEAD` installs several YARP devices for communicating directly with embedded boards of the iCub.
+To check if the installation was correct, you can list all the available YARP devices using the `yarpdev --list` command,
+and check if devices whose name is starting with `embObj` are present in the list. If those devices are present, then the installation
+should be working correctly. Furthermore, if the profile has been correctly enabled and compiled, you should be able to run the `diagnosticdaemon` executable from the command line.
+
+
+## iCub Basic Demos
+
+This profile is enabled by the `ROBOTOLOGY_ENABLE_BASIC_DEMOS` CMake option.
+
+### System Dependencies
+The steps necessary to install the system dependencies of the iCub Basic Demos profile are provided in
+operating system-specific installation documentation, and no additional required system dependency is required.
+
+### Check the installation
+If the iCub Basic Demos profile have been correctly installed, you should be able to find in your PATH and execute the `demoYoga` or `demoRedBall` executables.
+
+## Teleoperation
+This profile is enabled by the `ROBOTOLOGY_ENABLE_TELEOPERATION` CMake option.
+
+### System Dependencies
+To run a teleoperation scenario, with real robot or in simulation, at least we need a Windows machine and Linux/macOS machine. If you are using iCub, the linux/macOS source code can be placed on the robot head. The teleoperation dependencies are also related to the teleoperation scenario you want to perform.
+
+#### Teleoperation without Cyberith treadmill
+In this scenario, we only use [Oculus](#oculus) for teleoperation, and we do not use Cyberith treadmill. In this case, the user can give the command for robot walking through the Oculus joypads. The dependencies for this scenario are as following:
+* Windows: [Oculus](#oculus).
+* Linux/macOS: [walking controller](https://github.com/robotology/walking-controllers).
+
+#### Teleoperation with Cyberith treadmill
+In this scenario, we use both [Oculus](#oculus) and [cyberith treadmill](#cyberith) for teleopration. In this case, the user can give the command for robot walking through walking on cyberith treadmill. The dependencies for this scenario are as follwoing:
+* Windows: [Oculus](#oculus), [Cyberith](#cyberith).
+* Linux/macOS: [walking controller](https://github.com/robotology/walking-controllers).
+
+## Human Dynamics
+This profile is enabled by the `ROBOTOLOGY_ENABLE_HUMAN_DYNAMICS` CMake option.
+
+### System Dependencies
+To run a human dynamics estimation scenario, we need a Windows machine to install the Xsens suit SDK for getting the sensory information of the human motions from [Xsens](https://www.xsens.com/) and [ESD USB CAN driver](https://esd.eu/en/products/can-usb2) to get the FTShoes/FTSkShoes sensory information. Refer to [Xsens](#xsens) and [ESDCAN](#esdcan) for more information about the dependencies.
+
+## Event-driven
+This profile is enabled by the `ROBOTOLOGY_ENABLE_EVENT_DRIVEN` CMake option. For the moment, Windows is not a supported platform.
+
+### System Dependencies
+The steps necessary to install the system dependencies of the Event-driven profile are provided in
+operating system-specific installation documentation.
+
+Dependencies-specific documentation
+===================================
+
+## Gazebo
+Support for this dependency is enabled by the `ROBOTOLOGY_USES_GAZEBO` CMake option.
+This option is still set to `OFF` on Windows as it is still experimental.
+
+### System Dependencies
+On Linux or macOS, install Gazebo following the instructions available at http://gazebosim.org/tutorials?cat=install .
+Make sure to install also the development files, i.e. `libgazebo*-dev` on Debian/Ubuntu.
+
+On Windows, make sure that you install the Windows dependencies using the `vcpkg-robotology-with-gazebo.zip` archive and you set
+the correct enviroment variables as documented in [`robotology-superbuild-dependencies-vcpkg` documentation](https://github.com/robotology/robotology-superbuild-dependencies-vcpkg).
+
+### Check the installation
+Follow the steps in https://github.com/robotology/icub-gazebo#usage and/or https://github.com/robotology/icub-models#use-the-models-with-gazebo to check if the Gazebo-based iCub simulation works fine.
+
+## MATLAB
+Support for this dependency is enabled by the `ROBOTOLOGY_USES_MATLAB` CMake option.
+
+**Warning: differently from other optional dependencies, MATLAB is a commercial product that requires a license to be used.**
+
+### System Dependencies
+If MATLAB is not installed on your computer, install it following the instruction in https://mathworks.com/help/install/ .
+Once you installed it, make sure that the directory containing the `matlab` executable is present in the `PATH` of your system,
+as [CMake's FindMatlab module](https://cmake.org/cmake/help/v3.5/module/FindMatlab.html) relies on this to find MATLAB.
+
+**Note: tipically we assume that a user that selects the `ROBOTOLOGY_USES_MATLAB` also has Simulink installed in his computer.
+If this is not the case, you can enable the advanced CMake option `ROBOTOLOGY_NOT_USE_SIMULINK` to compile all the subprojects that depend on MATLAB, but disable the subprojecs that depend on Simulink (i.e. the
+[wb-toolbox](https://github.com/robotology/wb-toolbox) Simulink Library) if you have enabled the `ROBOTOLOGY_ENABLE_DYNAMICS` CMake options.**
+
+### Configuration
+If [MATLAB](mathworks.com/products/matlab/) is installed on your computer, the robotology-superbuild
+can install some projects that depend on MATLAB, in particular:
+ * the MATLAB bindings of the [iDynTree](https://github.com/robotology/idyntree) library,
+ * the native MATLAB bindings of YARP, contained in the [yarp-matlab-bindings](https://github.com/robotology-playground/yarp-matlab-bindings/) repository,
+ * the MATLAB bindings of qpOASES, contained in the [robotology-dependencies/qpOASES](https://github.com/robotology-dependencies/qpOASES) fork,
+ * The [WB-Toolbox](https://github.com/robotology/WB-Toolbox) Simulink toolbox,
+ * The [whole-body-controllers](https://github.com/robotology/whole-body-controllers) Simulink-based balancing controllers. Note that whole-body-controllers can be installed and compiled also without MATLAB, but its functionalities are reduced.
+
+To use this software, you can simply enable its compilation using the `ROBOTOLOGY_USES_MATLAB` CMake option.
+Once this software has been compiled by the superbuild, you just need to add some directories of the robotology-superbuild install (typically `$ROBOTOLOGY_SUPERBUILD_SOURCE_DIR/build/install`) to [the MATLAB path](https://www.mathworks.com/help/matlab/matlab_env/what-is-the-matlab-search-path.html).
+In particular you need to add to the MATLAB path the `$ROBOTOLOGY_SUPERBUILD_INSTALL_PREFIX/mex` directory and all the subdirectories `$ROBOTOLOGY_SUPERBUILD_INSTALL_PREFIX/share/WBToolbox`.
+
+#### Start MATLAB from the launcher or the application menu
+
+You could add this line to your MATLAB script that uses the robotology-superbuild matlab software, substituting `<ROBOTOLOGY_SUPERBUILD_INSTALL_PREFIX>` with the `install` folder inside the build directory of the superbuild:
+
+~~~
+    addpath(['<ROBOTOLOGY_SUPERBUILD_INSTALL_PREFIX>' '/mex'])
+    addpath(['<ROBOTOLOGY_SUPERBUILD_INSTALL_PREFIX>' '/mex/+wbc/simulink'])
+    addpath(['<ROBOTOLOGY_SUPERBUILD_INSTALL_PREFIX>' '/share/WBToolbox'])
+    addpath(['<ROBOTOLOGY_SUPERBUILD_INSTALL_PREFIX>' '/share/WBToolbox/images'])
+~~~
+
+Another way is to run (only once) the script `startup_robotology_superbuild.m` in the `$ROBOTOLOGY_SUPERBUILD_SOURCE_DIR/build` folder. This should be enough to permanently add the required paths for all the toolbox that use MATLAB.
+
+#### Start MATLAB from the terminal
+
+You can add the folders by modifying the `startup.m` or the `MATLABPATH` environmental variable [as described in official MATLAB documentation](https://www.mathworks.com/help/matlab/matlab_env/add-folders-to-matlab-search-path-at-startup.html).
+If you are using the `setup.sh` or `setup.bat` script for configuring your environment, `MATLABPATH` is automatically populated with these directories.
+
+For more info on configuring MATLAB software with the robotology-superbuild, please check the [wb-toolbox README](https://github.com/robotology/wb-toolbox).
+
+### Check the installation
+To verify that the compilation of `ROBOTOLOGY_USES_MATLAB` option was successful, try to run a script that uses
+the Matlab bindings of `yarp` and see if it executes without any error, for example:
+~~~matlab
+yarpVec = yarp.Vector();
+yarpVec.fromMatlab([1;2;3]);
+yarpVec.toMatlab()
+~~~~
+This scripts should print a `1 2 3` vector, but only if the `yarp` bindings are working correctly.
+
+
+## Octave
+Support for this dependency is enabled by the `ROBOTOLOGY_USES_OCTAVE` CMake option.
+
+### System Dependencies
+
+#### Linux
+Install octave and the necessary development files using the following command:
+~~~
+sudo apt-get install liboctave-dev
+~~~
+
+#### macOS
+Install octave using the following command:
+~~~
+brew install octave
+~~~
+
+#### Windows
+The `ROBOTOLOGY_USES_OCTAVE` option is not supported on Windows, see https://github.com/robotology/robotology-superbuild/issues/139 for more info.
+
+### Configuration
+Add the `$ROBOTOLOGY_SUPERBUILD_SOURCE_DIR/build/install/octave` directory to your [Octave path](https://www.gnu.org/software/octave/doc/interpreter/Manipulating-the-Load-Path.html).
+
+### Check the installation
+To verify that the compilation of `ROBOTOLOGY_USES_OCTAVE` option was successful, try to run a script that uses
+the Octave bindings of `yarp` and see if it executes without any error, for example:
+~~~matlab
+yarpVec = yarp.Vector();
+yarpVec.fromMatlab([1;2;3]);
+yarpVec.toMatlab()
+~~~~
+This scripts should print a `1 2 3` vector, but only if the `yarp` bindings are working correctly.
+
+
+## Python
+
+Support for this dependency is enabled by the `ROBOTOLOGY_USES_PYTHON` CMake option.
+
+### Check the installation
+Open a python interpreter and try to import modules, for example verify that `import yarp` works.
+
+## Oculus
+Support for this dependency is enabled by the `ROBOTOLOGY_USES_OCULUS_SDK` CMake option.
+
+**Warning: at the moment the Oculus SDK does not support macOS and Linux, so this option is only supported
+on Windows.**
+
+### System Dependencies
+To check and install the Oculus SDK please follow the steps for Oculus SDK mentioned [here](https://github.com/robotology/walking-teleoperation/blob/master/docs/Dependencies.md).
+
+### Configuration
+To configure the Oculus SDK follow the steps for Oculus SDK mentioned [here](https://github.com/robotology/walking-teleoperation/blob/master/docs/Dependencies.md).
+
+## Cyberith
+Support for this dependency is enabled by the `ROBOTOLOGY_USES_CYBERITH_SDK` CMake option.
+
+**Warning: at the moment the Cyberith SDK does not support macOS and Linux, so this option is only supported on Windows.**
+
+### System Dependencies
+To check and install the Cyberith SDK, please follow the steps for Cyberith SDK mentioned in [here](https://github.com/robotology/walking-teleoperation/blob/master/docs/Dependencies.md).
+
+### Configuration
+To configure the Cyberith SDK please follow the steps for Cyberith SDK mentioned in [here](https://github.com/robotology/walking-teleoperation/blob/master/docs/Dependencies.md).
+
+## Xsens
+Support for `ROBOTOLOGY_USES_XSENS_MVN_SDK` option is only enabled when the `ROBOTOLOGY_ENABLE_HUMAN_DYNAMICS` CMake option is set to ON.
+
+**Warning: at the moment the Xsens MVN SDK does not support macOS and Linux, so this option is only supported
+on Windows.**
+
+### System Dependencies
+To check and install the Xsens MVN SDK, please follow the steps for Xsens MVN SDK mentioned in [here](https://github.com/robotology/human-dynamics-estimation/wiki/Set-up-Machine-for-running-HDE#xsens-only-for-windows).
+
+### Configuration
+To configure the Xsens MVN SDK please follow the steps for Xsens MVN SDK mentioned in [here](https://github.com/robotology/human-dynamics-estimation/wiki/Set-up-Machine-for-running-HDE#xsens-only-for-windows).
+
+## ESDCAN
+The `ROBOTOLOGY_USES_ESDCAN` option is used to enable support for interacting with [esd CAN devices](https://esd.eu/en/products/can-usb2) on Windows. On Linux no special option is necessary, as the interconnection with esd CAN device is supported  using the default [SocketCAN](https://www.kernel.org/doc/Documentation/networking/can.txt) Linux driver. Use of [esd CAN devices](https://esd.eu/en/products/can-usb2) is not supported in macOS .
+
+### System Dependencies
+To compile the software enabled by the `ROBOTOLOGY_USES_ESDCAN` option (such as the `icub-main`'s [`esdcan`](http://www.icub.org/software_documentation/classyarp_1_1dev_1_1EsdCan.html) YARP driver) you need to install the esd CAN C library.
+This library is already contained  in the vcpkg installation installed by the `robotology-superbuild` dependencies installer.
+If you use a custom vcpkg installation, you can install the  `esdcan-binary` custom port from the [`robotology-vcpkg-ports`](https://github.com/robotology/robotology-vcpkg-ports) repo.
+
+To actually run the software that uses the esd CAN devices, you also need to install the esd CAN Driver for your specific esd CAN device.
+The installers for the esd CAN Driver should have been provided by esd, so ask for them to who provided you with the esd CAN device you want to use.
+
+### Configuration
+No additional configuration is required to use the software installed by the  `ROBOTOLOGY_USES_ESDCAN`
+
+### Check the installation
+Open a terminal, and check that amoung the device listed by `yarpdev --list` the `esdcan` YARP device is listed.


### PR DESCRIPTION
Over the years the README of the superbuild has grown complex. To make it more readable, let's move the CMake options-related documentation in another page, and just keep installation instructions in the main README. This change is in view of fixing https://github.com/robotology/robotology-superbuild/issues/505 .