### PR TITLE
Buildcasadi: Disable compilation of examples

### DIFF
--- a/cmake/Buildcasadi.cmake
+++ b/cmake/Buildcasadi.cmake
@@ -15,6 +15,7 @@ ycm_ep_helper(casadi TYPE GIT
               FOLDER src
               CMAKE_ARGS -DWITH_IPOPT:BOOL=ON
                          -DWITH_OSQP:BOOL=ON
+                         -DWITH_EXAMPLES:BOOL=OFF
                          -DUSE_SYSTEM_WISE_OSQP:BOOL=ON
                          -DINCLUDE_PREFIX:PATH=include
                          -DCMAKE_PREFIX:PATH=lib/cmake/casadi


### PR DESCRIPTION
As they are probably not necessary when compiling via the superbuild.