### PR TITLE
GitHub Actions CI: On Windows build on C:\

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -194,6 +194,25 @@ jobs:
             project_tags_cmake_options: "-DROBOTOLOGY_PROJECT_TAGS=Custom -DROBOTOLOGY_PROJECT_TAGS_CUSTOM_FILE=${GITHUB_WORKSPACE}/releases/2021.02.yaml"
     steps:
     - uses: actions/checkout@master
+    
+    - name: Move robotology-superbuild in C under Windows
+      if: contains(matrix.os, 'windows')
+      shell: bash
+      run: |
+        ls /d/
+        cp -r ${GITHUB_WORKSPACE} /c/
+        
+    - name: Define ROBOTOLOGY_SUPERBUILD_SOURCE_DIR 
+      if: contains(matrix.os, 'windows')
+      shell: bash
+      run: |
+        echo "ROBOTOLOGY_SUPERBUILD_SOURCE_DIR=/c/robotology-superbuild" >> $GITHUB_ENV
+
+    - name: Define ROBOTOLOGY_SUPERBUILD_SOURCE_DIR 
+      if: contains(matrix.os, 'macos') || contains(matrix.os, 'ubuntu')
+      shell: bash
+      run: |
+        echo "ROBOTOLOGY_SUPERBUILD_SOURCE_DIR=${GITHUB_WORKSPACE}" >> $GITHUB_ENV
 
     - name: Check free space
       shell: bash
@@ -231,12 +250,14 @@ jobs:
     - name: Dependencies [Ubuntu]
       if: contains(matrix.os, 'ubuntu')
       run: |
+        cd $ROBOTOLOGY_SUPERBUILD_SOURCE_DIR
         chmod +x ./.ci/install_debian.sh
         sudo ./.ci/install_debian.sh
 
     - name: Dependencies [macOS]
       if: contains(matrix.os, 'macos')
       run: |
+        cd ${ROBOTOLOGY_SUPERBUILD_SOURCE_DIR}
         cmake --version
         # Update homebrew 
         brew update
@@ -261,6 +282,7 @@ jobs:
     - name: Dependencies [Windows]
       if: contains(matrix.os, 'windows')
       run: |
+        cd ${ROBOTOLOGY_SUPERBUILD_SOURCE_DIR}
         # To avoid spending a huge time compiling vcpkg dependencies, we download an archive  that comes precompiled with all the ports that we need 
         choco install -y wget unzip
         # To avoid problems with non-relocatable packages, we unzip the archive exactly in the same directory
@@ -278,13 +300,15 @@ jobs:
       if: contains(matrix.os, 'macos') || contains(matrix.os, 'ubuntu')
       shell: bash
       run: |
+        cd ${ROBOTOLOGY_SUPERBUILD_SOURCE_DIR}
         mkdir -p build
         cd build
-        cmake -C ${GITHUB_WORKSPACE}/.ci/initial-cache.gh.cmake -G"${{ matrix.cmake_generator }}" -DYCM_BOOTSTRAP_VERBOSE=ON -DNON_INTERACTIVE_BUILD:BOOL=TRUE -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} ${{ matrix.project_tags_cmake_options }} ..
+        cmake -C ${ROBOTOLOGY_SUPERBUILD_SOURCE_DIR}/.ci/initial-cache.gh.cmake -G"${{ matrix.cmake_generator }}" -DYCM_BOOTSTRAP_VERBOSE=ON -DNON_INTERACTIVE_BUILD:BOOL=TRUE -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} ${{ matrix.project_tags_cmake_options }} ..
 
     - name: Disable macOS unsupported options
       if: contains(matrix.os, 'macos')
       run: |
+        cd ${ROBOTOLOGY_SUPERBUILD_SOURCE_DIR}
         cd build
         # Disable ROBOTOLOGY_USES_PYTHON in macOS
         cmake -DROBOTOLOGY_USES_OCTAVE:BOOL=OFF -DROBOTOLOGY_USES_PYTHON:BOOL=OFF .
@@ -293,12 +317,13 @@ jobs:
       if: contains(matrix.os, 'windows')
       shell: bash
       run: |
+        cd ${ROBOTOLOGY_SUPERBUILD_SOURCE_DIR}
         # Make sure that Gazebo packages can be found by CMake
         source /c/robotology/scripts/setup-deps.sh
         mkdir -p build
         cd build
         # ROBOTOLOGY_ENABLE_TELEOPERATION is OFF as a workaround for https://github.com/robotology/robotology-superbuild/issues/472
-        cmake -C ${GITHUB_WORKSPACE}/.ci/initial-cache.gh.cmake -A x64 -DCMAKE_TOOLCHAIN_FILE=C:/robotology/vcpkg/scripts/buildsystems/vcpkg.cmake -DYCM_BOOTSTRAP_VERBOSE=ON -DYCM_EP_INSTALL_DIR=C:/robotology/robotology -DNON_INTERACTIVE_BUILD:BOOL=TRUE -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}  ${{ matrix.project_tags_cmake_options }} ..
+        cmake -C ${ROBOTOLOGY_SUPERBUILD_SOURCE_DIR}/.ci/initial-cache.gh.cmake -A x64 -DCMAKE_TOOLCHAIN_FILE=C:/robotology/vcpkg/scripts/buildsystems/vcpkg.cmake -DYCM_BOOTSTRAP_VERBOSE=ON -DYCM_EP_INSTALL_DIR=C:/robotology/robotology -DNON_INTERACTIVE_BUILD:BOOL=TRUE -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}  ${{ matrix.project_tags_cmake_options }} ..
 
 
     - name: Build  [Ubuntu&macOS]
@@ -319,6 +344,7 @@ jobs:
       if: github.event_name == 'release' && matrix.project_tags == 'Default' && contains(matrix.os, 'windows')
       shell: bash
       run: |
+        cd ${ROBOTOLOGY_SUPERBUILD_SOURCE_DIR}
         cd build
         # Make sure that vcpkg's ace .dll are on the PATH
         source /c/robotology/scripts/setup-deps.sh
@@ -330,6 +356,7 @@ jobs:
       if: contains(matrix.os, 'windows')
       shell: bash
       run: |
+        cd ${ROBOTOLOGY_SUPERBUILD_SOURCE_DIR} 
         cd build
         # Make sure that vcpkg's ace .dll are on the PATH
         source /c/robotology/scripts/setup-deps.sh
@@ -337,7 +364,7 @@ jobs:
         # Cleanup build directories to avoid to fill the disk
         rm -rf ./robotology
 
-    # Just for release builds we gerate the installer
+    # Just for release builds we generate the installer
     - name: Generate installer [Windows]
       if: github.event_name == 'release' && matrix.project_tags == 'Default' && matrix.os == 'windows-2019'
       shell: bash
@@ -351,7 +378,7 @@ jobs:
         # that has more space of the D:\ drive in GitHub Actions
         mkdir /c/build-installer-full
         cd /c/build-installer-full
-        cmake -A x64 -DRI_BUILD_FULL_INSTALLER:BOOL=ON ${GITHUB_WORKSPACE}/packaging/windows
+        cmake -A x64 -DRI_BUILD_FULL_INSTALLER:BOOL=ON ${ROBOTOLOGY_SUPERBUILD_SOURCE_DIR}/packaging/windows
         cmake --build . --config Release --target PACKAGE
         # Move installer in installer directory with a fixed name
         mv *.exe /c/robotology-full-installer-win64.exe
@@ -360,7 +387,7 @@ jobs:
         rm -rf /c/build-installer-full
         mkdir /c/build-installer-dependencies
         cd /c/build-installer-dependencies
-        cmake -A x64 -DRI_BUILD_FULL_INSTALLER:BOOL=OFF ${GITHUB_WORKSPACE}/packaging/windows
+        cmake -A x64 -DRI_BUILD_FULL_INSTALLER:BOOL=OFF ${ROBOTOLOGY_SUPERBUILD_SOURCE_DIR}/packaging/windows
         cmake --build . --config Release --target PACKAGE
         # Move installer in installer directory with a fixed name
         mv *.exe /c/robotology-dependencies-installer-win64.exe


### PR DESCRIPTION
The C:\ drive has much more space then the D:\ drive that is used by default.

Fix https://github.com/robotology/robotology-superbuild/issues/637 .