### PR TITLE
Fix wrong conda versions for blocktest related packages

### DIFF
--- a/cmake/Buildblocktest-yarp-plugins.cmake
+++ b/cmake/Buildblocktest-yarp-plugins.cmake
@@ -19,4 +19,3 @@ ycm_ep_helper(blocktest-yarp-plugins TYPE GIT
               CMAKE_CACHE_ARGS -DENABLE_MSVC_WARNINGS:BOOL=OFF)
               
 set(blocktest-yarp-plugins_CONDA_DEPENDENCIES boost-cpp)
-set(blocktest-yarp-plugins_CONDA_VERSION "1.1.0.1")

--- a/cmake/Buildblocktestcore.cmake
+++ b/cmake/Buildblocktestcore.cmake
@@ -16,4 +16,3 @@ ycm_ep_helper(blocktestcore TYPE GIT
               DEPENDS YCM)
 
 set(blocktestcore_CONDA_DEPENDENCIES qt boost-cpp)
-set(blocktestcore_CONDA_VERSION "2.3.0.1")


### PR DESCRIPTION
`blocktest` and `blocktest-yarp-plugins` contained the wrong conda version (due to the some old workarounds). This PR should fix this.