### PR TITLE
Latest releases update: clarify how to start CI

### DIFF
--- a/.github/workflows/update-latest-releases.yml
+++ b/.github/workflows/update-latest-releases.yml
@@ -43,6 +43,8 @@ jobs:
             body: |
               This is the **periodic automatic update** of the latest releases versions.
               
+              Due to limitations of Github Actions, you will need to close/reopen the PR to get the actions running.
+              
               Before merging, wait for the continuous integration outcome as it is possible that the automatic update of a given project created problems in the compilation of the overall superbuild.
               
               For more info, check the [developer FAQs documentation of the robotology-superbuild](https://github.com/robotology/robotology-superbuild/blob/master/doc/developers-faqs.md). 


### PR DESCRIPTION
Closing and opening the PR is sufficient to actually start CI (see https://github.com/robotology/robotology-superbuild/pull/647), so better to clearly state it in the PR message.