### PR TITLE
Disable compilation of qpOASES MATLAB bindings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,3 +10,4 @@ The format of this document is based on [Keep a Changelog](https://keepachangelo
 
 ### Removed
 - The `icub-gazebo-wholebody` project was removed from the superbuild (https://github.com/robotology/robotology-superbuild/issues/543, https://github.com/robotology/robotology-superbuild/pull/555).
+- Support for compiling the `MATLAB` bindings of qpOASES have been removed (https://github.com/robotology/robotology-superbuild/pull/613).

--- a/cmake/BuildqpOASES.cmake
+++ b/cmake/BuildqpOASES.cmake
@@ -27,4 +27,4 @@ ycm_ep_helper(qpOASES TYPE GIT
               TAG master
               COMPONENT external
               FOLDER src
-              CMAKE_ARGS -DQPOASES_BUILD_BINDINGS_MATLAB:BOOL=${ROBOTOLOGY_USES_MATLAB})
+              CMAKE_ARGS -DQPOASES_BUILD_BINDINGS_MATLAB:BOOL=OFF)


### PR DESCRIPTION
As discussed in https://github.com/robotology/robotology-superbuild/issues/239#issuecomment-774983308 . qpOASES will still be compiled but just as a C++ library, such that it can be consumed by WB-Toolbox until https://github.com/robotology/wb-toolbox/issues/180 is fixed.