### PR TITLE
Fix MATLAB and Octave snippets

### DIFF
--- a/doc/cmake-options.md
+++ b/doc/cmake-options.md
@@ -310,6 +310,7 @@ To verify that the compilation of `ROBOTOLOGY_USES_MATLAB` option was successful
 the Matlab bindings of `yarp` and see if it executes without any error, for example:
 ~~~matlab
 yarpVec = yarp.Vector();
+yarpVec.resize(3);
 yarpVec.fromMatlab([1;2;3]);
 yarpVec.toMatlab()
 ~~~~
@@ -344,6 +345,7 @@ To verify that the compilation of `ROBOTOLOGY_USES_OCTAVE` option was successful
 the Octave bindings of `yarp` and see if it executes without any error, for example:
 ~~~matlab
 yarpVec = yarp.Vector();
+yarpVec.resize(3);
 yarpVec.fromMatlab([1;2;3]);
 yarpVec.toMatlab()
 ~~~~


### PR DESCRIPTION
For YARP Vectors, the `fromMatlab` methods expects the YARP vector to be of the same size of the passed MATLAB vector, see https://github.com/robotology/robotology-superbuild/issues/515 and https://github.com/robotology/yarp-matlab-bindings/issues/62 .