### PR TITLE
Ignore src directory, not old robotology and external

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,5 @@ CTestTestfile.cmake
 *~
 /build*/
 *kdev*
-/external/
-/robotology/
+/src/
 *.user


### PR DESCRIPTION
Leftover from https://github.com/robotology/robotology-superbuild/pull/556 . The `src` was not ignored, while `robotology` and `external` were still ignored. 