### PR TITLE
Add dependency of blocktestcore on YCM

### DIFF
--- a/cmake/Buildblocktestcore.cmake
+++ b/cmake/Buildblocktestcore.cmake
@@ -4,10 +4,13 @@
 
 include(YCMEPHelper)
 
+find_or_build_package(YCM QUIET)
+
 ycm_ep_helper(blocktestcore TYPE GIT
               STYLE GITHUB
               REPOSITORY robotology/blocktest.git
               TAG master
               COMPONENT core
               FOLDER src
-              CMAKE_CACHE_ARGS -DENABLE_MSVC_WARNINGS:BOOL=OFF)
+              CMAKE_CACHE_ARGS -DENABLE_MSVC_WARNINGS:BOOL=OFF
+              DEPENDS YCM)


### PR DESCRIPTION
The YCM dependency was added in https://github.com/robotology/blocktest/commit/dce9197e5b58adf37697013a9736fc3cb0a246e6 but was never propagated here. 

We never realized this because by chance YCM always got compiled first and blocktestcore was lucky enough to find it. However, I noticed that the dependency was missing by experimenting with conda package generation in https://github.com/traversaro/robotology-superbuild/runs/1797950461 . While generating conda packages, each package is compiled in a sandbox where only the explicitly specified dependencies are available, and so there I noticed that blockfactory was not compiling without YCM.