### PR TITLE
GitHub Actions: Install mamba as documented in setup-miniconda

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,17 +42,17 @@ jobs:
 
     - uses: conda-incubator/setup-miniconda@v2
       with:
-        auto-update-conda: true
+        mamba-version: "*"
+        channels: conda-forge,defaults
+        channel-priority: true
 
     - name: Dependencies [Conda]
       shell: bash -l {0}
       run: |
-        # Install mamba (https://github.com/mamba-org/mamba) as first step 
-        conda install -c conda-forge mamba
         # Compilation related dependencies 
-        mamba install -c conda-forge cmake compilers make ninja pkg-config
+        mamba install cmake compilers make ninja pkg-config
         # Actual dependencies
-        mamba install -c conda-forge ace asio boost eigen gazebo glew glfw gsl ipopt libjpeg-turbo libmatio libode libxml2 opencv pkg-config portaudio qt sdl sdl2 sqlite tinyxml
+        mamba install ace asio boost eigen gazebo glew glfw gsl ipopt libjpeg-turbo libmatio libode libxml2 opencv pkg-config portaudio qt sdl sdl2 sqlite tinyxml
 
     # Additional dependencies useful only on Linux
     - name: Dependencies [Conda/Linux]
@@ -61,7 +61,7 @@ jobs:
       run: |
         # Additional dependencies only useful on Linux
         # See https://github.com/robotology/robotology-superbuild/issues/477
-        mamba install -c conda-forge expat-cos6-x86_64 freeglut libselinux-cos6-x86_64 libxau-cos6-x86_64 libxcb-cos6-x86_64 libxdamage-cos6-x86_64 libxext-cos6-x86_64 libxfixes-cos6-x86_64 libxxf86vm-cos6-x86_64 mesalib mesa-libgl-cos6-x86_64
+        mamba install expat-cos6-x86_64 freeglut libselinux-cos6-x86_64 libxau-cos6-x86_64 libxcb-cos6-x86_64 libxdamage-cos6-x86_64 libxext-cos6-x86_64 libxfixes-cos6-x86_64 libxxf86vm-cos6-x86_64 mesalib mesa-libgl-cos6-x86_64
 
     - name: Configure [Conda]
       # ROBOTOLOGY_ENABLE_ICUB_HEAD is disabled due to https://github.com/robotology/icub-main/issues/685


### PR DESCRIPTION
Switch to install mamba and conda-forge channels as documented in https://github.com/conda-incubator/setup-miniconda/tree/v2.0.1#example-6-mamba , instead of using an ad-hoc procedure, that probably is creating problem, see https://github.com/robotology/robotology-superbuild/issues/552 . 