### PR TITLE
Fix assumed installation path of Python bindings

### DIFF
--- a/cmake/RobotologySuperbuildOptions.cmake
+++ b/cmake/RobotologySuperbuildOptions.cmake
@@ -19,7 +19,7 @@ option(ROBOTOLOGY_USES_PYTHON "Enable compilation of software that depend on Pyt
 
 ## Find the active version of Python
 find_package(Python COMPONENTS Interpreter)
-set(PYTHON_VERSION_PATH "python${Python_VERSION_MAJOR}.${Python_VERSION_MINOR}")
+set(PYTHON_VERSION_PATH "python${Python_VERSION_MAJOR}")
 
 ## Enable packages that depend on the Gazebo simulator
 if(WIN32)


### PR DESCRIPTION
The bindings where installed in `python2.7` for Python <= 2, but for Python >= 3 they are actually installed in `python3`. 

Fix https://github.com/robotology/robotology-superbuild/issues/428 . Thanks @torsten93 for reporting the issue. 