### PR TITLE
In ICUB compilation set ENABLE_icubmod_socketcan to ON when appropriate

### DIFF
--- a/cmake/BuildICUB.cmake
+++ b/cmake/BuildICUB.cmake
@@ -37,6 +37,13 @@ else()
   set(ENABLE_icubmod_xsensmtx ${ROBOTOLOGY_ENABLE_ICUB_HEAD})
 endif()
 
+# Socketcan is only enabled on Linux, and if ROBOTOLOGY_ENABLE_ICUB_HEAD is enabled
+if (CMAKE_SYSTEM_NAME STREQUAL "Linux")
+  set(ENABLE_icubmod_socketcan ${ROBOTOLOGY_ENABLE_ICUB_HEAD})
+else()
+  set(ENABLE_icubmod_socketcan OFF)
+endif()
+
 ycm_ep_helper(ICUB TYPE GIT
                    STYLE GITHUB
                    REPOSITORY robotology/icub-main.git
@@ -71,5 +78,6 @@ ycm_ep_helper(ICUB TYPE GIT
                                     -DENABLE_icubmod_parametricCalibrator:BOOL=${ROBOTOLOGY_ENABLE_ICUB_HEAD}
                                     -DENABLE_icubmod_parametricCalibratorEth:BOOL=${ROBOTOLOGY_ENABLE_ICUB_HEAD}
                                     -DENABLE_icubmod_xsensmtx:BOOL=${ENABLE_icubmod_xsensmtx}
+                                    -DENABLE_icubmod_socketcan:BOOL=${ENABLE_icubmod_socketcan}
                                     -DICUB_USE_icub_firmware_shared:BOOL=${ROBOTOLOGY_ENABLE_ICUB_HEAD}
                                     -DICUBMAIN_COMPILE_SIMULATORS:BOOL=${ICUBMAIN_COMPILE_SIMULATORS})


### PR DESCRIPTION
In particular, this should be enabled if the `ROBOTOLOGY_ENABLE_ICUB_HEAD` option of superbuild is enabled and we are on Linux. 

The [`ROBOTOLOGY_ENABLE_ICUB_HEAD`  option](https://github.com/robotology/robotology-superbuild/blob/master/doc/profiles.md#icub-head) is meant to be enabled not only on the iCub head, but also for laptop of developers that need to communicate with internal iCub boards, and in that case if they are on Linux they need to have the `socketcan` YARP device if the want to communicate with CAN boards via the [ESD CAN-USB/2 device](https://esd.eu/en/products/can-usb2). 

This was actually already intended, as the documentation says (in https://github.com/robotology/robotology-superbuild/blame/v2020.11/doc/profiles.md#L137):
> On Linux all the software necessary to communicate with boards contained in the robot, including CAN devices via esd's CAN USB bridges, is already included.

However, this was not true, as `socketcan`  was not enabled. Thanks @violadelbono for noticing this. 