### PR TITLE
robotologyUpdateLatestReleases: add message when checking for a new version of a package

### DIFF
--- a/scripts/robotologyUpdateLatestReleases.sh
+++ b/scripts/robotologyUpdateLatestReleases.sh
@@ -59,6 +59,8 @@ updateLatestRelease () {
     is_contained=$?
     if [ $is_contained == 1 ]
     then
+       # Printing package name to simplify debugging for errors
+        echo "Checking if a new release of ${package_name} is available"
         # Extract latest tag
         latest_tag=`git describe --abbrev=0 --tags`
         # Update latest tag in latest-release.yaml file,


### PR DESCRIPTION
This simplifies understanding to which package an error is related to. This is related to https://github.com/robotology/robotology-superbuild/issues/605, even if it does not address it in full.