### PR TITLE
Buildcasadi: pass WITH_PYTHON3 option when Python bindings are built

### DIFF
--- a/cmake/Buildcasadi.cmake
+++ b/cmake/Buildcasadi.cmake
@@ -23,6 +23,7 @@ ycm_ep_helper(casadi TYPE GIT
                          -DBIN_PREFIX:PATH=bin
                          -DWITH_PYTHON:BOOL=${ROBOTOLOGY_USES_PYTHON}
                          -DWITH_PYTHON3:BOOL=${ROBOTOLOGY_USES_PYTHON}
+                         -DWITH_COPYSIGN_UNDEF=ON
                          -DPYTHON_PREFIX:PATH=${ROBOTOLOGY_SUPERBUILD_PYTHON_INSTALL_DIR}
               DEPENDS osqp)
 

--- a/cmake/Buildcasadi.cmake
+++ b/cmake/Buildcasadi.cmake
@@ -22,6 +22,7 @@ ycm_ep_helper(casadi TYPE GIT
                          -DLIB_PREFIX:PATH=lib
                          -DBIN_PREFIX:PATH=bin
                          -DWITH_PYTHON:BOOL=${ROBOTOLOGY_USES_PYTHON}
+                         -DWITH_PYTHON3:BOOL=${ROBOTOLOGY_USES_PYTHON}
                          -DPYTHON_PREFIX:PATH=${ROBOTOLOGY_SUPERBUILD_PYTHON_INSTALL_DIR}
               DEPENDS osqp)
 

--- a/cmake/Buildcasadi.cmake
+++ b/cmake/Buildcasadi.cmake
@@ -7,6 +7,12 @@ include(YCMEPHelper)
 include(FindOrBuildPackage)
 find_or_build_package(osqp QUIET)
 
+if(MSVC AND ROBOTOLOGY_USES_PYTHON)
+  set(WITH_COPYSIGN_UNDEF ON)
+else()
+  set(WITH_COPYSIGN_UNDEF OFF)
+endif()
+
 ycm_ep_helper(casadi TYPE GIT
               STYLE GITHUB
               REPOSITORY dic-iit/casadi.git
@@ -23,7 +29,7 @@ ycm_ep_helper(casadi TYPE GIT
                          -DBIN_PREFIX:PATH=bin
                          -DWITH_PYTHON:BOOL=${ROBOTOLOGY_USES_PYTHON}
                          -DWITH_PYTHON3:BOOL=${ROBOTOLOGY_USES_PYTHON}
-                         -DWITH_COPYSIGN_UNDEF=ON
+                         -DWITH_COPYSIGN_UNDEF:BOOL=${WITH_COPYSIGN_UNDEF}
                          -DPYTHON_PREFIX:PATH=${ROBOTOLOGY_SUPERBUILD_PYTHON_INSTALL_DIR}
               DEPENDS osqp)
 


### PR DESCRIPTION
Follow up of https://github.com/robotology/robotology-superbuild/pull/694, fix https://github.com/robotology/robotology-superbuild/issues/698 by explicitly requesting to use Python3, that means that the system Python should not be used on macOS .

The use of this option is copied from https://github.com/conda-forge/casadi-feedstock/blob/391139c859e1fba1321818bae27b6ca11fa4081e/recipe/build.sh#L7 .