### PR TITLE
Enable compilation of ROBOTOLOGY_USES_MATLAB option in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -201,14 +201,8 @@ jobs:
             build_type: Release
             cmake_generator: "Unix Makefiles"
           - os: ubuntu-20.04
-            build_type: Debug
-            cmake_generator: "Ninja"
-          - os: ubuntu-20.04
             build_type: Release
-            cmake_generator: "Unix Makefiles"
-          - os: macos-10.15
-            build_type: Debug
-            cmake_generator: "Unix Makefiles"
+            cmake_generator: "Ninja"
           - os: macos-10.15
             build_type: Release
             cmake_generator: "Ninja"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,33 @@ jobs:
         channels: conda-forge,defaults
         channel-priority: true
 
+    - name: Install files to enable compilation of mex files [Conda/Linux]
+      if: contains(matrix.os, 'ubuntu') 
+      run: |
+        curl -L -O https://github.com/robotology/robotology-vcpkg-ports/releases/download/storage/msdk_R2019b_mexa64.zip
+        unzip msdk_R2019b_mexa64.zip
+        rm msdk_R2019b_mexa64.zip
+        echo "::set-env name=GHA_Matlab_ROOT_DIR::${GITHUB_WORKSPACE}/msdk_R2019b_mexa64"
+        echo "::set-env name=GHA_Matlab_MEX_EXTENSION::mexa64"
+                
+    - name: Install files to enable compilation of mex files [Conda/macOS]
+      if: contains(matrix.os, 'macos') 
+      run: |
+        curl -L -O https://github.com/robotology/robotology-vcpkg-ports/releases/download/storage/msdk_R2019b_mexmaci64.zip
+        unzip msdk_R2019b_mexmaci64.zip
+        rm msdk_R2019b_mexmaci64.zip
+        echo "::set-env name=GHA_Matlab_ROOT_DIR::${GITHUB_WORKSPACE}/msdk_R2019b_mexmaci64"
+        echo "::set-env name=GHA_Matlab_MEX_EXTENSION::mexmaci64"
+        
+    - name: Install files to enable compilation of mex files [Conda/Windows]
+      shell: bash
+      run: |
+        curl -L -O https://github.com/robotology/robotology-vcpkg-ports/releases/download/storage/msdk_R2020a_mexw64.zip
+        unzip msdk_R2020a_mexw64.zip
+        rm msdk_R2020a_mexw64.zip
+        echo "::set-env name=GHA_Matlab_ROOT_DIR::${GITHUB_WORKSPACE}/msdk_R2019b_mexw64"
+        echo "::set-env name=GHA_Matlab_MEX_EXTENSION::mexw64"
+
     - name: Dependencies [Conda]
       shell: bash -l {0}
       run: |
@@ -67,7 +94,7 @@ jobs:
       run: |
         mkdir -p build
         cd build
-        cmake -GNinja -C ${GITHUB_WORKSPACE}/.ci/initial-cache.gh.cmake  -DNON_INTERACTIVE_BUILD:BOOL=TRUE -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}  ${{ matrix.project_tags_cmake_options }}  ..
+        cmake -GNinja -C ${GITHUB_WORKSPACE}/.ci/initial-cache.gh.cmake -DYCM_EP_ADDITIONAL_CMAKE_ARGS:STRING="-DMatlab_ROOT_DIR=${GHA_Matlab_ROOT_DIR} -DMatlab_MEX_EXTENSION:STRING=${GHA_Matlab_MEX_EXTENSION}" -DROBOTOLOGY_USES_MATLAB:BOOL=ON  -DNON_INTERACTIVE_BUILD:BOOL=TRUE -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}  ${{ matrix.project_tags_cmake_options }}  ..
         # Disable options not tested on Conda for now
         # Reference issue: https://github.com/robotology/robotology-superbuild/issues/563
         cmake -DROBOTOLOGY_USES_OCTAVE:BOOL=OFF -DROBOTOLOGY_USES_PYTHON:BOOL=OFF -DROBOTOLOGY_ENABLE_ICUB_HEAD:BOOL=OFF -DROBOTOLOGY_ENABLE_DYNAMICS_FULL_DEPS:BOOL=OFF .
@@ -81,7 +108,7 @@ jobs:
         mamba install freeglut
         mkdir -p build
         cd build
-        cmake -G"Visual Studio 16 2019" -C ${GITHUB_WORKSPACE}/.ci/initial-cache.gh.cmake -DNON_INTERACTIVE_BUILD:BOOL=TRUE -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}  ${{ matrix.project_tags_cmake_options }}  ..
+        cmake -G"Visual Studio 16 2019" -C ${GITHUB_WORKSPACE}/.ci/initial-cache.gh.cmake -DYCM_EP_ADDITIONAL_CMAKE_ARGS:STRING="-DMatlab_ROOT_DIR=${GHA_Matlab_ROOT_DIR} -DMatlab_MEX_EXTENSION:STRING=${GHA_Matlab_MEX_EXTENSION}" -DROBOTOLOGY_USES_MATLAB:BOOL=ON  -DNON_INTERACTIVE_BUILD:BOOL=TRUE -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}  ${{ matrix.project_tags_cmake_options }}  ..
         # Disable options not tested on Conda for now
         # Reference issue: https://github.com/robotology/robotology-superbuild/issues/563
         cmake -DROBOTOLOGY_USES_OCTAVE:BOOL=OFF -DROBOTOLOGY_USES_PYTHON:BOOL=OFF -DROBOTOLOGY_ENABLE_ICUB_HEAD:BOOL=OFF -DROBOTOLOGY_ENABLE_DYNAMICS_FULL_DEPS:BOOL=OFF .
@@ -195,6 +222,33 @@ jobs:
     steps:
     - uses: actions/checkout@master
     
+    - name: Install files to enable compilation of mex files [Ubuntu]
+      if: contains(matrix.os, 'ubuntu') 
+      run: |
+        curl -L -O https://github.com/robotology/robotology-vcpkg-ports/releases/download/storage/msdk_R2019b_mexa64.zip
+        unzip msdk_R2019b_mexa64.zip
+        rm msdk_R2019b_mexa64.zip
+        echo "::set-env name=GHA_Matlab_ROOT_DIR::${GITHUB_WORKSPACE}/msdk_R2019b_mexa64"
+        echo "::set-env name=GHA_Matlab_MEX_EXTENSION::mexa64"
+                
+    - name: Install files to enable compilation of mex files [macOS]
+      if: contains(matrix.os, 'macos') 
+      run: |
+        curl -L -O https://github.com/robotology/robotology-vcpkg-ports/releases/download/storage/msdk_R2019b_mexmaci64.zip
+        unzip msdk_R2019b_mexmaci64.zip
+        rm msdk_R2019b_mexmaci64.zip
+        echo "::set-env name=GHA_Matlab_ROOT_DIR::${GITHUB_WORKSPACE}/msdk_R2019b_mexmaci64"
+        echo "::set-env name=GHA_Matlab_MEX_EXTENSION::mexmaci64"
+        
+    - name: Install files to enable compilation of mex files [Windows]
+      shell: bash
+      run: |
+        curl -L -O https://github.com/robotology/robotology-vcpkg-ports/releases/download/storage/msdk_R2020a_mexw64.zip
+        unzip msdk_R2020a_mexw64.zip
+        rm msdk_R2020a_mexw64.zip
+        echo "::set-env name=GHA_Matlab_ROOT_DIR::${GITHUB_WORKSPACE}/msdk_R2019b_mexw64"
+        echo "::set-env name=GHA_Matlab_MEX_EXTENSION::mexw64"
+    
     - name: Move robotology-superbuild in C under Windows
       if: contains(matrix.os, 'windows')
       shell: bash
@@ -303,7 +357,7 @@ jobs:
         cd ${ROBOTOLOGY_SUPERBUILD_SOURCE_DIR}
         mkdir -p build
         cd build
-        cmake -C ${ROBOTOLOGY_SUPERBUILD_SOURCE_DIR}/.ci/initial-cache.gh.cmake -G"${{ matrix.cmake_generator }}" -DYCM_BOOTSTRAP_VERBOSE=ON -DNON_INTERACTIVE_BUILD:BOOL=TRUE -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} ${{ matrix.project_tags_cmake_options }} ..
+        cmake -C ${ROBOTOLOGY_SUPERBUILD_SOURCE_DIR}/.ci/initial-cache.gh.cmake -G"${{ matrix.cmake_generator }}" -DYCM_EP_ADDITIONAL_CMAKE_ARGS:STRING="-DMatlab_ROOT_DIR=${GHA_Matlab_ROOT_DIR} -DMatlab_MEX_EXTENSION:STRING=${GHA_Matlab_MEX_EXTENSION}" -DROBOTOLOGY_USES_MATLAB:BOOL=ON -DYCM_BOOTSTRAP_VERBOSE=ON -DNON_INTERACTIVE_BUILD:BOOL=TRUE -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} ${{ matrix.project_tags_cmake_options }} ..
 
     - name: Disable macOS unsupported options
       if: contains(matrix.os, 'macos')
@@ -323,7 +377,7 @@ jobs:
         mkdir -p build
         cd build
         # ROBOTOLOGY_ENABLE_TELEOPERATION is OFF as a workaround for https://github.com/robotology/robotology-superbuild/issues/472
-        cmake -C ${ROBOTOLOGY_SUPERBUILD_SOURCE_DIR}/.ci/initial-cache.gh.cmake -A x64 -DCMAKE_TOOLCHAIN_FILE=C:/robotology/vcpkg/scripts/buildsystems/vcpkg.cmake -DYCM_BOOTSTRAP_VERBOSE=ON -DYCM_EP_INSTALL_DIR=C:/robotology/robotology -DNON_INTERACTIVE_BUILD:BOOL=TRUE -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}  ${{ matrix.project_tags_cmake_options }} ..
+        cmake -C ${ROBOTOLOGY_SUPERBUILD_SOURCE_DIR}/.ci/initial-cache.gh.cmake -A x64 -DCMAKE_TOOLCHAIN_FILE=C:/robotology/vcpkg/scripts/buildsystems/vcpkg.cmake  -DYCM_EP_ADDITIONAL_CMAKE_ARGS:STRING="-DMatlab_ROOT_DIR=${GHA_Matlab_ROOT_DIR} -DMatlab_MEX_EXTENSION:STRING=${GHA_Matlab_MEX_EXTENSION}" -DROBOTOLOGY_USES_MATLAB:BOOL=ON -DYCM_BOOTSTRAP_VERBOSE=ON -DYCM_EP_INSTALL_DIR=C:/robotology/robotology -DNON_INTERACTIVE_BUILD:BOOL=TRUE -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}  ${{ matrix.project_tags_cmake_options }} ..
 
 
     - name: Build  [Ubuntu&macOS]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,19 +47,19 @@ jobs:
     - name: Install files to enable compilation of mex files [Conda/Linux]
       if: contains(matrix.os, 'ubuntu') 
       run: |
-        curl -L -O https://github.com/robotology/robotology-vcpkg-ports/releases/download/storage/msdk_R2019b_mexa64.zip
-        unzip msdk_R2019b_mexa64.zip
-        rm msdk_R2019b_mexa64.zip
-        echo "GHA_Matlab_ROOT_DIR=${GITHUB_WORKSPACE}/msdk_R2019b_mexa64" >> $GITHUB_ENV
+        curl -L -O https://github.com/robotology/robotology-vcpkg-ports/releases/download/storage/msdk_R2020b_mexa64.zip
+        unzip msdk_R2020b_mexa64.zip
+        rm msdk_R2020b_mexa64.zip
+        echo "GHA_Matlab_ROOT_DIR=${GITHUB_WORKSPACE}/msdk_R2020b_mexa64" >> $GITHUB_ENV
         echo "GHA_Matlab_MEX_EXTENSION=mexa64" >> $GITHUB_ENV
                 
     - name: Install files to enable compilation of mex files [Conda/macOS]
       if: contains(matrix.os, 'macos') 
       run: |
-        curl -L -O https://github.com/robotology/robotology-vcpkg-ports/releases/download/storage/msdk_R2019b_mexmaci64.zip
-        unzip msdk_R2019b_mexmaci64.zip
-        rm msdk_R2019b_mexmaci64.zip
-        echo "GHA_Matlab_ROOT_DIR=${GITHUB_WORKSPACE}/msdk_R2019b_mexmaci64" >> $GITHUB_ENV
+        curl -L -O https://github.com/robotology/robotology-vcpkg-ports/releases/download/storage/msdk_R2020a_mexmaci64.zip
+        unzip msdk_R2020a_mexmaci64.zip
+        rm msdk_R2020a_mexmaci64.zip
+        echo "GHA_Matlab_ROOT_DIR=${GITHUB_WORKSPACE}/msdk_R2020a_mexmaci64" >> $GITHUB_ENV
         echo "GHA_Matlab_MEX_EXTENSION=mexmaci64" >> $GITHUB_ENV
         
     - name: Install files to enable compilation of mex files [Conda/Windows]
@@ -226,19 +226,19 @@ jobs:
     - name: Install files to enable compilation of mex files [Linux]
       if: contains(matrix.os, 'ubuntu') 
       run: |
-        curl -L -O https://github.com/robotology/robotology-vcpkg-ports/releases/download/storage/msdk_R2019b_mexa64.zip
-        unzip msdk_R2019b_mexa64.zip
-        rm msdk_R2019b_mexa64.zip
-        echo "GHA_Matlab_ROOT_DIR=${GITHUB_WORKSPACE}/msdk_R2019b_mexa64" >> $GITHUB_ENV
+        curl -L -O https://github.com/robotology/robotology-vcpkg-ports/releases/download/storage/msdk_R2020b_mexa64.zip
+        unzip msdk_R2020b_mexa64.zip
+        rm msdk_R2020b_mexa64.zip
+        echo "GHA_Matlab_ROOT_DIR=${GITHUB_WORKSPACE}/msdk_R2020b_mexa64" >> $GITHUB_ENV
         echo "GHA_Matlab_MEX_EXTENSION=mexa64" >> $GITHUB_ENV
                 
     - name: Install files to enable compilation of mex files [macOS]
       if: contains(matrix.os, 'macos') 
       run: |
-        curl -L -O https://github.com/robotology/robotology-vcpkg-ports/releases/download/storage/msdk_R2019b_mexmaci64.zip
-        unzip msdk_R2019b_mexmaci64.zip
-        rm msdk_R2019b_mexmaci64.zip
-        echo "GHA_Matlab_ROOT_DIR=${GITHUB_WORKSPACE}/msdk_R2019b_mexmaci64" >> $GITHUB_ENV
+        curl -L -O https://github.com/robotology/robotology-vcpkg-ports/releases/download/storage/msdk_R2020a_mexmaci64.zip
+        unzip msdk_R2020a_mexmaci64.zip
+        rm msdk_R2020a_mexmaci64.zip
+        echo "GHA_Matlab_ROOT_DIR=${GITHUB_WORKSPACE}/msdk_R2020a_mexmaci64" >> $GITHUB_ENV
         echo "GHA_Matlab_MEX_EXTENSION=mexmaci64" >> $GITHUB_ENV
         
     - name: Install files to enable compilation of mex files [Windows]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,8 +50,8 @@ jobs:
         curl -L -O https://github.com/robotology/robotology-vcpkg-ports/releases/download/storage/msdk_R2019b_mexa64.zip
         unzip msdk_R2019b_mexa64.zip
         rm msdk_R2019b_mexa64.zip
-        echo "::set-env name=GHA_Matlab_ROOT_DIR::${GITHUB_WORKSPACE}/msdk_R2019b_mexa64"
-        echo "::set-env name=GHA_Matlab_MEX_EXTENSION::mexa64"
+        echo "GHA_Matlab_ROOT_DIR=${GITHUB_WORKSPACE}/msdk_R2019b_mexa64" >> $GITHUB_ENV
+        echo "GHA_Matlab_MEX_EXTENSION=mexa64" >> $GITHUB_ENV
                 
     - name: Install files to enable compilation of mex files [Conda/macOS]
       if: contains(matrix.os, 'macos') 
@@ -59,8 +59,8 @@ jobs:
         curl -L -O https://github.com/robotology/robotology-vcpkg-ports/releases/download/storage/msdk_R2019b_mexmaci64.zip
         unzip msdk_R2019b_mexmaci64.zip
         rm msdk_R2019b_mexmaci64.zip
-        echo "::set-env name=GHA_Matlab_ROOT_DIR::${GITHUB_WORKSPACE}/msdk_R2019b_mexmaci64"
-        echo "::set-env name=GHA_Matlab_MEX_EXTENSION::mexmaci64"
+        echo "GHA_Matlab_ROOT_DIR=${GITHUB_WORKSPACE}/msdk_R2019b_mexmaci64" >> $GITHUB_ENV
+        echo "GHA_Matlab_MEX_EXTENSION=mexmaci64" >> $GITHUB_ENV
         
     - name: Install files to enable compilation of mex files [Conda/Windows]
       shell: bash
@@ -68,8 +68,8 @@ jobs:
         curl -L -O https://github.com/robotology/robotology-vcpkg-ports/releases/download/storage/msdk_R2020a_mexw64.zip
         unzip msdk_R2020a_mexw64.zip
         rm msdk_R2020a_mexw64.zip
-        echo "::set-env name=GHA_Matlab_ROOT_DIR::${GITHUB_WORKSPACE}/msdk_R2019b_mexw64"
-        echo "::set-env name=GHA_Matlab_MEX_EXTENSION::mexw64"
+        echo "GHA_Matlab_ROOT_DIR=${GITHUB_WORKSPACE}/msdk_R2020a_mexw64" >> $GITHUB_ENV
+        echo "GHA_Matlab_MEX_EXTENSION=mexw64" >> $GITHUB_ENV
 
     - name: Dependencies [Conda]
       shell: bash -l {0}
@@ -222,14 +222,14 @@ jobs:
     steps:
     - uses: actions/checkout@master
     
-    - name: Install files to enable compilation of mex files [Ubuntu]
+    - name: Install files to enable compilation of mex files [Linux]
       if: contains(matrix.os, 'ubuntu') 
       run: |
         curl -L -O https://github.com/robotology/robotology-vcpkg-ports/releases/download/storage/msdk_R2019b_mexa64.zip
         unzip msdk_R2019b_mexa64.zip
         rm msdk_R2019b_mexa64.zip
-        echo "::set-env name=GHA_Matlab_ROOT_DIR::${GITHUB_WORKSPACE}/msdk_R2019b_mexa64"
-        echo "::set-env name=GHA_Matlab_MEX_EXTENSION::mexa64"
+        echo "GHA_Matlab_ROOT_DIR=${GITHUB_WORKSPACE}/msdk_R2019b_mexa64" >> $GITHUB_ENV
+        echo "GHA_Matlab_MEX_EXTENSION=mexa64" >> $GITHUB_ENV
                 
     - name: Install files to enable compilation of mex files [macOS]
       if: contains(matrix.os, 'macos') 
@@ -237,8 +237,8 @@ jobs:
         curl -L -O https://github.com/robotology/robotology-vcpkg-ports/releases/download/storage/msdk_R2019b_mexmaci64.zip
         unzip msdk_R2019b_mexmaci64.zip
         rm msdk_R2019b_mexmaci64.zip
-        echo "::set-env name=GHA_Matlab_ROOT_DIR::${GITHUB_WORKSPACE}/msdk_R2019b_mexmaci64"
-        echo "::set-env name=GHA_Matlab_MEX_EXTENSION::mexmaci64"
+        echo "GHA_Matlab_ROOT_DIR=${GITHUB_WORKSPACE}/msdk_R2019b_mexmaci64" >> $GITHUB_ENV
+        echo "GHA_Matlab_MEX_EXTENSION=mexmaci64" >> $GITHUB_ENV
         
     - name: Install files to enable compilation of mex files [Windows]
       shell: bash
@@ -246,8 +246,9 @@ jobs:
         curl -L -O https://github.com/robotology/robotology-vcpkg-ports/releases/download/storage/msdk_R2020a_mexw64.zip
         unzip msdk_R2020a_mexw64.zip
         rm msdk_R2020a_mexw64.zip
-        echo "::set-env name=GHA_Matlab_ROOT_DIR::${GITHUB_WORKSPACE}/msdk_R2019b_mexw64"
-        echo "::set-env name=GHA_Matlab_MEX_EXTENSION::mexw64"
+        echo "GHA_Matlab_ROOT_DIR=${GITHUB_WORKSPACE}/msdk_R2020a_mexw64" >> $GITHUB_ENV
+        echo "GHA_Matlab_MEX_EXTENSION=mexw64" >> $GITHUB_ENV
+
     
     - name: Move robotology-superbuild in C under Windows
       if: contains(matrix.os, 'windows')

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,6 +63,7 @@ jobs:
         echo "GHA_Matlab_MEX_EXTENSION=mexmaci64" >> $GITHUB_ENV
         
     - name: Install files to enable compilation of mex files [Conda/Windows]
+      if: contains(matrix.os, 'windows') 
       shell: bash
       run: |
         curl -L -O https://github.com/robotology/robotology-vcpkg-ports/releases/download/storage/msdk_R2020a_mexw64.zip
@@ -242,6 +243,7 @@ jobs:
         
     - name: Install files to enable compilation of mex files [Windows]
       shell: bash
+      if: contains(matrix.os, 'windows') 
       run: |
         curl -L -O https://github.com/robotology/robotology-vcpkg-ports/releases/download/storage/msdk_R2020a_mexw64.zip
         unzip msdk_R2020a_mexw64.zip

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,7 +78,7 @@ jobs:
         # Compilation related dependencies 
         mamba install cmake compilers make ninja pkg-config
         # Actual dependencies
-        mamba install ace asio boost eigen gazebo glew glfw gsl ipopt irrlicht libjpeg-turbo libmatio libode libxml2 opencv pkg-config portaudio qt sdl sdl2 sqlite tinyxml
+        mamba install ace asio boost eigen gazebo glew glfw gsl ipopt irrlicht libjpeg-turbo libmatio libode libxml2 opencv pkg-config portaudio qt sdl sdl2 sqlite tinyxml tbb-devel=2020
 
     # Additional dependencies useful only on Linux
     - name: Dependencies [Conda/Linux]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,7 +95,7 @@ jobs:
       run: |
         mkdir -p build
         cd build
-        cmake -GNinja -C ${GITHUB_WORKSPACE}/.ci/initial-cache.gh.cmake -DYCM_EP_ADDITIONAL_CMAKE_ARGS:STRING="-DMatlab_ROOT_DIR=${GHA_Matlab_ROOT_DIR} -DMatlab_MEX_EXTENSION:STRING=${GHA_Matlab_MEX_EXTENSION}" -DROBOTOLOGY_USES_MATLAB:BOOL=ON  -DNON_INTERACTIVE_BUILD:BOOL=TRUE -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}  ${{ matrix.project_tags_cmake_options }}  ..
+        cmake -GNinja -C ${GITHUB_WORKSPACE}/.ci/initial-cache.gh.cmake -DYCM_EP_ADDITIONAL_CMAKE_ARGS:STRING="-DMatlab_ROOT_DIR:PATH=${GHA_Matlab_ROOT_DIR} -DMatlab_MEX_EXTENSION:STRING=${GHA_Matlab_MEX_EXTENSION}" -DROBOTOLOGY_USES_MATLAB:BOOL=ON  -DNON_INTERACTIVE_BUILD:BOOL=TRUE -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}  ${{ matrix.project_tags_cmake_options }}  ..
         # Disable options not tested on Conda for now
         # Reference issue: https://github.com/robotology/robotology-superbuild/issues/563
         cmake -DROBOTOLOGY_USES_OCTAVE:BOOL=OFF -DROBOTOLOGY_USES_PYTHON:BOOL=OFF -DROBOTOLOGY_ENABLE_ICUB_HEAD:BOOL=OFF -DROBOTOLOGY_ENABLE_DYNAMICS_FULL_DEPS:BOOL=OFF .
@@ -109,7 +109,7 @@ jobs:
         mamba install freeglut
         mkdir -p build
         cd build
-        cmake -G"Visual Studio 16 2019" -C ${GITHUB_WORKSPACE}/.ci/initial-cache.gh.cmake -DYCM_EP_ADDITIONAL_CMAKE_ARGS:STRING="-DMatlab_ROOT_DIR=${GHA_Matlab_ROOT_DIR} -DMatlab_MEX_EXTENSION:STRING=${GHA_Matlab_MEX_EXTENSION}" -DROBOTOLOGY_USES_MATLAB:BOOL=ON  -DNON_INTERACTIVE_BUILD:BOOL=TRUE -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}  ${{ matrix.project_tags_cmake_options }}  ..
+        cmake -G"Visual Studio 16 2019" -C ${GITHUB_WORKSPACE}/.ci/initial-cache.gh.cmake -DYCM_EP_ADDITIONAL_CMAKE_ARGS:STRING="-DMatlab_ROOT_DIR:PATH=${GHA_Matlab_ROOT_DIR} -DMatlab_MEX_EXTENSION:STRING=${GHA_Matlab_MEX_EXTENSION}" -DROBOTOLOGY_USES_MATLAB:BOOL=ON  -DNON_INTERACTIVE_BUILD:BOOL=TRUE -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}  ${{ matrix.project_tags_cmake_options }}  ..
         # Disable options not tested on Conda for now
         # Reference issue: https://github.com/robotology/robotology-superbuild/issues/563
         cmake -DROBOTOLOGY_USES_OCTAVE:BOOL=OFF -DROBOTOLOGY_USES_PYTHON:BOOL=OFF -DROBOTOLOGY_ENABLE_ICUB_HEAD:BOOL=OFF -DROBOTOLOGY_ENABLE_DYNAMICS_FULL_DEPS:BOOL=OFF .
@@ -354,7 +354,7 @@ jobs:
         cd ${ROBOTOLOGY_SUPERBUILD_SOURCE_DIR}
         mkdir -p build
         cd build
-        cmake -C ${ROBOTOLOGY_SUPERBUILD_SOURCE_DIR}/.ci/initial-cache.gh.cmake -G"${{ matrix.cmake_generator }}" -DYCM_EP_ADDITIONAL_CMAKE_ARGS:STRING="-DMatlab_ROOT_DIR=${GHA_Matlab_ROOT_DIR} -DMatlab_MEX_EXTENSION:STRING=${GHA_Matlab_MEX_EXTENSION}" -DROBOTOLOGY_USES_MATLAB:BOOL=ON -DYCM_BOOTSTRAP_VERBOSE=ON -DNON_INTERACTIVE_BUILD:BOOL=TRUE -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} ${{ matrix.project_tags_cmake_options }} ..
+        cmake -C ${ROBOTOLOGY_SUPERBUILD_SOURCE_DIR}/.ci/initial-cache.gh.cmake -G"${{ matrix.cmake_generator }}" -DYCM_EP_ADDITIONAL_CMAKE_ARGS:STRING="-DMatlab_ROOT_DIR:PATH=${GHA_Matlab_ROOT_DIR} -DMatlab_MEX_EXTENSION:STRING=${GHA_Matlab_MEX_EXTENSION}" -DROBOTOLOGY_USES_MATLAB:BOOL=ON -DYCM_BOOTSTRAP_VERBOSE=ON -DNON_INTERACTIVE_BUILD:BOOL=TRUE -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} ${{ matrix.project_tags_cmake_options }} ..
 
     - name: Disable macOS unsupported options
       if: contains(matrix.os, 'macos')
@@ -374,7 +374,7 @@ jobs:
         mkdir -p build
         cd build
         # ROBOTOLOGY_ENABLE_TELEOPERATION is OFF as a workaround for https://github.com/robotology/robotology-superbuild/issues/472
-        cmake -C ${ROBOTOLOGY_SUPERBUILD_SOURCE_DIR}/.ci/initial-cache.gh.cmake -A x64 -DCMAKE_TOOLCHAIN_FILE=C:/robotology/vcpkg/scripts/buildsystems/vcpkg.cmake  -DYCM_EP_ADDITIONAL_CMAKE_ARGS:STRING="-DMatlab_ROOT_DIR=${GHA_Matlab_ROOT_DIR} -DMatlab_MEX_EXTENSION:STRING=${GHA_Matlab_MEX_EXTENSION}" -DROBOTOLOGY_USES_MATLAB:BOOL=ON -DYCM_BOOTSTRAP_VERBOSE=ON -DYCM_EP_INSTALL_DIR=C:/robotology/robotology -DNON_INTERACTIVE_BUILD:BOOL=TRUE -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}  ${{ matrix.project_tags_cmake_options }} ..
+        cmake -C ${ROBOTOLOGY_SUPERBUILD_SOURCE_DIR}/.ci/initial-cache.gh.cmake -A x64 -DCMAKE_TOOLCHAIN_FILE=C:/robotology/vcpkg/scripts/buildsystems/vcpkg.cmake  -DYCM_EP_ADDITIONAL_CMAKE_ARGS:STRING="-DMatlab_ROOT_DIR:PATH=${GHA_Matlab_ROOT_DIR} -DMatlab_MEX_EXTENSION:STRING=${GHA_Matlab_MEX_EXTENSION}" -DROBOTOLOGY_USES_MATLAB:BOOL=ON -DYCM_BOOTSTRAP_VERBOSE=ON -DYCM_EP_INSTALL_DIR=C:/robotology/robotology -DNON_INTERACTIVE_BUILD:BOOL=TRUE -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}  ${{ matrix.project_tags_cmake_options }} ..
 
 
     - name: Build  [Ubuntu&macOS]


### PR DESCRIPTION
This ensures that compilation problems are catched early, furthermore that MATLAB binaries will be included in Windows installers. 