### PR TITLE
Create MATLAB script for simple local few line installation of MATLAB packages

### DIFF
--- a/doc/matlab-one-line-install.md
+++ b/doc/matlab-one-line-install.md
@@ -1,0 +1,29 @@
+# One-line Installation of Robotology MATLAB/Simulink Packages
+
+This guide provides a simple documentation to install use Robotology MATLAB/Simulink packages in a pure MATLAB workflow (so without launching **anything else** via terminal, so for example no Gazebo simulation).
+
+## Installation on Local MATLAB Installation
+~~~matlab
+websave('install_robotology_packages.m', 'https://gist.githubusercontent.com/traversaro/cb955c93c71728be65e881d9766e74fb/raw/003d4efb4dd0d1f22754aac551126e6447f53285/install_robotology_packages.m')
+install_robotology_packages
+robotology_setup
+~~~
+This will install everything in a `robotology-gazebo` local directory, without perturbing anything else in your system. 
+Once installed, you just need to re-run the `robotology_setup` script (or add it in your [`setup.m`](https://www.mathworks.com/help/matlab/ref/startup.html) file) to make the library available again. The overall installation process should take 2/3 minutes.
+
+
+## Installation on MATLAB Online
+Due to specific problems on MATLAB Online, you can't install the libraries in the local directory, and if you need to run this on MATLAB Online the command is slightly nmore difficult: 
+~~~matlab
+websave('install_robotology_packages.m', 'https://gist.githubusercontent.com/traversaro/cb955c93c71728be65e881d9766e74fb/raw/003d4efb4dd0d1f22754aac551126e6447f53285/install_robotology_packages.m')
+install_robotology_packages(installPrefix=fullfile(getenv('HOME'),'robotology-matlab'))
+robotology_setup
+~~~
+
+## Uninstall 
+
+To remove the packages installed by this guide, just remove the `robotology-gazebo` and the `install_robotology_packages.m` and `robotology_setup.m` scripts created by the installation.
+
+## Technical Details
+
+Under the hood, the `install_robotology_packages.m` scripts just automatically installs a conda environment in the `robotology-gazebo`, automatically following the command described in [documentation on how to install robotology binary packages via conda](doc/conda.md).

--- a/doc/matlab-one-line-install.md
+++ b/doc/matlab-one-line-install.md
@@ -1,6 +1,6 @@
 # One-line Installation of Robotology MATLAB/Simulink Packages
 
-This guide provides a simple documentation to install use Robotology MATLAB/Simulink packages in a pure MATLAB workflow (so without launching **anything else** via terminal, so for example no Gazebo simulation).
+This guide provides a simple documentation to install Robotology MATLAB/Simulink packages in a pure MATLAB workflow (so without launching **anything else** via terminal, so for example no Gazebo simulation).
 
 ## Installation
 ~~~matlab
@@ -8,7 +8,7 @@ websave('install_robotology_packages.m', 'https://raw.githubusercontent.com/robo
 install_robotology_packages
 robotology_setup
 ~~~
-This will install everything in a `robotology-gazebo` local directory, without perturbing anything else in your system. 
+This will install everything in a `robotology-matlab` local directory, without perturbing anything else in your system. 
 Once installed, you just need to re-run the `robotology_setup` script (or add it in your [`setup.m`](https://www.mathworks.com/help/matlab/ref/startup.html) file) to make the library available again. The overall installation process should take 2/3 minutes.
 
 If the installation and launching the `robotology_setup`, you should be able to run the following MATLAB code without any error:

--- a/doc/matlab-one-line-install.md
+++ b/doc/matlab-one-line-install.md
@@ -4,7 +4,7 @@ This guide provides a simple documentation to install use Robotology MATLAB/Simu
 
 ## Installation
 ~~~matlab
-websave('install_robotology_packages.m', 'https://gist.githubusercontent.com/traversaro/cb955c93c71728be65e881d9766e74fb/raw/003d4efb4dd0d1f22754aac551126e6447f53285/install_robotology_packages.m')
+websave('install_robotology_packages.m', 'https://raw.githubusercontent.com/robotology/robotology-superbuild/master/scripts/install_robotology_packages.m')
 install_robotology_packages
 robotology_setup
 ~~~
@@ -25,7 +25,7 @@ vec.toString();
 
 Due to specific problems on MATLAB Online, you can't install the libraries in the local directory, and if you need to run this on MATLAB Online the command is slightly nmore difficult: 
 ~~~matlab
-websave('install_robotology_packages.m', 'https://gist.githubusercontent.com/traversaro/cb955c93c71728be65e881d9766e74fb/raw/003d4efb4dd0d1f22754aac551126e6447f53285/install_robotology_packages.m')
+websave('install_robotology_packages.m', 'https://raw.githubusercontent.com/robotology/robotology-superbuild/master/scripts/install_robotology_packages.m')
 install_robotology_packages(installPrefix=fullfile(getenv('HOME'),'robotology-matlab'))
 robotology_setup
 ~~~

--- a/doc/matlab-one-line-install.md
+++ b/doc/matlab-one-line-install.md
@@ -2,7 +2,7 @@
 
 This guide provides a simple documentation to install use Robotology MATLAB/Simulink packages in a pure MATLAB workflow (so without launching **anything else** via terminal, so for example no Gazebo simulation).
 
-## Installation on Local MATLAB Installation
+## Installation
 ~~~matlab
 websave('install_robotology_packages.m', 'https://gist.githubusercontent.com/traversaro/cb955c93c71728be65e881d9766e74fb/raw/003d4efb4dd0d1f22754aac551126e6447f53285/install_robotology_packages.m')
 install_robotology_packages
@@ -11,8 +11,18 @@ robotology_setup
 This will install everything in a `robotology-gazebo` local directory, without perturbing anything else in your system. 
 Once installed, you just need to re-run the `robotology_setup` script (or add it in your [`setup.m`](https://www.mathworks.com/help/matlab/ref/startup.html) file) to make the library available again. The overall installation process should take 2/3 minutes.
 
+If the installation and launching the `robotology_setup`, you should be able to run the following MATLAB code without any error:
+~~~
+vec = iDynTree.Vector3();
+vec.fromMatlab([1,2,3])
+vec.toString();
+~~~
 
-## Installation on MATLAB Online
+
+
+### Installation on MATLAB Online
+**This section is required only if you want to use this on [MATLAB Online](https://www.mathworks.com/products/matlab-online.html). If you are using a MATLAB installation on your system, please skip it.**
+
 Due to specific problems on MATLAB Online, you can't install the libraries in the local directory, and if you need to run this on MATLAB Online the command is slightly nmore difficult: 
 ~~~matlab
 websave('install_robotology_packages.m', 'https://gist.githubusercontent.com/traversaro/cb955c93c71728be65e881d9766e74fb/raw/003d4efb4dd0d1f22754aac551126e6447f53285/install_robotology_packages.m')

--- a/doc/matlab-one-line-install.md
+++ b/doc/matlab-one-line-install.md
@@ -36,4 +36,4 @@ To remove the packages installed by this guide, just remove the `robotology-gaze
 
 ## Technical Details
 
-Under the hood, the `install_robotology_packages.m` scripts just automatically installs a conda environment in the `robotology-gazebo`, automatically following the command described in [documentation on how to install robotology binary packages via conda](doc/conda.md).
+Under the hood, the `install_robotology_packages.m` scripts just automatically installs a conda environment in the `robotology-gazebo`, automatically following the command described in [documentation on how to install robotology binary packages via conda](./conda.md).

--- a/scripts/install_robotology_packages.m
+++ b/scripts/install_robotology_packages.m
@@ -15,7 +15,8 @@ function install_robotology_packages(varargin)
         return;
     end
 
-    fprintf('Installing robotology MATLAB/Simulink binaries in %s', install_prefix);
+    fprintf('Installing robotology MATLAB/Simulink binaries in %s\n', install_prefix);
+
     % The install url is created following 
     mambaforge_url_prefix = 'https://github.com/conda-forge/miniforge/releases/latest/download/';
     if ispc
@@ -34,25 +35,38 @@ function install_robotology_packages(varargin)
         uname_m = strip(uname_m);
         mambaforge_installer_name = sprintf('Mambaforge-%s-%s.sh', uname, uname_m);
     end
+    
+    fprintf('Downloading mambaforge installer \n');
     mambaforge_installer_url = strcat(mambaforge_url_prefix, mambaforge_installer_name);
     websave(mambaforge_installer_name, mambaforge_installer_url);
-    
+    fprintf('Download of mambaforge installer completed\n');
+
+    % See https://github.com/conda-forge/miniforge#non-interactive-install
+    fprintf('Installing mambaforge\n');
     if ispc
-        system(sprintf('TODO'));
-        mamba_full_path = 'TODO';
+        system(sprintf('start /wait "" %s /InstallationType=JustMe /RegisterPython=0 /S /D=%s', mambaforge_installer_name, install_prefix));
+        conda_full_path = fullfile(install_prefix, 'condabin', 'conda.bat');
+        % On Windows, the files in conda are installed in the Library
+        % subdirectory of the prefix
+        robotology_install_prefix = fullfile(install_prefix, 'Library');
     elseif isunix
         system(sprintf('sh %s -b -p %s', mambaforge_installer_name, install_prefix));
-        mamba_full_path = fullfile(install_prefix, 'bin', 'mamba');
+        conda_full_path = fullfile(install_prefix, 'bin', 'conda');
+        robotology_install_prefix = install_prefix;
     end
+    fprintf('Installation of mambaforge completed\n');
     
+    
+
     if ~exist(install_prefix, 'dir')
-        fprintf('Installation in %s failed for unknown reason, please open an issue at https://github.com/robotology/robotology-superbuild/issues/new', install_prefix);
+        fprintf('Installation in %s failed for unknown reason, please open an issue at https://github.com/robotology/robotology-superbuild/issues/new\n', install_prefix);
         return;
     end
     
     % Install all the robotology packages related to MATLAB or Simulink
-    system(sprintf('%s install -y -c conda-forge -c robotology yarp-matlab-bindings idyntree wb-toolbox osqp-matlab whole-body-controllers matlab-whole-body-simulator icub-models', mamba_full_path));    
-    fprintf('\t\t\t\t[done]\n');
+    fprintf('Installing robotology packages\n');
+    system(sprintf('%s install -y -c conda-forge -c robotology yarp-matlab-bindings idyntree wb-toolbox osqp-matlab whole-body-controllers matlab-whole-body-simulator icub-models', conda_full_path));    
+    fprintf('Installation of robotology packages completed\n');
 
     fprintf('Creating setup script in %s', setup_script);
     % Generate robotology_setup.m 
@@ -67,7 +81,7 @@ function install_robotology_packages(varargin)
     fprintf(setupID, 'end\n');
     fprintf(setupID, '\n');
     fprintf(setupID, '%% Install prefix (hardcoded at generation time)\n');
-    fprintf(setupID, 'robotology_install_prefix = "%s";\n', install_prefix);
+    fprintf(setupID, 'robotology_install_prefix = "%s";\n', robotology_install_prefix);
     fprintf(setupID, '\n');
     fprintf(setupID, '%% Add directory to MATLAB path\n');
     fprintf(setupID, 'addpath(fullfile(robotology_install_prefix,"mex"));\n');
@@ -84,13 +98,12 @@ function install_robotology_packages(varargin)
     fprintf(setupID, 'setenv("ROS_PACKAGE_PATH",strcat(fullfile(robotology_install_prefix,"share"), rob_env_sep, getenv("ROS_PACKAGE_PATH")));\n');
     fprintf(setupID, 'setenv("BLOCKFACTORY_PLUGIN_PATH",fullfile(robotology_install_prefix,rob_shlib_install_dir,"blockfactory"));\n');
     fclose(setupID);
-    fprintf('\t\t\t\t[done]\n');
 
-    fprintf('Deleting temporary files...');
+    fprintf('Deleting mambaforge installer');
     delete(mambaforge_installer_name);
-    fprintf('\t\t\t[done]\n');
 
     fprintf('robotology MATLAB and Simulink packages are successfully installed!\n');
-    fprintf('Please run %s before using the packages, or just add that script to your startup.m file, to run it whenever you open MATLAB.\n', setup_script);
+    fprintf('Please run %s before using the packages,\n',setup_script)
+    fprintf('or just add that script to your startup.m file, to run it whenever you open MATLAB.\n');
     fprintf('To uninstall these packages, just delete the folder %s.\n', install_prefix);
 end

--- a/scripts/install_robotology_packages.m
+++ b/scripts/install_robotology_packages.m
@@ -1,0 +1,96 @@
+function install_robotology_packages(varargin)
+    % Install the robotology MATLAB/Simulink packages in a local directory
+    p = inputParser;
+    default_install_prefix = fullfile(pwd,'robotology-matlab');
+    addOptional(p,'installPrefix', default_install_prefix);
+    parse(p,varargin{:});
+      
+    % Build package installation directory
+    install_prefix = p.Results.installPrefix;
+
+    setup_script = fullfile(pwd, 'robotology_setup.m');
+      
+    if exist(install_prefix)
+        fprintf('Directory %s already present. Please use it or delete to proceed with the install', install_prefix);
+        return;
+    end
+
+    fprintf('Installing robotology MATLAB/Simulink binaries in %s', install_prefix);
+    % The install url is created following 
+    mambaforge_url_prefix = 'https://github.com/conda-forge/miniforge/releases/latest/download/';
+    if ispc
+        mambaforge_installer_name = 'Mambaforge-Windows-x86_64.exe';
+    elseif ismac
+        [~, uname_m] = system('uname -m');
+        % Remove newline
+        uname_m = strip(uname_m);
+        mambaforge_installer_name = sprintf('Mambaforge-MacOSX-%s.sh', uname_m);
+    elseif isunix
+        [~, uname] = system('uname');
+        % Remove newline
+        uname = strip(uname);
+        [~, uname_m] = system('uname -m');
+        % Remove newline
+        uname_m = strip(uname_m);
+        mambaforge_installer_name = sprintf('Mambaforge-%s-%s.sh', uname, uname_m);
+    end
+    mambaforge_installer_url = strcat(mambaforge_url_prefix, mambaforge_installer_name);
+    websave(mambaforge_installer_name, mambaforge_installer_url);
+    
+    if ispc
+        system(sprintf('TODO'));
+        mamba_full_path = 'TODO';
+    elseif isunix
+        system(sprintf('sh %s -b -p %s', mambaforge_installer_name, install_prefix));
+        mamba_full_path = fullfile(install_prefix, 'bin', 'mamba');
+    end
+    
+    if ~exist(install_prefix, 'dir')
+        fprintf('Installation in %s failed for unknown reason, please open an issue at https://github.com/robotology/robotology-superbuild/issues/new', install_prefix);
+        return;
+    end
+    
+    % Install all the robotology packages related to MATLAB or Simulink
+    system(sprintf('%s install -y -c conda-forge -c robotology yarp-matlab-bindings idyntree wb-toolbox osqp-matlab whole-body-controllers matlab-whole-body-simulator icub-models', mamba_full_path));    
+    fprintf('\t\t\t\t[done]\n');
+
+    fprintf('Creating setup script in %s', setup_script);
+    % Generate robotology_setup.m 
+    setupID = fopen(setup_script,'w');
+    fprintf(setupID, '%% Specify OS-specific locations\n');
+    fprintf(setupID, 'if ispc\n');
+    fprintf(setupID, '    rob_env_sep = ";";\n');
+    fprintf(setupID, '    rob_shlib_install_dir = "bin";\n');
+    fprintf(setupID, 'else\n');
+    fprintf(setupID, '    rob_env_sep = ":";\n');
+    fprintf(setupID, '    rob_shlib_install_dir = "lib";\n');
+    fprintf(setupID, 'end\n');
+    fprintf(setupID, '\n');
+    fprintf(setupID, '%% Install prefix (hardcoded at generation time)\n');
+    fprintf(setupID, 'robotology_install_prefix = "%s";\n', install_prefix);
+    fprintf(setupID, '\n');
+    fprintf(setupID, '%% Add directory to MATLAB path\n');
+    fprintf(setupID, 'addpath(fullfile(robotology_install_prefix,"mex"));\n');
+    fprintf(setupID, 'addpath(fullfile(robotology_install_prefix,"mex/+wbc/simulink"));\n');
+    fprintf(setupID, 'addpath(fullfile(robotology_install_prefix,"share/WBToolbox"));\n');
+    fprintf(setupID, 'addpath(fullfile(robotology_install_prefix,"share/WBToolbox/images"));\n');
+    fprintf(setupID, '\n');
+    fprintf(setupID, '%% Append required values to system environment variables\n');
+    fprintf(setupID, 'setenv("PATH",strcat(fullfile(robotology_install_prefix,"bin"), rob_env_sep, getenv("PATH")));\n');
+    fprintf(setupID, 'setenv("YARP_DATA_DIRS",strcat(fullfile(robotology_install_prefix,"share/yarp"), ...\n');
+    fprintf(setupID, '       rob_env_sep, fullfile(robotology_install_prefix,"share/iCub"), ...\n');
+    fprintf(setupID, '       rob_env_sep, fullfile(robotology_install_prefix,"share/ICUBcontrib"), ...\n');
+    fprintf(setupID, '       rob_env_sep, fullfile(robotology_install_prefix,"share/RRbot")));\n');
+    fprintf(setupID, 'setenv("ROS_PACKAGE_PATH",strcat(fullfile(robotology_install_prefix,"share"), rob_env_sep, getenv("ROS_PACKAGE_PATH")));\n');
+    fprintf(setupID, 'setenv("BLOCKFACTORY_PLUGIN_PATH",fullfile(robotology_install_prefix,rob_shlib_install_dir,"blockfactory"));\n');
+    fclose(setupID);
+    fprintf('\t\t\t\t[done]\n');
+
+    fprintf('Deleting temporary files...');
+    delete(mambaforge_installer_name);
+    fprintf('\t\t\t[done]\n');
+
+    fprintf('robotology MATLAB and Simulink packages are successfully installed!\n');
+    fprintf('Please run %s before using the packages, or just add that script to your startup.m file, to run it whenever you open MATLAB.\n', setup_script);
+    fprintf('To uninstall these packages, just delete the folder %s.\n', install_prefix);
+end


### PR DESCRIPTION
Fix https://github.com/robotology/robotology-superbuild/issues/713 .

In particular, if you are interesting in a pure MATLAB workflow (so without launching **anything else** via terminal, so no Gazebo) to install all the MATLAB and Simulink robotology packages it should be sufficient to run:
~~~matlab
websave('install_robotology_packages.m', 'https://raw.githubusercontent.com/traversaro/robotology-superbuild/fix/713/scripts/install_robotology_packages.m')
install_robotology_packages
robotology_setup
~~~
This will install everything in a `robotology-gazebo` local directory, without perturbing anything else in your system. Once installed, you just need to re-run the `robotology_setup` script (or add it in your setup) to make the library available again. The overall installation process should take 2/3 minutes.


Due to specific problems on MATLAB Online, you can't install the libraries in the local directory, and if you need to run this on MATLAB Online the command is slightly nmore difficult: 
~~~matlab
websave('install_robotology_packages.m', 'https://raw.githubusercontent.com/traversaro/robotology-superbuild/fix/713/scripts/install_robotology_packages.m')
install_robotology_packages(installPrefix=fullfile(getenv('HOME'),'robotology-matlab'))
robotology_setup
~~~