### PR TITLE
Bump CppAD version in ProjectsTags***.cmake to a relased version

### DIFF
--- a/cmake/ProjectsTagsStable.cmake
+++ b/cmake/ProjectsTagsStable.cmake
@@ -8,7 +8,7 @@ endmacro()
 set_tag(osqp_TAG v0.6.0)
 set_tag(manif_TAG 44bdfebff0fbc56cb189f680212257dc7f20ea58)
 set_tag(qhull_TAG v8.0.2)
-set_tag(CppAD_TAG 4aac52664de911af02cfade06131a9a6f6b48d7e)
+set_tag(CppAD_TAG 20210000.1)
 set_tag(casadi a26cd8ffba99052b74553eec1daeff640eea7e79)
 
 # Robotology projects

--- a/cmake/ProjectsTagsStable.cmake
+++ b/cmake/ProjectsTagsStable.cmake
@@ -8,7 +8,7 @@ endmacro()
 set_tag(osqp_TAG v0.6.0)
 set_tag(manif_TAG 44bdfebff0fbc56cb189f680212257dc7f20ea58)
 set_tag(qhull_TAG v8.0.2)
-set_tag(CppAD_TAG d885a2a2d02f5f6e52fb6620e0ced39abe60d5ba)
+set_tag(CppAD_TAG 20210000.2)
 set_tag(casadi a26cd8ffba99052b74553eec1daeff640eea7e79)
 
 # Robotology projects

--- a/cmake/ProjectsTagsStable.cmake
+++ b/cmake/ProjectsTagsStable.cmake
@@ -8,7 +8,7 @@ endmacro()
 set_tag(osqp_TAG v0.6.0)
 set_tag(manif_TAG 44bdfebff0fbc56cb189f680212257dc7f20ea58)
 set_tag(qhull_TAG v8.0.2)
-set_tag(CppAD_TAG 20210000.1)
+set_tag(CppAD_TAG b880f086f36effeb1d78a10054337499c058ecea)
 set_tag(casadi a26cd8ffba99052b74553eec1daeff640eea7e79)
 
 # Robotology projects

--- a/cmake/ProjectsTagsStable.cmake
+++ b/cmake/ProjectsTagsStable.cmake
@@ -8,7 +8,7 @@ endmacro()
 set_tag(osqp_TAG v0.6.0)
 set_tag(manif_TAG 44bdfebff0fbc56cb189f680212257dc7f20ea58)
 set_tag(qhull_TAG v8.0.2)
-set_tag(CppAD_TAG b880f086f36effeb1d78a10054337499c058ecea)
+set_tag(CppAD_TAG d885a2a2d02f5f6e52fb6620e0ced39abe60d5ba)
 set_tag(casadi a26cd8ffba99052b74553eec1daeff640eea7e79)
 
 # Robotology projects

--- a/cmake/ProjectsTagsUnstable.cmake
+++ b/cmake/ProjectsTagsUnstable.cmake
@@ -8,7 +8,7 @@ endmacro()
 set_tag(osqp_TAG v0.6.0)
 set_tag(manif_TAG 44bdfebff0fbc56cb189f680212257dc7f20ea58)
 set_tag(qhull_TAG v8.0.2)
-set_tag(CppAD_TAG 4aac52664de911af02cfade06131a9a6f6b48d7e)
+set_tag(CppAD_TAG 20210000.1)
 set_tag(casadi a26cd8ffba99052b74553eec1daeff640eea7e79)
 
 # Robotology projects

--- a/cmake/ProjectsTagsUnstable.cmake
+++ b/cmake/ProjectsTagsUnstable.cmake
@@ -8,7 +8,7 @@ endmacro()
 set_tag(osqp_TAG v0.6.0)
 set_tag(manif_TAG 44bdfebff0fbc56cb189f680212257dc7f20ea58)
 set_tag(qhull_TAG v8.0.2)
-set_tag(CppAD_TAG d885a2a2d02f5f6e52fb6620e0ced39abe60d5ba)
+set_tag(CppAD_TAG 20210000.2)
 set_tag(casadi a26cd8ffba99052b74553eec1daeff640eea7e79)
 
 # Robotology projects

--- a/cmake/ProjectsTagsUnstable.cmake
+++ b/cmake/ProjectsTagsUnstable.cmake
@@ -8,7 +8,7 @@ endmacro()
 set_tag(osqp_TAG v0.6.0)
 set_tag(manif_TAG 44bdfebff0fbc56cb189f680212257dc7f20ea58)
 set_tag(qhull_TAG v8.0.2)
-set_tag(CppAD_TAG 20210000.1)
+set_tag(CppAD_TAG b880f086f36effeb1d78a10054337499c058ecea)
 set_tag(casadi a26cd8ffba99052b74553eec1daeff640eea7e79)
 
 # Robotology projects

--- a/cmake/ProjectsTagsUnstable.cmake
+++ b/cmake/ProjectsTagsUnstable.cmake
@@ -8,7 +8,7 @@ endmacro()
 set_tag(osqp_TAG v0.6.0)
 set_tag(manif_TAG 44bdfebff0fbc56cb189f680212257dc7f20ea58)
 set_tag(qhull_TAG v8.0.2)
-set_tag(CppAD_TAG b880f086f36effeb1d78a10054337499c058ecea)
+set_tag(CppAD_TAG d885a2a2d02f5f6e52fb6620e0ced39abe60d5ba)
 set_tag(casadi a26cd8ffba99052b74553eec1daeff640eea7e79)
 
 # Robotology projects


### PR DESCRIPTION
20210000.1 was recently released, and the bipedal-locomotion-framework CI has been already tested with a master version of CppAD close to this release (see https://github.com/dic-iit/bipedal-locomotion-framework/actions). In this way, we can stop depending on a unreleased checkout for CppAD.