### PR TITLE
Do not source hardcoded Gazebo's setup.sh on Conda

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,10 +61,10 @@ endif()
 
 # Configure a setup.sh
 if(ROBOTOLOGY_USES_GAZEBO)
-  if(WIN32)
-    # On Windows we assume that the Gazebo's enviroment variables are already set,
+  if(WIN32 OR ROBOTOLOGY_CONFIGURING_UNDER_CONDA)
+    # On Windows or Conda we assume that the Gazebo's enviroment variables are already set,
     # so we set as this name a file that does not exists and so will be ignored
-    set(GAZEBO_SETUP_SH_PATH "on-windows-we-assume-that-gazebo-env-variables-are-already-set")
+    set(GAZEBO_SETUP_SH_PATH "on-windows-or-conda-we-assume-that-gazebo-env-variables-are-already-set")
   # TODO(traversaro): make sure that Gazebo exports this, for now hardcode
   elseif(APPLE)
     set(GAZEBO_SETUP_SH_PATH "/usr/local/share/gazebo/setup.sh")


### PR DESCRIPTION
On conda, the Gazebo's environment variables are already set in the environment activation scripts, so there is no need to source it manually in the `setup.sh` script. Actually, we need to make sure that the apt-installed Gazebo setup.sh is not accidentally sourced, as that could conflict with the conda-installed one. 