### PR TITLE
bipedal-locomotion-framework related changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -373,6 +373,13 @@ jobs:
         # Disable ROBOTOLOGY_USES_PYTHON in macOS
         cmake -DROBOTOLOGY_USES_OCTAVE:BOOL=OFF -DROBOTOLOGY_USES_PYTHON:BOOL=OFF .
 
+    - name: Disable options unsupported on Ubuntu 18.04
+      if: contains(matrix.os, '18.04') &&  contains(matrix.project_tags, 'Unstable') 
+      run: |
+        cd ${ROBOTOLOGY_SUPERBUILD_SOURCE_DIR}
+        cd build
+        cmake -DROBOTOLOGY_ENABLE_DYNAMICS:BOOL=OFF
+
     - name: Configure [Windows]
       if: contains(matrix.os, 'windows')
       shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -378,7 +378,7 @@ jobs:
       run: |
         cd ${ROBOTOLOGY_SUPERBUILD_SOURCE_DIR}
         cd build
-        cmake -DROBOTOLOGY_ENABLE_DYNAMICS:BOOL=OFF
+        cmake -DROBOTOLOGY_ENABLE_DYNAMICS:BOOL=OFF .
 
     - name: Configure [Windows]
       if: contains(matrix.os, 'windows')

--- a/cmake/Buildcasadi.cmake
+++ b/cmake/Buildcasadi.cmake
@@ -10,7 +10,7 @@ find_or_build_package(osqp QUIET)
 ycm_ep_helper(casadi TYPE GIT
               STYLE GITHUB
               REPOSITORY dic-iit/casadi.git
-              TAG feature/support_osqp_0.6.0
+              TAG support_osqp_0.6.2
               COMPONENT external
               FOLDER src
               CMAKE_ARGS -DWITH_IPOPT:BOOL=ON

--- a/cmake/Buildcasadi.cmake
+++ b/cmake/Buildcasadi.cmake
@@ -9,7 +9,7 @@ find_or_build_package(osqp QUIET)
 
 ycm_ep_helper(casadi TYPE GIT
               STYLE GITHUB
-              REPOSITORY GiulioRomualdi/casadi.git
+              REPOSITORY dic-iit/casadi.git
               TAG feature/support_osqp_0.6.0
               COMPONENT external
               FOLDER src

--- a/cmake/ProjectsTagsStable.cmake
+++ b/cmake/ProjectsTagsStable.cmake
@@ -15,3 +15,6 @@ set_tag(casadi 3.5.5.2)
 set_tag(YCM_TAG ycm-0.12)
 set_tag(YARP_TAG yarp-3.4)
 set_tag(yarp-matlab-bindings_TAG yarp-3.4)
+
+# Temporary workaround for Ubuntu 18.04 spdlog problems
+set_tag(bipedal-locomotion-framework_TAG 5b76dc40b0f9e825e29f8de5e100240b9f7d640c)

--- a/cmake/ProjectsTagsStable.cmake
+++ b/cmake/ProjectsTagsStable.cmake
@@ -9,7 +9,7 @@ set_tag(osqp_TAG v0.6.2)
 set_tag(manif_TAG 0.0.3)
 set_tag(qhull_TAG v8.0.2)
 set_tag(CppAD_TAG 20210000.4)
-set_tag(casadi 3.5.5.1)
+set_tag(casadi 3.5.5.2)
 
 # Robotology projects
 set_tag(YCM_TAG ycm-0.12)

--- a/cmake/ProjectsTagsUnstable.cmake
+++ b/cmake/ProjectsTagsUnstable.cmake
@@ -9,7 +9,7 @@ set_tag(osqp_TAG v0.6.2)
 set_tag(manif_TAG 0.0.3)
 set_tag(qhull_TAG v8.0.2)
 set_tag(CppAD_TAG 20210000.4)
-set_tag(casadi 3.5.5.1)
+set_tag(casadi 3.5.5.2)
 
 # Robotology projects
 set_tag(YARP_TAG master)

--- a/releases/latest.releases.yaml
+++ b/releases/latest.releases.yaml
@@ -21,8 +21,8 @@ repositories:
     version: 20210000.4
   casadi:
     type: git
-    url: https://github.com/GiulioRomualdi/casadi.git
-    version: 3.5.5.1
+    url: https://github.com/dic-iit/casadi.git
+    version: 3.5.5.2
   YCM:
     type: git
     url: https://github.com/robotology/ycm.git


### PR DESCRIPTION
* Use new version of the casadi fork 
* Temporary fix blf version for Stable branch to a version before the use of spdlog, that is incompatible with Ubuntu 18.04 (a few days, just for doing some serious announcements) 
* Disable CI of ROBOTOLOGY_ENABLE_DYNAMICS on Unstable and Ubuntu 18.04