### PR TITLE
generate-conda-packages: Use conda-forge-pinning conda_build_config.yaml

### DIFF
--- a/.github/workflows/generate-conda-packages.yaml
+++ b/.github/workflows/generate-conda-packages.yaml
@@ -70,7 +70,7 @@ jobs:
         - name: Dependencies for conda recipes generation and upload
           shell: bash -l {0}
           run: |
-            mamba install pyyaml jinja2 conda-build ninja anaconda-client
+            mamba install pyyaml jinja2 conda-build ninja anaconda-client conda-forge-pinning
             python -m pip install git+https://github.com/wolfv/multisheller.git@0cc03c68d0c68d2f9cf7b07ddb68afa531419a6d
 
         - name: Generate recipes [Linux&macOS]

--- a/.github/workflows/generate-conda-packages.yaml
+++ b/.github/workflows/generate-conda-packages.yaml
@@ -104,7 +104,9 @@ jobs:
           shell: bash -l {0}
           run: |
             cd build/conda/generated_recipes
-            conda build -m ${GITHUB_WORKSPACE}/conda/conda_build_config.yml .
+            # We use the conda_build_config from conda-forge-pinning, and our local one
+            # See https://docs.conda.io/projects/conda-build/en/latest/resources/variants.html#creating-conda-build-variant-config-files
+            conda build -m ${CONDA_PREFIX}/conda_build_config.yaml -m ${GITHUB_WORKSPACE}/conda/conda_build_config.yml .
 
         - name: Upload conda packages
           shell: bash -l {0}

--- a/conda/conda_build_config.yml
+++ b/conda/conda_build_config.yml
@@ -1,3 +1,7 @@
 # bipedal-locomotion-framework requires 10.13 for std::bad_cast_any
 MACOSX_DEPLOYMENT_TARGET:      # [osx and x86_64]
   - 10.13                      # [osx and x86_64]
+
+# Pin opencv to as a workaround for https://github.com/robotology/robotology-superbuild/issues/711
+opencv:
+  - 4.5.1

--- a/conda/conda_build_config.yml
+++ b/conda/conda_build_config.yml
@@ -2,6 +2,6 @@
 MACOSX_DEPLOYMENT_TARGET:      # [osx and x86_64]
   - 10.13                      # [osx and x86_64]
 
-# Pin opencv to as a workaround for https://github.com/robotology/robotology-superbuild/issues/711
+# Pin opencv 4.5.1 to as a workaround for https://github.com/robotology/robotology-superbuild/issues/711
 opencv:
   - 4.5.1

--- a/doc/conda-recipe-generation.md
+++ b/doc/conda-recipe-generation.md
@@ -13,7 +13,7 @@ To generate the conda recipes for a given configuration of the `robotology-super
 
 After that, install the additional dependencies required for the recipe generation:
 ~~~
-conda install pyyaml jinja2 conda-build ninja anaconda-client
+conda install pyyaml jinja2 conda-build ninja anaconda-client conda-forge-pinning
 python -m pip install git+https://github.com/wolfv/multisheller.git@0cc03c68d0c68d2f9cf7b07ddb68afa531419a6d
 ~~~
 
@@ -25,7 +25,15 @@ for building projects of the `robotology-superbuild`, and instead will generate 
 -- Generating done
 -- Build files have been written to: C:/src/robotology-superbuild/build-conda
 ~~~
-you can then build the generated recipes by moving in the `<build_dir>/conda/generated_recipes` directory and running either [`conda build .`](https://github.com/conda/conda-build) or [`boa .`](https://github.com/mamba-org/boa).
+you can then build the generated recipes. To build the generate recipes, you can move in the `<build_dir>/conda/generated_recipes` directory and run the appropriate build command using [`conda build`](https://github.com/conda/conda-build) :
+~~~
+cd <build_dir>/conda/generated_recipes
+conda build -m ${CONDA_PREFIX}/conda_build_config.yaml -m <src_dir>/conda/conda_build_config.yml .
+~~~
+The `-m` option specifies the additional [build configuration files that are used for conda-build](https://docs.conda.io/projects/conda-build/en/latest/resources/variants.html#creating-conda-build-variant-config-files). In particular, we use two `conda_build_config` files. 
+The first one is the standard one of conda-forge, installed via the [`conda-forge-pinning`](https://github.com/conda-forge/conda-forge-pinning-feedstock) package,
+and that is used to ensure compatibility with conda-forge binaries. The second is a local file, that is used to specify setting specific to the `robotology` channel.
+
 
 Note that the generated recipes will depend on the specific configuration of the robotology-superbuild used, so enabling additional profiles will generate recipes
 for the packages contained in those profiles. For this reason, the generated recipes in general are not cross-platform. For example the recipes generated on `Linux` could contain Linux-specific CMake options passed to the projects, so may not be usable on Windows.


### PR DESCRIPTION
As documented in https://docs.conda.io/projects/conda-build/en/latest/resources/variants.html#creating-conda-build-variant-config-files, the `conda_build_config.yaml` files can be used to specified the specific version of the libraries used, to build multiple versions of the libraries, or to specific more options. 

Until now when generating conda packages we just used our local `conda/conda_build_config.yml` file, now as explained in https://github.com/robotology/robotology-superbuild/issues/708 we will switch to consider the conda-forge `conda_build_config.yaml` (mantained at https://github.com/conda-forge/conda-forge-pinning-feedstock) to ensure the maximum compatibility of our binaries with the one compiled by conda-forge. 