### PR TITLE
2020.11 : Bump icub-models version to 1.18.1

### DIFF
--- a/releases/2020.11.yaml
+++ b/releases/2020.11.yaml
@@ -54,7 +54,7 @@ repositories:
   icub-models:
     type: git
     url: https://github.com/robotology/icub-models.git
-    version: v1.18.0
+    version: v1.18.1
   yarp-matlab-bindings:
     type: git
     url: https://github.com/robotology/yarp-matlab-bindings.git


### PR DESCRIPTION
Propagating the change https://github.com/robotology/robotology-superbuild/commit/8b8815db5c3d741e309a23dd978350ce04161998 from `releases/2020.11` branch to master. 