### PR TITLE
Specify both YARP 3.4 and 3.5 style options for depthimage portmonitor

### DIFF
--- a/cmake/BuildYARP.cmake
+++ b/cmake/BuildYARP.cmake
@@ -57,6 +57,9 @@ ycm_ep_helper(YARP TYPE GIT
                               -DENABLE_yarpcar_bayer:BOOL=ON
                               -DENABLE_yarpcar_mjpeg:BOOL=${ENABLE_yarpcar_mjpeg}
                               -DENABLE_yarpcar_portmonitor:BOOL=ON
+                              -DENABLE_yarppm_depthimage_to_mono:BOOL=ON
+                              -DENABLE_yarppm_depthimage_to_rgb:BOOL=ON
+                              # Deprecated, remove when YARP 3.5 is in Stable branches and latest releases
                               -DENABLE_yarpcar_depthimage:BOOL=ON
                               -DENABLE_yarpcar_depthimage2:BOOL=ON
                               -DENABLE_yarpidl_thrift:BOOL=ON


### PR DESCRIPTION
See https://github.com/robotology/yarp/pull/2552 . As we now need to support both YARP 3.4 (Stable branches and latest releases) and YARP 3.5 (Unstable branches) we will pass both options, as this should work fine and avoid to trigger the bug https://github.com/robotology/yarp/issues/2556 .

Fix https://github.com/robotology/robotology-superbuild/issues/695