### PR TITLE
Move matio library dependency from Dynamic profile to the main superbuild dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ If there is any non-robotology dependency handled by the superbuild as it is not
 ### System Dependencies
 On Debian based systems (as Ubuntu) you can install the C++ toolchain, Git, CMake and Eigen (and other dependencies necessary for the software include in `robotology-superbuild`) using `apt-get`:
 ```
-sudo apt-get install build-essential cmake cmake-curses-gui coinor-libipopt-dev freeglut3-dev git libace-dev libboost-filesystem-dev libboost-system-dev libboost-thread-dev libdc1394-22-dev libedit-dev libeigen3-dev libgsl0-dev libjpeg-dev liblua5.1-dev libode-dev libopencv-dev libsdl1.2-dev libtinyxml-dev libv4l-dev libxml2-dev lua5.1 portaudio19-dev qml-module-qt-labs-folderlistmodel qml-module-qt-labs-settings qml-module-qtmultimedia qml-module-qtquick-controls qml-module-qtquick-dialogs qml-module-qtquick-window2 qml-module-qtquick2 qtbase5-dev qtdeclarative5-dev qtmultimedia5-dev swig
+sudo apt-get install build-essential cmake cmake-curses-gui coinor-libipopt-dev freeglut3-dev git libace-dev libboost-filesystem-dev libboost-system-dev libboost-thread-dev libdc1394-22-dev libedit-dev libeigen3-dev libgsl0-dev libjpeg-dev liblua5.1-dev libode-dev libopencv-dev libsdl1.2-dev libtinyxml-dev libv4l-dev libxml2-dev lua5.1 portaudio19-dev qml-module-qt-labs-folderlistmodel qml-module-qt-labs-settings qml-module-qtmultimedia qml-module-qtquick-controls qml-module-qtquick-dialogs qml-module-qtquick-window2 qml-module-qtquick2 qtbase5-dev qtdeclarative5-dev qtmultimedia5-dev swig libmatio-dev
 ```
 
 For what regards CMake, the robotology-superbuild requires CMake 3.16 . If you are using a recent Debian-based system such as Ubuntu 20.04, the default CMake is recent enough and you do not need to do further steps.
@@ -164,7 +164,7 @@ If for any reason you do not want to use the provided `setup.sh` script and you 
 ### System Dependencies
 To install the system dependencies, it is possible to use [Homebrew](http://brew.sh/):
 ```
-brew install ace boost cmake eigen gsl ipopt jpeg libedit opencv pkg-config portaudio qt5 sqlite swig tinyxml
+brew install ace boost cmake eigen gsl ipopt jpeg libedit opencv pkg-config portaudio qt5 sqlite swig tinyxml libmatio
 ```
 
 Since Qt5 is not symlinked in `/usr/local` by default in the homebrew formula, `Qt5_DIR` needs to be properly set to make sure that CMake-based projects are able to find Qt5.

--- a/doc/profiles.md
+++ b/doc/profiles.md
@@ -102,28 +102,6 @@ This profile is enabled by the `ROBOTOLOGY_ENABLE_DYNAMICS` CMake option.
 The steps necessary to install the system dependencies of the Dynamics profile are provided in
 operating system-specific installation documentation, and no additional required system dependency is required.
 
-The only optional system dependency of `wb-toolbox` and `matio-cpp`, projects part of this profile, is [tbeu/matio](https://github.com/tbeu/matio/).
-
-#### Linux
-
-Install matio using the following command:
-
-```
-sudo apt install libmatio-dev
-```
-
-#### macOS
-
-Install matio from `homebrew/core` using the following command:
-
-```
-brew install libmatio
-```
-
-#### Windows
-
-Install matio following the [installation instructions](https://github.com/tbeu/matio/#20-building) present in the repository.
-
 ## iCub Head
 
 This profile is enabled by the `ROBOTOLOGY_ENABLE_ICUB_HEAD` CMake option. It is used in the system installed on iCub head,


### PR DESCRIPTION
Following this issue, https://github.com/robotology/robotology-superbuild/issues/539, with this PR we move the `matio` library dependency from Dynamics profile to the main superbuild dependency.