### PR TITLE
Enable IDYNTREE_USES_IRRLICHT option for iDynTree and bump released versions

### DIFF
--- a/.ci/install_debian.sh
+++ b/.ci/install_debian.sh
@@ -13,7 +13,7 @@ apt-get install -y clang valgrind ccache ninja-build
 apt-get install -y build-essential cmake cmake-curses-gui coinor-libipopt-dev freeglut3-dev git libace-dev libboost-filesystem-dev libboost-system-dev libboost-thread-dev libdc1394-22-dev libedit-dev libeigen3-dev libgsl0-dev libjpeg-dev liblua5.1-dev libode-dev libopencv-dev libsdl1.2-dev libtinyxml-dev libv4l-dev libxml2-dev lua5.1 portaudio19-dev qml-module-qt-labs-folderlistmodel qml-module-qt-labs-settings qml-module-qtmultimedia qml-module-qtquick-controls qml-module-qtquick-dialogs qml-module-qtquick-window2 qml-module-qtquick2 qtbase5-dev qtdeclarative5-dev qtmultimedia5-dev swig
 
 # Dynamics dependencies
-apt-get install -y libmatio-dev
+apt-get install -y libmatio-dev libirrlicht-dev
 
 # Python
 apt-get install -y python3-dev python3-numpy

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -249,7 +249,7 @@ jobs:
         # Core dependencies
         brew install ace boost cmake eigen gsl ipopt jpeg libedit opencv pkg-config portaudio qt@5 sqlite swig tinyxml
         # ROBOTOLOGY_ENABLE_DYNAMICS dependencies
-        brew install libmatio
+        brew install libmatio irrlicht
         # ROBOTOLOGY_ENABLE_DYNAMICS_FULL_DEPS (qhull and cppad are installed  with brew)
         brew install cppad qhull
         # ROBOTOLOGY_USES_GAZEBO dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ jobs:
         # Compilation related dependencies 
         mamba install cmake compilers make ninja pkg-config
         # Actual dependencies
-        mamba install ace asio boost eigen gazebo glew glfw gsl ipopt libjpeg-turbo libmatio libode libxml2 opencv pkg-config portaudio qt sdl sdl2 sqlite tinyxml
+        mamba install ace asio boost eigen gazebo glew glfw gsl ipopt irrlicht libjpeg-turbo libmatio libode libxml2 opencv pkg-config portaudio qt sdl sdl2 sqlite tinyxml
 
     # Additional dependencies useful only on Linux
     - name: Dependencies [Conda/Linux]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ The format of this document is based on [Keep a Changelog](https://keepachangelo
 
 ### Changed
 - All the subproject repos are now cloned in `robotology-superbuild/src` and the corresponding build directories are created in `robotology-superbuild/build/src` ( https://github.com/robotology/community/discussions/451 ).
-- iDynTree is now compieled with the `IDYNTREE_USES_IRRLICHT` option. As a consequence, [`irrlicht`](http://irrlicht.sourceforge.net/) has been added as a dependency on all supported platforms (https://github.com/robotology/robotology-superbuild/pull/618).
+- iDynTree is now compiled with the `IDYNTREE_USES_IRRLICHT` option. As a consequence, [`irrlicht`](http://irrlicht.sourceforge.net/) has been added as a dependency on all supported platforms (https://github.com/robotology/robotology-superbuild/pull/618).
 
 ### Removed
 - The `icub-gazebo-wholebody` project was removed from the superbuild (https://github.com/robotology/robotology-superbuild/issues/543, https://github.com/robotology/robotology-superbuild/pull/555).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format of this document is based on [Keep a Changelog](https://keepachangelo
 
 ### Changed
 - All the subproject repos are now cloned in `robotology-superbuild/src` and the corresponding build directories are created in `robotology-superbuild/build/src` ( https://github.com/robotology/community/discussions/451 ).
+- iDynTree is now compieled with the `IDYNTREE_USES_IRRLICHT` option. As a consequence, [`irrlicht`](http://irrlicht.sourceforge.net/) has been added as a dependency on all supported platforms (https://github.com/robotology/robotology-superbuild/pull/618).
 
 ### Removed
 - The `icub-gazebo-wholebody` project was removed from the superbuild (https://github.com/robotology/robotology-superbuild/issues/543, https://github.com/robotology/robotology-superbuild/pull/555).

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ All the software packages are installed using the `install` directory of the bui
 ### System Dependencies
 On Debian based systems (as Ubuntu) you can install the C++ toolchain, Git, CMake and Eigen (and other dependencies necessary for the software include in `robotology-superbuild`) using `apt-get`:
 ```
-sudo apt-get install build-essential cmake cmake-curses-gui coinor-libipopt-dev freeglut3-dev git libace-dev libboost-filesystem-dev libboost-system-dev libboost-thread-dev libdc1394-22-dev libedit-dev libeigen3-dev libgsl0-dev libjpeg-dev liblua5.1-dev libode-dev libopencv-dev libsdl1.2-dev libtinyxml-dev libv4l-dev libxml2-dev lua5.1 portaudio19-dev qml-module-qt-labs-folderlistmodel qml-module-qt-labs-settings qml-module-qtmultimedia qml-module-qtquick-controls qml-module-qtquick-dialogs qml-module-qtquick-window2 qml-module-qtquick2 qtbase5-dev qtdeclarative5-dev qtmultimedia5-dev swig libmatio-dev
+sudo apt-get install build-essential cmake cmake-curses-gui coinor-libipopt-dev freeglut3-dev git libace-dev libboost-filesystem-dev libboost-system-dev libboost-thread-dev libdc1394-22-dev libedit-dev libeigen3-dev libgsl0-dev libjpeg-dev liblua5.1-dev libode-dev libopencv-dev libsdl1.2-dev libtinyxml-dev libv4l-dev libxml2-dev lua5.1 portaudio19-dev qml-module-qt-labs-folderlistmodel qml-module-qt-labs-settings qml-module-qtmultimedia qml-module-qtquick-controls qml-module-qtquick-dialogs qml-module-qtquick-window2 qml-module-qtquick2 qtbase5-dev qtdeclarative5-dev qtmultimedia5-dev swig libmatio-dev libirrlicht-dev
 ```
 
 For what regards CMake, the robotology-superbuild requires CMake 3.16 . If you are using a recent Debian-based system such as Ubuntu 20.04, the default CMake is recent enough and you do not need to do further steps.
@@ -166,7 +166,7 @@ If for any reason you do not want to use the provided `setup.sh` script and you 
 ### System Dependencies
 To install the system dependencies, it is possible to use [Homebrew](http://brew.sh/):
 ```
-brew install ace boost cmake eigen gsl ipopt jpeg libedit opencv pkg-config portaudio qt@5 sqlite swig tinyxml libmatio
+brew install ace boost cmake eigen gsl ipopt jpeg libedit opencv pkg-config portaudio qt@5 sqlite swig tinyxml libmatio irrlicht
 ```
 
 Since Qt5 is not symlinked in `/usr/local` by default in the homebrew formula, `Qt5_DIR` needs to be properly set to make sure that CMake-based projects are able to find Qt5.

--- a/cmake/BuildiDynTree.cmake
+++ b/cmake/BuildiDynTree.cmake
@@ -24,6 +24,7 @@ ycm_ep_helper(iDynTree TYPE GIT
                          -DIDYNTREE_USES_YARP:BOOL=ON
                          -DIDYNTREE_USES_ICUB_MAIN:BOOL=ON
                          -DIDYNTREE_USES_OSQPEIGEN:BOOL=ON
+                         -DIDYNTREE_USES_IRRLICHT:BOOL=ON
                          -DIDYNTREE_USES_MATLAB:BOOL=${ROBOTOLOGY_USES_MATLAB}
                          -DIDYNTREE_USES_PYTHON:BOOL=${ROBOTOLOGY_USES_PYTHON}
                          -DIDYNTREE_USES_OCTAVE:BOOL=${ROBOTOLOGY_USES_OCTAVE}

--- a/doc/vcpkg-dependencies.md
+++ b/doc/vcpkg-dependencies.md
@@ -3,7 +3,7 @@
 If you prefer to install dependencies of the `robotology-superbuild` on your own existing [`vcpkg`](https://github.com/microsoft/vcpkg) installation,
 the ports that are required are the following: 
 ~~~
-./vcpkg.exe install --triplet x64-windows ace asio boost-asio boost-any boost-bind boost-date-time boost-filesystem boost-format boost-interprocess boost-iostreams boost-program-options boost-property-tree boost-regex boost-smart-ptr boost-system boost-thread boost-variant boost-uuid freeglut gsl eigen3 glew glfw3 ode openssl libxml2 libjpeg-turbo eigen3 opencv portaudio matio sdl1 sdl2 qt5-base[latest] qt5-declarative qt5-multimedia qt5-quickcontrols qt5-quickcontrols2 sqlite3[core,tool]
+./vcpkg.exe install --triplet x64-windows ace asio boost-asio boost-any boost-bind boost-date-time boost-filesystem boost-format boost-interprocess boost-iostreams boost-program-options boost-property-tree boost-regex boost-smart-ptr boost-system boost-thread boost-variant boost-uuid freeglut gsl eigen3 glew glfw3 ode openssl libxml2 libjpeg-turbo eigen3 opencv portaudio matio sdl1 sdl2 qt5-base[latest] qt5-declarative qt5-multimedia qt5-quickcontrols qt5-quickcontrols2 sqlite3[core,tool] irrlicht
 ~~~
 
 Furthermore, we also require the custom `ipopt-binary` and `esdcan-binary` ports that are available in the [`robotology/robotology-vcpkg-ports`](https://github.com/robotology/robotology-vcpkg-ports) repo.

--- a/releases/2021.02.yaml
+++ b/releases/2021.02.yaml
@@ -6,11 +6,11 @@ repositories:
   osqp:
     type: git
     url: https://github.com/oxfordcontrol/osqp.git
-    version: v0.6.0
+    version: v0.6.2
   manif:
     type: git
     url: https://github.com/artivis/manif.git
-    version: 44bdfebff0fbc56cb189f680212257dc7f20ea58
+    version: 0.0.3
   qhull:
     type: git
     url: https://github.com/qhull/qhull.git
@@ -78,7 +78,7 @@ repositories:
   iDynTree:
     type: git
     url: https://github.com/robotology/idyntree.git
-    version: v2.0.1
+    version: v3.0.0
   BlockFactory:
     type: git
     url: https://github.com/robotology/blockfactory.git
@@ -98,7 +98,7 @@ repositories:
   walking-controllers:
     type: git
     url: https://github.com/robotology/walking-controllers.git
-    version: v0.3.3
+    version: v0.4.1
   icub-gazebo-wholebody:
     type: git
     url: https://github.com/robotology/icub-gazebo-wholebody.git
@@ -114,7 +114,7 @@ repositories:
   walking-teleoperation:
     type: git
     url: https://github.com/robotology/walking-teleoperation.git
-    version: v0.2.0
+    version: 99e8c5e6e5d91bbe7ef6e02ceb7a0c599b3e19fd
   forcetorque-yarp-devices:
     type: git
     url: https://github.com/robotology/forcetorque-yarp-devices.git
@@ -122,11 +122,11 @@ repositories:
   wearables:
     type: git
     url: https://github.com/robotology/wearables.git
-    version: v1.1.1
+    version: v1.2.0
   human-dynamics-estimation:
     type: git
     url: https://github.com/robotology/human-dynamics-estimation.git
-    version: v2.1.0
+    version: v2.2.0
   human-gazebo:
     type: git
     url: https://github.com/robotology/human-gazebo.git
@@ -163,3 +163,15 @@ repositories:
     type: git
     url: https://github.com/dic-iit/bipedal-locomotion-framework.git
     version: 46d8f68c51fad71ae06db8686fa88218f7404923
+  LieGroupControllers:
+    type: git
+    url: https://github.com/dic-iit/lie-group-controllers.git
+    version: v0.0.1
+  event-driven:
+    type: git
+    url: https://github.com/robotology/event-driven.git
+    version: v1.5
+  matio-cpp:
+    type: git
+    url: https://github.com/dic-iit/matio-cpp.git
+    version: v0.1.0

--- a/releases/2021.02.yaml
+++ b/releases/2021.02.yaml
@@ -110,7 +110,7 @@ repositories:
   whole-body-estimators:
     type: git
     url: https://github.com/robotology/whole-body-estimators.git
-    version: v0.3.0
+    version: cc8ffb83375a2d410b225f4fa67aee4a29074b42
   walking-teleoperation:
     type: git
     url: https://github.com/robotology/walking-teleoperation.git

--- a/releases/latest.releases.yaml
+++ b/releases/latest.releases.yaml
@@ -6,11 +6,11 @@ repositories:
   osqp:
     type: git
     url: https://github.com/oxfordcontrol/osqp.git
-    version: v0.6.0
+    version: v0.6.2
   manif:
     type: git
     url: https://github.com/artivis/manif.git
-    version: 44bdfebff0fbc56cb189f680212257dc7f20ea58
+    version: v0.0.3
   qhull:
     type: git
     url: https://github.com/qhull/qhull.git
@@ -18,7 +18,7 @@ repositories:
   CppAD:
     type: git
     url: https://github.com/coin-or/CppAD.git
-    version: 72fde5fc783c9d85a6d2453631f0b8c3f4159fe1
+    version: 4aac52664de911af02cfade06131a9a6f6b48d7e
   casadi:
     type: git
     url: https://github.com/GiulioRomualdi/casadi.git
@@ -78,7 +78,7 @@ repositories:
   iDynTree:
     type: git
     url: https://github.com/robotology/idyntree.git
-    version: v2.0.2
+    version: v3.0.0
   BlockFactory:
     type: git
     url: https://github.com/robotology/blockfactory.git
@@ -98,7 +98,7 @@ repositories:
   walking-controllers:
     type: git
     url: https://github.com/robotology/walking-controllers.git
-    version: v0.4.0
+    version: v0.4.1
   icub-gazebo-wholebody:
     type: git
     url: https://github.com/robotology/icub-gazebo-wholebody.git
@@ -114,7 +114,7 @@ repositories:
   walking-teleoperation:
     type: git
     url: https://github.com/robotology/walking-teleoperation.git
-    version: v0.2.0
+    version: 99e8c5e6e5d91bbe7ef6e02ceb7a0c599b3e19fd
   forcetorque-yarp-devices:
     type: git
     url: https://github.com/robotology/forcetorque-yarp-devices.git
@@ -126,7 +126,7 @@ repositories:
   human-dynamics-estimation:
     type: git
     url: https://github.com/robotology/human-dynamics-estimation.git
-    version: v2.1.0
+    version: v2.2.0
   human-gazebo:
     type: git
     url: https://github.com/robotology/human-gazebo.git
@@ -170,5 +170,8 @@ repositories:
   event-driven:
     type: git
     url: https://github.com/robotology/event-driven.git
-    version: 62523c05032f7b56c174a882e594cefd036f7590
-
+    version: v1.5
+  matio-cpp:
+    type: git
+    url: https://github.com/dic-iit/matio-cpp.git
+    version: v0.1.0

--- a/releases/latest.releases.yaml
+++ b/releases/latest.releases.yaml
@@ -110,7 +110,7 @@ repositories:
   whole-body-estimators:
     type: git
     url: https://github.com/robotology/whole-body-estimators.git
-    version: v0.3.0
+    version: cc8ffb83375a2d410b225f4fa67aee4a29074b42
   walking-teleoperation:
     type: git
     url: https://github.com/robotology/walking-teleoperation.git

--- a/releases/latest.releases.yaml
+++ b/releases/latest.releases.yaml
@@ -10,7 +10,7 @@ repositories:
   manif:
     type: git
     url: https://github.com/artivis/manif.git
-    version: v0.0.3
+    version: 0.0.3
   qhull:
     type: git
     url: https://github.com/qhull/qhull.git


### PR DESCRIPTION
`IDYNTREE_USES_IRRLICHT` is quite used in the context of the IIT's ANA Avatar XPRIZE, and after the fix in iDynTree 3 to support meshes specified by `package://` in URDF and mouse control, it is a much more useful tool in general, so it make sense to enable it by default.

As iDynTree support for finding the irrlicht installed by vcpkg is only in iDynTree 3, we also bump a few dependencies in latest release.