### PR TITLE
Set GAZEBO_YARP_PLUGINS_HAS_OPENCV to ON in gazebo-yarp-plugins compilation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format of this document is based on [Keep a Changelog](https://keepachangelo
 
 ### Changed
 - All the subproject repos are now cloned in `robotology-superbuild/src` and the corresponding build directories are created in `robotology-superbuild/build/src` ( https://github.com/robotology/community/discussions/451 ).
+- The `GAZEBO_YARP_PLUGINS_HAS_OPENCV` CMake option of `gazebo-yarp-plugins` is now set to `ON` (https://github.com/robotology/robotology-superbuild/pull/619).
 
 ### Removed
 - The `icub-gazebo-wholebody` project was removed from the superbuild (https://github.com/robotology/robotology-superbuild/issues/543, https://github.com/robotology/robotology-superbuild/pull/555).

--- a/cmake/BuildGazeboYARPPlugins.cmake
+++ b/cmake/BuildGazeboYARPPlugins.cmake
@@ -39,4 +39,4 @@ ycm_ep_helper(GazeboYARPPlugins TYPE GIT
                                 FOLDER src
                                 DEPENDS YARP
                                         gazebo
-                                CMAKE_ARGS -DGAZEBO_YARP_PLUGINS_HAS_OPENCV:BOOL=OFF)
+                                CMAKE_ARGS -DGAZEBO_YARP_PLUGINS_HAS_OPENCV:BOOL=ON)


### PR DESCRIPTION
I was looking into some Dockerfiles used for https://robot-bazaar.iit.it/homepage, and I noticed that there were a few workaround for enabling the GAZEBO_YARP_PLUGINS_HAS_OPENCV  option in gazebo-yarp-plugins compilation. However, I don't remember nor see any reason why that options should be disabled: OpenCV is a dependency of the `Core` profile of the robotology-superbuild, and so enabling  this option just take a bit of space more. 

