### PR TITLE
Buildbipedal-locomotion-framework.cmake: Set FRAMEWORK_USE_YARP and Buildbipedal-locomotion-framework.cmake option to ON

### DIFF
--- a/cmake/Buildbipedal-locomotion-framework.cmake
+++ b/cmake/Buildbipedal-locomotion-framework.cmake
@@ -37,6 +37,8 @@ ycm_ep_helper(bipedal-locomotion-framework TYPE GIT
               COMPONENT dynamics
               FOLDER src
               CMAKE_ARGS -DBUILD_TESTING:BOOL=OFF
+                         -DFRAMEWORK_USE_YARP:BOOL=ON
+                         -DFRAMEWORK_USE_matioCpp:BOOL=ON
                          -DFRAMEWORK_USE_manif:BOOL=${ROBOTOLOGY_ENABLE_DYNAMICS_FULL_DEPS}
                          -DFRAMEWORK_USE_Qhull:BOOL=${ROBOTOLOGY_ENABLE_DYNAMICS_FULL_DEPS}
                          -DFRAMEWORK_USE_cppad:BOOL=${ROBOTOLOGY_ENABLE_DYNAMICS_FULL_DEPS}


### PR DESCRIPTION
If for any reason or bug YARP or matio-cpp or one of its dependencies are missing, then bipedal-locomotion-framework built by the robotology-superbuild should fail with a clear error, not silently disable the relative support. 

See https://github.com/dic-iit/matio-cpp/pull/41#issuecomment-787496467 for a background on this fix.