### PR TITLE
Use src folder also for YCM

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,7 +32,7 @@ endmacro()
 include(RobotologySuperbuildOptions)
 
 # Bootstrap YCM
-set(YCM_FOLDER robotology)
+set(YCM_FOLDER src)
 set(YCM_COMPONENT core)
 set(YCM_MINIMUM_VERSION 0.11.1)
 include(YCMBootstrap)


### PR DESCRIPTION
Leftover from https://github.com/robotology/robotology-superbuild/pull/556 . All the repos were now cloned in src, except for YCM.