### PR TITLE
Remove macOS 11.0 jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -166,7 +166,7 @@ jobs:
       fail-fast: false
       matrix:
         build_type: [Release]
-        os: [ubuntu-18.04, ubuntu-20.04, macos-10.15, macos-11.0, windows-2019]
+        os: [ubuntu-18.04, ubuntu-20.04, macos-10.15, windows-2019]
         project_tags: [Default, Unstable, LatestReleases, Release202102]
         include:
           - os: ubuntu-18.04
@@ -182,12 +182,6 @@ jobs:
             build_type: Debug
             cmake_generator: "Unix Makefiles"
           - os: macos-10.15
-            build_type: Release
-            cmake_generator: "Ninja"
-          - os: macos-11.0
-            build_type: Debug
-            cmake_generator: "Unix Makefiles"
-          - os: macos-11.0
             build_type: Release
             cmake_generator: "Ninja"
           - project_tags: Default


### PR DESCRIPTION
First step in the direction of https://github.com/robotology/robotology-superbuild/issues/597 . 

Having a nice subset of the combinations of macOS builds would be better, but apparently the logic with which GitHub Actions deals with the combinations has changed so doing that would require looking into that. As we never had problems just on 11.0 that were not on 10.15, I think we can first doing that.