### PR TITLE
Remove gsl on Windows conda workaround in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,10 +79,6 @@ jobs:
       run: |
         # Workaround for https://github.com/conda-forge/freeglut-feedstock/issues/26
         mamba install freeglut==3.0.0
-        # Workaround for https://github.com/conda-forge/gsl-feedstock/pull/55
-        curl https://raw.githubusercontent.com/conda-forge/gsl-feedstock/af134d827b7e19992b9e034bf86ad7d4b4b67142/recipe/windows_shared.gsl_types.h -o gsl_types.h
-        cp gsl_types.h $CONDA_PREFIX/Library/include/gsl
-        rm gsl_types.h
         mkdir -p build
         cd build
         cmake -G"Visual Studio 16 2019" -C ${GITHUB_WORKSPACE}/.ci/initial-cache.gh.cmake -DNON_INTERACTIVE_BUILD:BOOL=TRUE -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}  ${{ matrix.project_tags_cmake_options }}  ..


### PR DESCRIPTION
As https://github.com/conda-forge/gsl-feedstock/pull/55 was merged, we don't need to manually patch the header file to fix https://github.com/conda-forge/gsl-feedstock/issues/50 .