### PR TITLE
Clone all the repos in the src directory instead of external and robotology

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Superbuild
 The `robotology-superbuild` is an infrastructure to simplify development and use of **open source research software** developed at the **[Italian Institute of Technology](https://iit.it/)**, in particular as part of the **[iCub project](https://icub.iit.it/)**. 
 
 ### Profiles and Optional Dependencies
-As a huge number of software projects are contained in the `robotology-superbuild`, and a tipical user is only interested in some of them, there are several **options** to instruct the superbuild on which packages should be built and which one should not be built. In particular, the robotology-superbuild is divided in different **profiles**, that specify the specific subset of robotology packages to build. You can read more on the available **profiles** and how to enabled them in the [`doc/profiles.md` documentation](doc/profiles.md). 
+As a huge number of software projects are contained in the `robotology-superbuild`, and a tipical user is only interested in some of them, there are several **options** to instruct the superbuild on which packages should be built and which one should not be built. In particular, the robotology-superbuild is divided in different **profiles**, that specify the specific subset of robotology packages to build. You can read more on the available **profiles** and how to enabled them in the [`doc/profiles.md` documentation](doc/profiles.md).
 
 Furthermore, some **dependencies** of software contained in the `robotology-superbuild` are either tricky to install or proprietary, and for this reason software that depends on those  optional dependencies can be **enabled** or **disabled** with specific options,as documented in [`doc/profiles.md#dependencies-specific-documentation`](doc/profiles.md#dependencies-specific-documentation).
 
@@ -106,11 +106,10 @@ The exact versions of the operating systems supported by the robotology-superbui
 Complete documentation on how to use a YCM-based superbuild is available in the [YCM documentation](http://robotology.github.io/ycm/gh-pages/git-master/manual/ycm-superbuild.7.html).
 
 When compiled from source, `robotology-superbuild` will download and build a number of software.
-For each project, the repository will be downloaded in the `robotology/<package_name>` subdirectory of the superbuild root. 
-The build directory for a given project will be instead the `robotology/<package_name>` subdirectory of the superbuild build directory. 
-All the software packages are installed using the `install` directory of the build as installation prefix.
+For each project, the repository will be downloaded in the `src/<package_name>` subdirectory of the superbuild root. 
+The build directory for a given project will be instead the `src/<package_name>` subdirectory of the superbuild build directory. 
+All the software packages are installed using the `install` directory of the build as installation prefix.s
 
-If there is any non-robotology dependency handled by the superbuild as it is not easily in the system, it will located in the `external` directory instead of the `robotology` one.
 
 ## Linux from source
 ### System Dependencies

--- a/cmake/BuildBlockFactory.cmake
+++ b/cmake/BuildBlockFactory.cmake
@@ -15,6 +15,6 @@ ycm_ep_helper(BlockFactory TYPE GIT
               REPOSITORY robotology/blockfactory.git
               TAG master
               COMPONENT dynamics
-              FOLDER robotology
+              FOLDER src
               CMAKE_ARGS -DUSES_MATLAB:BOOL=${BLOCKFACTORY_USES_SIMULINK}
                          -DENABLE_WARNINGS:BOOL=OFF)

--- a/cmake/BuildCppAD.cmake
+++ b/cmake/BuildCppAD.cmake
@@ -9,4 +9,4 @@ ycm_ep_helper(CppAD TYPE GIT
               REPOSITORY coin-or/CppAD.git
               TAG master
               COMPONENT external
-              FOLDER external)
+              FOLDER src)

--- a/cmake/BuildGazeboYARPPlugins.cmake
+++ b/cmake/BuildGazeboYARPPlugins.cmake
@@ -36,7 +36,7 @@ ycm_ep_helper(GazeboYARPPlugins TYPE GIT
                                 REPOSITORY robotology/gazebo-yarp-plugins.git
                                 TAG master
                                 COMPONENT core
-                                FOLDER robotology
+                                FOLDER src
                                 DEPENDS YARP
                                         gazebo
                                 CMAKE_ARGS -DGAZEBO_YARP_PLUGINS_HAS_OPENCV:BOOL=OFF)

--- a/cmake/BuildICUB.cmake
+++ b/cmake/BuildICUB.cmake
@@ -42,7 +42,7 @@ ycm_ep_helper(ICUB TYPE GIT
                    REPOSITORY robotology/icub-main.git
                    DEPENDS ${ICUB_DEPENDS}
                    COMPONENT iCub
-                   FOLDER robotology
+                   FOLDER src
                    CMAKE_ARGS -DICUB_INSTALL_WITH_RPATH:BOOL=ON
                    CMAKE_CACHE_ARGS -DENABLE_icubmod_cartesiancontrollerserver:BOOL=ON
                                     -DENABLE_icubmod_cartesiancontrollerclient:BOOL=ON

--- a/cmake/BuildICUBcontrib.cmake
+++ b/cmake/BuildICUBcontrib.cmake
@@ -12,4 +12,4 @@ ycm_ep_helper(ICUBcontrib TYPE GIT
                           REPOSITORY robotology/icub-contrib-common.git
                           DEPENDS YARP
                           COMPONENT iCub
-                          FOLDER robotology)
+                          FOLDER src)

--- a/cmake/BuildOsqpEigen.cmake
+++ b/cmake/BuildOsqpEigen.cmake
@@ -11,6 +11,6 @@ ycm_ep_helper(OsqpEigen TYPE GIT
               REPOSITORY robotology/osqp-eigen.git
               TAG master
               COMPONENT dynamics
-              FOLDER robotology
+              FOLDER src
               CMAKE_ARGS -DBUILD_TESTING:BOOL=OFF
               DEPENDS osqp)

--- a/cmake/BuildRobotTestingFramework.cmake
+++ b/cmake/BuildRobotTestingFramework.cmake
@@ -11,5 +11,5 @@ ycm_ep_helper(RobotTestingFramework TYPE GIT
                                     CMAKE_ARGS -DENABLE_LUA_PLUGIN:BOOL=${ROBOTOLOGY_USES_LUA}
                                                -DENABLE_PYTHON_PLUGIN:BOOL=OFF
                                     COMPONENT core
-                                    FOLDER robotology)
+                                    FOLDER src)
 

--- a/cmake/BuildUnicyclePlanner.cmake
+++ b/cmake/BuildUnicyclePlanner.cmake
@@ -12,5 +12,5 @@ ycm_ep_helper(UnicyclePlanner TYPE GIT
               REPOSITORY robotology/unicycle-footstep-planner.git
               TAG master
               COMPONENT dynamics
-              FOLDER robotology
+              FOLDER src
               DEPENDS iDynTree)

--- a/cmake/BuildWBToolbox.cmake
+++ b/cmake/BuildWBToolbox.cmake
@@ -16,7 +16,7 @@ ycm_ep_helper(WBToolbox TYPE GIT
               REPOSITORY robotology/wb-toolbox.git
               TAG master
               COMPONENT dynamics
-              FOLDER robotology
+              FOLDER src
               CMAKE_ARGS -DWBT_USES_MATLAB:BOOL=${ROBOTOLOGY_USES_MATLAB}
               DEPENDS YARP
                       ICUB

--- a/cmake/BuildYARP.cmake
+++ b/cmake/BuildYARP.cmake
@@ -49,7 +49,7 @@ ycm_ep_helper(YARP TYPE GIT
                    REPOSITORY robotology/yarp.git
                    TAG master
                    COMPONENT core
-                   FOLDER robotology
+                   FOLDER src
                    DEPENDS YCM
                            ACE
                            Eigen3

--- a/cmake/Buildbipedal-locomotion-framework.cmake
+++ b/cmake/Buildbipedal-locomotion-framework.cmake
@@ -33,7 +33,7 @@ ycm_ep_helper(bipedal-locomotion-framework TYPE GIT
               REPOSITORY dic-iit/bipedal-locomotion-framework.git
               TAG master
               COMPONENT dynamics
-              FOLDER robotology
+              FOLDER src
               CMAKE_ARGS -DBUILD_TESTING:BOOL=OFF
                          -DFRAMEWORK_USE_manif:BOOL=${ROBOTOLOGY_ENABLE_DYNAMICS_FULL_DEPS}
                          -DFRAMEWORK_USE_Qhull:BOOL=${ROBOTOLOGY_ENABLE_DYNAMICS_FULL_DEPS}

--- a/cmake/Buildblocktest-yarp-plugins.cmake
+++ b/cmake/Buildblocktest-yarp-plugins.cmake
@@ -13,7 +13,7 @@ ycm_ep_helper(blocktest-yarp-plugins TYPE GIT
               REPOSITORY robotology/blocktest-yarp-plugins.git
               TAG master
               COMPONENT core
-              FOLDER robotology
+              FOLDER src
               DEPENDS YARP
                       blocktestcore
               CMAKE_CACHE_ARGS -DENABLE_MSVC_WARNINGS:BOOL=OFF)

--- a/cmake/Buildblocktestcore.cmake
+++ b/cmake/Buildblocktestcore.cmake
@@ -9,5 +9,5 @@ ycm_ep_helper(blocktestcore TYPE GIT
               REPOSITORY robotology/blocktest.git
               TAG master
               COMPONENT core
-              FOLDER robotology
+              FOLDER src
               CMAKE_CACHE_ARGS -DENABLE_MSVC_WARNINGS:BOOL=OFF)

--- a/cmake/Buildcasadi.cmake
+++ b/cmake/Buildcasadi.cmake
@@ -12,7 +12,7 @@ ycm_ep_helper(casadi TYPE GIT
               REPOSITORY GiulioRomualdi/casadi.git
               TAG feature/support_osqp_0.6.0
               COMPONENT external
-              FOLDER external
+              FOLDER src
               CMAKE_ARGS -DWITH_IPOPT:BOOL=ON
                          -DWITH_OSQP:BOOL=ON
                          -DUSE_SYSTEM_WISE_OSQP:BOOL=ON

--- a/cmake/Buildcer.cmake
+++ b/cmake/Buildcer.cmake
@@ -13,6 +13,6 @@ ycm_ep_helper(cer TYPE GIT
               REPOSITORY robotology/cer.git
               TAG master
               COMPONENT R1
-              FOLDER robotology
+              FOLDER src
               DEPENDS YARP
                       ICUB)

--- a/cmake/Builddiagnosticdaemon.cmake
+++ b/cmake/Builddiagnosticdaemon.cmake
@@ -13,6 +13,6 @@ ycm_ep_helper(diagnosticdaemon TYPE GIT
               TAG master
               CMAKE_ARGS -DCOMPILE_WITHYARP_DEF:BOOL=ON
               COMPONENT core
-              FOLDER robotology
+              FOLDER src
               DEPENDS YARP
                       icub_firmware_shared)

--- a/cmake/Buildevent-driven.cmake
+++ b/cmake/Buildevent-driven.cmake
@@ -13,4 +13,4 @@ ycm_ep_helper(event-driven TYPE GIT
               DEPENDS YARP
                       YCM
               COMPONENT event-driven
-              FOLDER robotology)
+              FOLDER src)

--- a/cmake/Buildforcetorque-yarp-devices.cmake
+++ b/cmake/Buildforcetorque-yarp-devices.cmake
@@ -11,7 +11,7 @@ ycm_ep_helper(forcetorque-yarp-devices TYPE GIT
                                    REPOSITORY robotology/forcetorque-yarp-devices.git
                                    TAG master
                                    COMPONENT iCub
-                                   FOLDER robotology
+                                   FOLDER src
                                    DEPENDS YARP
                                    CMAKE_CACHE_ARGS -DENABLE_ftshoe:BOOL=ON)
 

--- a/cmake/Buildfunny-things.cmake
+++ b/cmake/Buildfunny-things.cmake
@@ -12,7 +12,7 @@ ycm_ep_helper(funny-things TYPE GIT
                            REPOSITORY robotology/funny-things.git
                            TAG master
                            COMPONENT ICUB_BASIC_DEMOS
-                           FOLDER robotology
+                           FOLDER src
                            DEPENDS YARP
                                    ICUB
                                    ICUBcontrib)

--- a/cmake/Buildhimrep.cmake
+++ b/cmake/Buildhimrep.cmake
@@ -15,4 +15,5 @@ ycm_ep_helper(himrep TYPE GIT
                      DEPENDS YARP
                              ICUB
                              ICUBcontrib
-                     COMPONENT robotology)
+                     COMPONENT robotology
+                     FOLDER src)

--- a/cmake/Buildhuman-dynamics-estimation.cmake
+++ b/cmake/Buildhuman-dynamics-estimation.cmake
@@ -15,7 +15,7 @@ ycm_ep_helper(human-dynamics-estimation TYPE GIT
               REPOSITORY robotology/human-dynamics-estimation.git
               TAG master
               COMPONENT human_dynamics
-              FOLDER robotology
+              FOLDER src
               DEPENDS iDynTree
                       YARP
                       wearables

--- a/cmake/Buildhuman-gazebo.cmake
+++ b/cmake/Buildhuman-gazebo.cmake
@@ -9,4 +9,4 @@ ycm_ep_helper(human-gazebo TYPE GIT
               REPOSITORY robotology/human-gazebo.git
               TAG master
               COMPONENT human_dynamics
-              FOLDER robotology)
+              FOLDER src)

--- a/cmake/BuildiDynTree.cmake
+++ b/cmake/BuildiDynTree.cmake
@@ -19,7 +19,7 @@ ycm_ep_helper(iDynTree TYPE GIT
               REPOSITORY robotology/idyntree.git
               TAG master
               COMPONENT dynamics
-              FOLDER robotology
+              FOLDER src
               CMAKE_ARGS -DIDYNTREE_USES_IPOPT:BOOL=ON
                          -DIDYNTREE_USES_YARP:BOOL=ON
                          -DIDYNTREE_USES_ICUB_MAIN:BOOL=ON
@@ -27,5 +27,4 @@ ycm_ep_helper(iDynTree TYPE GIT
                          -DIDYNTREE_USES_MATLAB:BOOL=${ROBOTOLOGY_USES_MATLAB}
                          -DIDYNTREE_USES_PYTHON:BOOL=${ROBOTOLOGY_USES_PYTHON}
                          -DIDYNTREE_USES_OCTAVE:BOOL=${ROBOTOLOGY_USES_OCTAVE}
-                         
               DEPENDS ${iDynTree_DEPENDS})

--- a/cmake/Buildicub-basic-demos.cmake
+++ b/cmake/Buildicub-basic-demos.cmake
@@ -12,7 +12,7 @@ ycm_ep_helper(icub-basic-demos TYPE GIT
                                REPOSITORY robotology/icub-basic-demos.git
                                TAG master
                                COMPONENT ICUB_BASIC_DEMOS
-                               FOLDER robotology
+                               FOLDER src
                                DEPENDS YARP
                                        ICUB
                                        ICUBcontrib)

--- a/cmake/Buildicub-gazebo.cmake
+++ b/cmake/Buildicub-gazebo.cmake
@@ -10,4 +10,4 @@ ycm_ep_helper(icub-gazebo
               REPOSITORY robotology/icub-gazebo.git
               TAG master
               COMPONENT iCub
-              FOLDER robotology)
+              FOLDER src)

--- a/cmake/Buildicub-grasp-demo.cmake
+++ b/cmake/Buildicub-grasp-demo.cmake
@@ -25,4 +25,4 @@ ycm_ep_helper(icub-grasp-demo  TYPE GIT
                                        himrep
                                        stereo-vision
                                COMPONENT grasping
-                               FOLDER robotology)
+                               FOLDER src)

--- a/cmake/Buildicub-models.cmake
+++ b/cmake/Buildicub-models.cmake
@@ -9,4 +9,4 @@ ycm_ep_helper(icub-models
               REPOSITORY robotology/icub-models.git
               TAG master
               COMPONENT iCub
-              FOLDER robotology)
+              FOLDER src)

--- a/cmake/Buildicub-tests.cmake
+++ b/cmake/Buildicub-tests.cmake
@@ -14,7 +14,7 @@ ycm_ep_helper(icub-tests TYPE GIT
               REPOSITORY robotology/icub-tests.git
               TAG master
               COMPONENT iCub
-              FOLDER robotology
+              FOLDER src
               DEPENDS RobotTestingFramework
                       YARP
                       ICUB)

--- a/cmake/Buildicub_firmware_shared.cmake
+++ b/cmake/Buildicub_firmware_shared.cmake
@@ -9,4 +9,4 @@ ycm_ep_helper(icub_firmware_shared TYPE GIT
                                    STYLE GITHUB
                                    REPOSITORY robotology/icub-firmware-shared.git
                                    COMPONENT iCub
-                                   FOLDER robotology)
+                                   FOLDER src)

--- a/cmake/Buildiol.cmake
+++ b/cmake/Buildiol.cmake
@@ -27,4 +27,4 @@ ycm_ep_helper(iol  TYPE GIT
                            stereo-vision
                            speech
                    COMPONENT IOL
-                   FOLDER robotology)
+                   FOLDER src)

--- a/cmake/Buildmanif.cmake
+++ b/cmake/Buildmanif.cmake
@@ -9,5 +9,5 @@ ycm_ep_helper(manif TYPE GIT
               REPOSITORY artivis/manif.git
               TAG master
               COMPONENT external
-              FOLDER external
+              FOLDER src
               CMAKE_ARGS -DBUILD_TESTING:BOOL=OFF -DBUILD_EXAMPLES:BOOL=OFF)

--- a/cmake/Buildmatio-cpp.cmake
+++ b/cmake/Buildmatio-cpp.cmake
@@ -8,5 +8,5 @@ ycm_ep_helper(matio-cpp TYPE GIT
               REPOSITORY dic-iit/matio-cpp.git
               TAG master
               COMPONENT dynamics
-              FOLDER robotology
+              FOLDER src
               CMAKE_ARGS -DBUILD_TESTING:BOOL=OFF)

--- a/cmake/Buildnavigation.cmake
+++ b/cmake/Buildnavigation.cmake
@@ -14,7 +14,7 @@ ycm_ep_helper(navigation TYPE GIT
                          REPOSITORY robotology/navigation.git
                          TAG master
                          COMPONENT navigation
-                         FOLDER robotology
+                         FOLDER src
                          DEPENDS YARP
                                  ICUB
                                  ICUBcontrib)

--- a/cmake/Buildosqp.cmake
+++ b/cmake/Buildosqp.cmake
@@ -8,6 +8,6 @@ ycm_ep_helper(osqp TYPE GIT
               STYLE GITHUB
               REPOSITORY oxfordcontrol/osqp.git
               TAG master
-              COMPONENT dynamics
-              FOLDER external
+              COMPONENT external
+              FOLDER src
               CMAKE_ARGS -DUNITTESTS:BOOL=OFF)

--- a/cmake/Buildqhull.cmake
+++ b/cmake/Buildqhull.cmake
@@ -9,4 +9,5 @@ ycm_ep_helper(qhull TYPE GIT
               REPOSITORY qhull/qhull.git
               TAG master
               COMPONENT external
+              FOLDER src
               CMAKE_ARGS -DCMAKE_POSITION_INDEPENDENT_CODE:BOOL=ON)

--- a/cmake/BuildqpOASES.cmake
+++ b/cmake/BuildqpOASES.cmake
@@ -26,4 +26,5 @@ ycm_ep_helper(qpOASES TYPE GIT
               REPOSITORY robotology-dependencies/qpOASES.git
               TAG master
               COMPONENT external
+              FOLDER src
               CMAKE_ARGS -DQPOASES_BUILD_BINDINGS_MATLAB:BOOL=${ROBOTOLOGY_USES_MATLAB})

--- a/cmake/BuildrfsmTools.cmake
+++ b/cmake/BuildrfsmTools.cmake
@@ -9,4 +9,4 @@ ycm_ep_helper(rfsmTools TYPE GIT
                         STYLE GITHUB
                         REPOSITORY robotology/rfsmTools.git
                         COMPONENT core
-                        FOLDER robotology)
+                        FOLDER src)

--- a/cmake/Buildrobots-configuration.cmake
+++ b/cmake/Buildrobots-configuration.cmake
@@ -22,5 +22,5 @@ ycm_ep_helper(robots-configuration TYPE GIT
                                    DEPENDS YARP
                                            ICUBcontrib
                                    COMPONENT iCub
-                                   FOLDER robotology
+                                   FOLDER src
                                    CMAKE_ARGS ${robots-configuration_CMAKE_ARGS})

--- a/cmake/Buildsegmentation.cmake
+++ b/cmake/Buildsegmentation.cmake
@@ -15,4 +15,5 @@ ycm_ep_helper(segmentation TYPE GIT
                            DEPENDS YARP
                                    ICUB
                                    ICUBcontrib
-                           COMPONENT robotology)
+                           COMPONENT robotology
+                           FOLDER src)

--- a/cmake/Buildspeech.cmake
+++ b/cmake/Buildspeech.cmake
@@ -17,4 +17,4 @@ ycm_ep_helper(speech TYPE GIT
                              ICUBcontrib
                      COMPONENT ICUB_BASIC_DEMOS
                      CMAKE_CACHE_ARGS -DBUILD_SVOX_SPEECH:BOOL=ON
-                     FOLDER robotology)
+                     FOLDER src)

--- a/cmake/Buildstereo-vision.cmake
+++ b/cmake/Buildstereo-vision.cmake
@@ -15,4 +15,5 @@ ycm_ep_helper(stereo-vision TYPE GIT
                             DEPENDS YARP
                                     ICUB
                                     ICUBcontrib
-                            COMPONENT robotology)
+                            COMPONENT robotology
+                            FOLDER src)

--- a/cmake/Buildwalking-controllers.cmake
+++ b/cmake/Buildwalking-controllers.cmake
@@ -27,5 +27,5 @@ ycm_ep_helper(walking-controllers TYPE GIT
               REPOSITORY robotology/walking-controllers
               TAG master
               COMPONENT dynamics
-              FOLDER robotology
+              FOLDER src
               DEPENDS ${walking-controllers_DEPENDS})

--- a/cmake/Buildwalking-teleoperation.cmake
+++ b/cmake/Buildwalking-teleoperation.cmake
@@ -13,7 +13,7 @@ ycm_ep_helper(walking-teleoperation TYPE GIT
               REPOSITORY robotology/walking-teleoperation.git
               TAG master
               COMPONENT teleoperation
-              FOLDER robotology
+              FOLDER src
               DEPENDS iDynTree
                       ICUB
                       YARP)

--- a/cmake/Buildwearables.cmake
+++ b/cmake/Buildwearables.cmake
@@ -17,7 +17,7 @@ ycm_ep_helper(wearables TYPE GIT
               REPOSITORY robotology/wearables.git
               TAG master
               COMPONENT human_dynamics
-              FOLDER robotology
+              FOLDER src
               DEPENDS YARP
                       iDynTree
               CMAKE_ARGS ${WEARABLES_CMAKE_ARGS})

--- a/cmake/Buildwhole-body-controllers.cmake
+++ b/cmake/Buildwhole-body-controllers.cmake
@@ -13,6 +13,6 @@ ycm_ep_helper(whole-body-controllers TYPE GIT
               REPOSITORY robotology/whole-body-controllers.git
               TAG master
               COMPONENT dynamics
-              FOLDER robotology
+              FOLDER src
               DEPENDS WBToolbox
                       qpOASES)

--- a/cmake/Buildwhole-body-estimators.cmake
+++ b/cmake/Buildwhole-body-estimators.cmake
@@ -20,5 +20,5 @@ ycm_ep_helper(whole-body-estimators TYPE GIT
               REPOSITORY robotology/whole-body-estimators.git
               TAG master
               COMPONENT dynamics
-              FOLDER robotology
+              FOLDER src
               DEPENDS ${whole-body-estimators_DEPENDS})

--- a/cmake/Buildyarp-device-ovrheadset.cmake
+++ b/cmake/Buildyarp-device-ovrheadset.cmake
@@ -12,5 +12,5 @@ ycm_ep_helper(yarp-device-ovrheadset TYPE GIT
               REPOSITORY robotology/yarp-device-ovrheadset.git
               TAG master
               COMPONENT iCub
-              FOLDER robotology
+              FOLDER src
               DEPENDS YARP)

--- a/cmake/Buildyarp-device-xsensmt.cmake
+++ b/cmake/Buildyarp-device-xsensmt.cmake
@@ -11,5 +11,5 @@ ycm_ep_helper(yarp-device-xsensmt TYPE GIT
               REPOSITORY robotology/yarp-device-xsensmt.git
               TAG master
               COMPONENT iCub
-              FOLDER robotology
+              FOLDER src
               DEPENDS YARP)

--- a/cmake/Buildyarp-matlab-bindings.cmake
+++ b/cmake/Buildyarp-matlab-bindings.cmake
@@ -12,7 +12,7 @@ ycm_ep_helper(yarp-matlab-bindings TYPE GIT
               REPOSITORY robotology/yarp-matlab-bindings.git
               TAG master
               COMPONENT core
-              FOLDER robotology
+              FOLDER src
               CMAKE_ARGS -DYARP_USES_MATLAB:BOOL=${ROBOTOLOGY_USES_MATLAB}
                          -DYARP_USES_OCTAVE:BOOL=${ROBOTOLOGY_USES_OCTAVE}
               DEPENDS YARP)

--- a/scripts/robotologyGitStatus.sh
+++ b/scripts/robotologyGitStatus.sh
@@ -20,7 +20,7 @@ getParentDir $script_dir
 
 superbuild_root="$DIR"
 
-subdirs="$superbuild_root/robotology $superbuild_root/external"
+subdirs="$superbuild_root/src"
 
 printGitStatus () {
     echo "--------------------------------------------"


### PR DESCRIPTION
This was discussed in https://github.com/robotology/robotology-superbuild/issues/333 . 
As this is kind an important change, it will be announced on https://github.com/robotology/QA before the PR is merged.