### PR TITLE
Change commands used to instll xquartz with homebrew cask

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -243,7 +243,6 @@ jobs:
       if: contains(matrix.os, 'macos')
       run: |
         cmake --version
-        brew cask install xquartz
         # Update homebrew 
         brew update
         # Workaround for https://github.com/robotology/robotology-superbuild/issues/571

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -250,6 +250,7 @@ jobs:
         # Workaround for https://github.com/robotology/robotology-superbuild/issues/565
         brew upgrade  python@3.9 || brew link --overwrite python@3.9
         brew upgrade
+        brew install --cask xquartz
         # Core dependencies
         brew install ace boost cmake eigen gsl ipopt jpeg libedit opencv pkg-config portaudio qt@5 sqlite swig tinyxml
         # ROBOTOLOGY_ENABLE_DYNAMICS dependencies


### PR DESCRIPTION
The GitHub Actions macOS has been failing with:
~~~
Error: Calling brew cask install is disabled! Use brew install [--cask] instead.
Error: Process completed with exit code 1.
~~~

I do not know the root cause of this, but I hope that this command was not actually necessary as we do not have it in the README, so I think we can try to remove it.