### PR TITLE
 Add detailed recommended instructions on how to install miniforge3 conda distribution

### DIFF
--- a/doc/conda-forge.md
+++ b/doc/conda-forge.md
@@ -26,7 +26,7 @@ This section describes how to compile and install the robotology-superbuild with
 
 ### Install a conda distribution
 If you do not have a conda distribution on your system, we suggest to use the minimal 
-[`miniforge3`](https://github.com/conda-forge/miniforge#miniforge3) distribution, that uses `conda-forge` packages by default. 
+[`miniforge3`](https://github.com/conda-forge/miniforge#miniforge3) distribution, that uses `conda-forge` packages by default, following the instructions in our [`install-miniforge`](install-miniforge.md) documentation. 
 
 After you installed it, make sure that you can execute the `conda info` package from your terminal, and its output is similar to:
 ~~~

--- a/doc/install-miniforge.md
+++ b/doc/install-miniforge.md
@@ -3,6 +3,12 @@
 This page provide detailed instructions on how to install the [miniforge conda distribution](https://github.com/conda-forge/miniforge). 
 For more information on conda and its use with the robotology-superbuild, please check the [related documentation](conda-forge.md).
 
+## Table of Contents
+
+* [Linux](#linux)
+* [macOS](#macos)
+* [Windows](#windows)
+
 ## Linux
 
 ### Install

--- a/doc/install-miniforge.md
+++ b/doc/install-miniforge.md
@@ -1,0 +1,145 @@
+# Install miniforge
+
+This page provide detailed instructions on how to install the [miniforge conda distribution](https://github.com/conda-forge/miniforge). 
+For more information on conda and its use with the robotology-superbuild, please check the [related documentation](conda-forge.md).
+
+## Linux
+
+### Install
+First of all, download the installer and install it in its default location:
+~~~
+# Download
+curl -LO https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-Linux-x86_64.sh
+# Install with default options
+bash ./Miniforge3-Linux-x86_64.sh -b
+~~~
+This will install miniforge in `~/miniforge3` .
+
+To use the `conda` command, you need to add the `~/miniforge3/condabin` directory to the [`PATH` environment variable](https://en.wikipedia.org/wiki/PATH_(variable)). 
+You can do this persistently by modifying the `.bashrc` via the command: 
+~~~
+~/miniforge3/condabin/conda init
+~~~
+
+By default, this command also automatically initialize the [`base` conda environment](https://conda.io/projects/conda/en/latest/user-guide/tasks/manage-environments.html#activating-an-environment) whenever you start a terminal.
+As this could interfere with other uses of your system (for example compilation against libraries installed via `apt`), it is recommended to disable this by setting:
+~~~
+conda config --set auto_activate_base false
+~~~
+
+After this configuration, whenever you open a new terminal, you should be able to access the `conda` command, but no environment should be enabled by default, i.e. if you execute `conda info` you should see:
+~~~
+$ conda info
+     active environment : None
+            shell level : 0
+            [...]
+~~~
+
+To activate in any terminal the `base` environment, just run:
+~~~
+conda activate base
+~~~
+
+### Uninstall
+To remove `miniforge`, first cleanup your `.bashrc` either manually or by running the command:
+~~~
+~/miniforge3/condabin/conda init --reverse
+~~~
+Then, just remove the `~/miniforge3` directory and the setting files:
+~~~
+rm -rf ~/miniforge3
+rm -rf ~/.conda
+rm -rf ~/.condarc
+~~~
+
+
+## macOS
+
+### Install
+First of all, download the installer and install it in its default location:
+~~~
+# Download
+curl -fsSLo Miniforge3.sh https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-MacOSX-$(uname -m).sh
+# Install with default options
+bash ./Miniforge3-MacOSX-$(uname -m).sh
+~~~
+This will install miniforge in `~/miniforge3` .
+
+To use the `conda` command, you need to add the `~/miniforge3/condabin` directory to the [`PATH` environment variable](https://en.wikipedia.org/wiki/PATH_(variable)). 
+You can do this persistently by modifying the appropriate file via the command: 
+~~~
+~/miniforge3/condabin/conda init
+~~~
+
+By default, this command also automatically initialize the [`base` conda environment](https://conda.io/projects/conda/en/latest/user-guide/tasks/manage-environments.html#activating-an-environment) whenever you start a terminal.
+As this could interfere with other uses of your system (for example compilation against libraries installed via `brew`), it is recommended to disable this by setting:
+~~~
+conda config --set auto_activate_base false
+~~~
+
+After this configuration, whenever you open a new terminal, you should be able to access the `conda` command, but no environment should be enabled by default, i.e. if you execute `conda info` you should see:
+~~~
+$ conda info
+     active environment : None
+            shell level : 0
+            [...]
+~~~
+
+To activate in any terminal the `base` environment, just run:
+~~~
+conda activate base
+~~~
+
+### Uninstall
+To remove `miniforge`, first cleanup your `PATH` environment variable by running the command:
+~~~
+~/miniforge3/condabin/conda init --reverse
+~~~
+Then, just remove the `~/miniforge3` directory and the setting files:
+~~~
+rm -rf ~/miniforge3
+rm -rf ~/.conda
+rm -rf ~/.condarc
+~~~
+
+## Windows
+
+First of all, download the installer from https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-Windows-x86_64.exe and install it by double clicking on it.
+
+If you already have a Python that you use in your system, make sure that you deselect the "Register Miniforge3 Python as my default Python" during the installation.
+
+After the installation has been completed, Miniforge should have been installed in `%HOME%\Miniforge3`.
+
+To ensure that the `conda` binary can be used in your terminal, open a Command Prompt and run:
+~~~
+%HOME%\Miniforge3\condabin\conda init
+~~~
+
+By default, this command also automatically initialize the [`base` conda environment](https://conda.io/projects/conda/en/latest/user-guide/tasks/manage-environments.html#activating-an-environment) whenever you start a terminal.
+As this could interfere with other uses of your system (for example compilation against libraries installed not installed via `conda`), it is recommended to disable this by setting:
+~~~
+%HOME%\Miniforge3\condabin\conda config --set auto_activate_base false
+~~~
+
+After this configuration, whenever you open a new terminal, you should be able to access the `conda` command, but no environment should be enabled by default, i.e. if you execute `conda info` you should see:
+~~~
+> conda info
+     active environment : None
+            shell level : 0
+            [...]
+~~~
+
+To activate in any terminal the `base` environment, just run:
+~~~
+conda activate base
+~~~
+
+### Uninstall
+First of all, open a command prompt and run:
+~~~
+%HOME%\Miniforge3\condabin\conda init --reverse
+~~~
+
+Then go to "Add or remove programs", search for Miniforge3 and uninstall it.
+
+After that, delete the `%HOME%/.conda` directory and the `%HOME%/.condarc` file.


### PR DESCRIPTION
While the instructions for building from source (and soon installing from binaries, see https://github.com/robotology/robotology-superbuild/issues/620) the robotology-superbuild packages using conda-forge-provided dependencies should work fine on all possible conda distributions, for all users that are new to conda we suggest to use the [miniforge distribution](https://github.com/conda-forge/miniforge). To avoid confusions, we add some detailed documentation on how to install this conda distribution. 