### PR TITLE
Add icub-firmware-models

### DIFF
--- a/releases/latest.releases.yaml
+++ b/releases/latest.releases.yaml
@@ -139,6 +139,10 @@ repositories:
     type: git
     url: https://github.com/robotology/icub-firmware-build.git
     version: v1.19.0
+  icub-firmware-models:
+    type: git
+    url: https://github.com/robotology/icub-firmware-models.git
+    version: devel
   yarp-device-xsensmt:
     type: git
     url: https://github.com/robotology/yarp-device-xsensmt.git


### PR DESCRIPTION
We're required now to maintain `icub-firmware-models` as well.
This PR just introduces it in our pipeline.

To be discussed how to deal with it.

As of now, the new repo sports only `master` and `devel` branches, no tags.