### PR TITLE
In conda docs explicitly indicate when the use of conda-forge channel  is needed

### DIFF
--- a/doc/conda-forge.md
+++ b/doc/conda-forge.md
@@ -55,24 +55,24 @@ conda activate robotologyenv
 
 Once you are in an activated environment, you can install robotology packages by just running the command:
 ~~~
-conda install -c robotology <packagename>
+conda install -c conda-forge -c robotology <packagename>
 ~~~
 
 The list of available packages is available at https://anaconda.org/robotology/repo . 
 
 For example, if you want to install yarp and icub-main, you simple need to install:
 ~~~
-conda install -c robotology yarp icub-main
+conda install -c conda-forge -c robotology yarp icub-main
 ~~~
 
 In addition, if you want to simulate the iCub in Gazebo, you should also install `icub-models` and `gazebo-yarp-plugins`:
 ~~~
-conda install -c robotology gazebo-yarp-plugins icub-models
+conda install -c conda-forge -c robotology gazebo-yarp-plugins icub-models
 ~~~
 
 If you want to develop some C++ code on the top of these libraries, it is recommended to also install the necessary compiler and development tools directly in the same environment:
 ~~~
-conda install compilers cmake pkg-config make ninja
+conda install -c conda-forge compilers cmake pkg-config make ninja
 ~~~
 
 ## Source installation
@@ -107,18 +107,18 @@ of the robotology-superbuild.**
 
 Once you activated it, you can install packages in it. In particular the dependencies for the robotology-superbuild can be installed as:
 ~~~
-conda install cmake compilers make ninja pkg-config
-conda install ace asio boost eigen gazebo glew glfw gsl ipopt libjpeg-turbo libmatio libode libxml2 opencv pkg-config portaudio qt sdl sdl2 sqlite tinyxml spdlog
+conda install -c conda-forge cmake compilers make ninja pkg-config
+conda install -c conda-forge ace asio boost eigen gazebo glew glfw gsl ipopt libjpeg-turbo libmatio libode libxml2 opencv pkg-config portaudio qt sdl sdl2 sqlite tinyxml spdlog
 ~~~
 
 If you are on **Linux**, you also need to install also the following packages:
 ~~~
-conda install expat-cos6-x86_64 freeglut libdc1394 libselinux-cos6-x86_64 libxau-cos6-x86_64 libxcb-cos6-x86_64 libxdamage-cos6-x86_64 libxext-cos6-x86_64 libxfixes-cos6-x86_64 libxxf86vm-cos6-x86_64 mesalib mesa-libgl-cos6-x86_64
+conda install -c conda-forge expat-cos6-x86_64 freeglut libdc1394 libselinux-cos6-x86_64 libxau-cos6-x86_64 libxcb-cos6-x86_64 libxdamage-cos6-x86_64 libxext-cos6-x86_64 libxfixes-cos6-x86_64 libxxf86vm-cos6-x86_64 mesalib mesa-libgl-cos6-x86_64
 ~~~
 
 If you are on **Windows**, you also need to install also the following packages:
 ~~~
-conda install freeglut
+conda install -c conda-forge freeglut
 ~~~
 
 ### Clone the repo


### PR DESCRIPTION
When building from sources or from binaries, we were implicitly assuming that the user already had the `conda-forge` channel configured by default. While this is the case for the `miniforge` distribution that we **suggest** to use, it may not be true for users or system using other distributions such as miniconda (see for example https://github.com/dic-iit/bipedal-locomotion-framework/issues/230#issuecomment-815562835) or anaconda (https://github.com/robotology/robotology-superbuild/issues/679).

For this reason, it make sense to modify the instructions to always specify the `-c conda-forge` option. This is also useful for the future, when we may migrate packages from the `robotology` channel to the `conda-forge` one, and we want the `conda-forge` one to have the precedence. 