### PR TITLE
Fix upload of Conda packages triggered by schedule

### DIFF
--- a/.github/workflows/generate-conda-packages.yaml
+++ b/.github/workflows/generate-conda-packages.yaml
@@ -109,7 +109,7 @@ jobs:
         - name: Upload conda packages
           shell: bash -l {0}
           # Upload by default on schedule events, and on workflow dispatch only if input upload_conda_binaries is 'true'
-          if: github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && github.event.inputs.upload_conda_binaries == 'true')
+          if: github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && github.event.inputs.upload_conda_binaries == 'true')
           env:
             ANACONDA_API_TOKEN: ${{ secrets.ANACONDA_API_TOKEN }}
           run: |


### PR DESCRIPTION
There was a bug in the condition for which conda packages are uploaded, in particular for scheduled jobs the generated packages were not uploaded (see https://github.com/robotology/robotology-superbuild/actions/runs/699934415 for an example).