### PR TITLE
Add the possibility to compile the casadi python bindings

### DIFF
--- a/cmake/Buildcasadi.cmake
+++ b/cmake/Buildcasadi.cmake
@@ -1,5 +1,5 @@
 # Copyright (C) 2020  iCub Facility, Istituto Italiano di Tecnologia
-# Authors: Giulio Romualdi <gulio.romualdi@iit.it>
+# Authors: Giulio Romualdi <giulio.romualdi@iit.it>
 # CopyPolicy: Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
 
 include(YCMEPHelper)

--- a/cmake/Buildcasadi.cmake
+++ b/cmake/Buildcasadi.cmake
@@ -21,6 +21,8 @@ ycm_ep_helper(casadi TYPE GIT
                          -DCMAKE_PREFIX:PATH=lib/cmake/casadi
                          -DLIB_PREFIX:PATH=lib
                          -DBIN_PREFIX:PATH=bin
+                         -DWITH_PYTHON:BOOL=${ROBOTOLOGY_USES_PYTHON}
+                         -DPYTHON_PREFIX:PATH=${ROBOTOLOGY_SUPERBUILD_PYTHON_INSTALL_DIR}
               DEPENDS osqp)
 
 set(casadi_CONDA_PKG_NAME casadi)

--- a/cmake/ProjectsTagsStable.cmake
+++ b/cmake/ProjectsTagsStable.cmake
@@ -9,7 +9,7 @@ set_tag(osqp_TAG v0.6.2)
 set_tag(manif_TAG 0.0.3)
 set_tag(qhull_TAG v8.0.2)
 set_tag(CppAD_TAG 20210000.4)
-set_tag(casadi 3.5.5.2)
+set_tag(casadi 3.5.5.3)
 
 # Robotology projects
 set_tag(YCM_TAG ycm-0.12)

--- a/cmake/ProjectsTagsUnstable.cmake
+++ b/cmake/ProjectsTagsUnstable.cmake
@@ -9,7 +9,7 @@ set_tag(osqp_TAG v0.6.2)
 set_tag(manif_TAG 85cad9841b0ac4800e10e38c634c397d401e6375)
 set_tag(qhull_TAG v8.0.2)
 set_tag(CppAD_TAG 20210000.4)
-set_tag(casadi 3.5.5.2)
+set_tag(casadi 3.5.5.3)
 
 # Robotology projects
 set_tag(YARP_TAG master)

--- a/releases/latest.releases.yaml
+++ b/releases/latest.releases.yaml
@@ -22,7 +22,7 @@ repositories:
   casadi:
     type: git
     url: https://github.com/dic-iit/casadi.git
-    version: 3.5.5.2
+    version: 3.5.5.3
   YCM:
     type: git
     url: https://github.com/robotology/ycm.git


### PR DESCRIPTION
Before merging the PR we should use casadi version `3.5.5.3`. I've just created the tag. I don't know if I can bump the new tag in this PR or handle it in a separate PR