### PR TITLE
Bump version of robotology-superbuild-dependencies-vcpkg to 0.6.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -266,7 +266,7 @@ jobs:
         # To avoid problems with non-relocatable packages, we unzip the archive exactly in the same directory
         # that has been used to create the pre-compiled archive
         cd C:/
-        wget https://github.com/robotology/robotology-superbuild-dependencies-vcpkg/releases/download/v0.5.0/vcpkg-robotology-with-gazebo.zip
+        wget https://github.com/robotology/robotology-superbuild-dependencies-vcpkg/releases/download/v0.6.0/vcpkg-robotology-with-gazebo.zip
         unzip vcpkg-robotology-with-gazebo.zip -d C:/
         rm vcpkg-robotology-with-gazebo.zip
 


### PR DESCRIPTION
Bump the version used in the CI.