### PR TITLE
Add bump-conda-build-number job to generate-conda-packages

### DIFF
--- a/.github/workflows/generate-conda-packages.yaml
+++ b/.github/workflows/generate-conda-packages.yaml
@@ -117,4 +117,17 @@ jobs:
             ls *.tar.bz2
             anaconda upload --skip-existing *.tar.bz2
 
+    # If the  generate-conda-packages completed correctly and binaries are uploaded,
+    # bump automatically the CONDA_BUILD_NUMBER in conda/cmake/CondaGenerationOptions.cmake
+    # for future builds
+    bump-conda-build-number:
+        name: "Bump Conda Build number for future builds"
+        runs-on: ubuntu-latest
+        needs: generate-conda-packages
+        if: github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && github.event.inputs.upload_conda_binaries == 'true')
 
+        steps:
+        - name: Bump Conda Build number for future builds
+          shell: bash
+          run: |
+            sh ./scripts/robotologyBumpCondaBuildNumber.sh 

--- a/.github/workflows/generate-conda-packages.yaml
+++ b/.github/workflows/generate-conda-packages.yaml
@@ -127,7 +127,14 @@ jobs:
         if: github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && github.event.inputs.upload_conda_binaries == 'true')
 
         steps:
+        - uses: actions/checkout@v2
+        
         - name: Bump Conda Build number for future builds
           shell: bash
           run: |
             sh ./scripts/robotologyBumpCondaBuildNumber.sh 
+      
+        - uses: EndBug/add-and-commit@v7.0.0
+          with:
+            default_author: github_actions
+            message: 'Bump CONDA_BUILD_NUMBER after successful Conda packages build and upload'

--- a/scripts/robotologyBumpCondaBuildNumber.sh
+++ b/scripts/robotologyBumpCondaBuildNumber.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+# Script to automatically update the CONDA_BUILD_NUMBER parameter in
+# the conda/cmake/CondaGenerationOptions.cmake file
+# after a successful build and upload of Conda binaries
+
+# To run it locally, make sure that you have awk installed, and execute it
+# from the root of the robotology-superbuild:
+# cd robotology-superbuild
+# ./scripts/robotologyBumpCondaBuildNumber.sh 
+
+# Inspired from https://superuser.com/questions/198143/increment-one-value-in-a-text-line-using-script
+cp ./conda/cmake/CondaGenerationOptions.cmake /tmp/CondaGenerationOptions.cmake
+awk '{if ($1 == "set(CONDA_BUILD_NUMBER") printf("%s %d)\n", $1, $2 + 1); else print $0;}' /tmp/CondaGenerationOptions.cmake > ./conda/cmake/CondaGenerationOptions.cmake


### PR DESCRIPTION
To ensure that each new build of the packages get correctly uploaded, even if the package version was not uploaded (for example because one of the dependencies that influences its ABI was updated) we have a `CONDA_BUILD_NUMBER` parameter in the `conda/cmake/CondaGenerationOptions.cmake` , that specifies the [Conda build number](https://docs.conda.io/projects/conda-build/en/latest/resources/define-metadata.html#build-number-and-string) that is used by all Conda packages.

This parameter should be bumped at each successful generation and upload of Conda binaries, and until now I have done this manually (see for example https://github.com/robotology/robotology-superbuild/commit/7a10e5088ad33a2166bb5635038b9c58fbb5fc8c and https://github.com/robotology/robotology-superbuild/commit/0df5e6a997ce716a947ef09630516db5b1726e12). However, this is quite error prone, so in this PR I added an additional job that if the generation and upload of packages works fine, also bumps the `CONDA_BUILD_NUMBER`  automatically.