### PR TITLE
Add LatestReleases variant to Conda jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
         project_tags:
           - Default
           - Unstable
-          - LatestRelease
+          - LatestReleases
         include:
           - project_tags: Default
             project_tags_cmake_options: ""

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,8 @@ jobs:
           - project_tags: Unstable
             project_tags_cmake_options: "-DROBOTOLOGY_PROJECT_TAGS=Unstable"
           - project_tags: LatestReleases
-            project_tags_cmake_options: "-DROBOTOLOGY_PROJECT_TAGS=LatestReleases"
+            project_tags_cmake_options: "-DROBOTOLOGY_PROJECT_TAGS=Custom -DROBOTOLOGY_PROJECT_TAGS_CUSTOM_FILE=${GITHUB_WORKSPACE}/releases/latest.releases.yaml"
+
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,16 +24,18 @@ jobs:
       fail-fast: false
       matrix:
         build_type: [Release]
-        # Windows is disabled due to the missing ipopt package
         os: [ubuntu-latest, macos-latest, windows-2019]
         project_tags:
           - Default
           - Unstable
+          - LatestRelease
         include:
           - project_tags: Default
             project_tags_cmake_options: ""
           - project_tags: Unstable
             project_tags_cmake_options: "-DROBOTOLOGY_PROJECT_TAGS=Unstable"
+          - project_tags: LatestReleases
+            project_tags_cmake_options: "-DROBOTOLOGY_PROJECT_TAGS=LatestReleases"
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
This is useful in general, but useful in particular to debug https://github.com/robotology/robotology-superbuild/issues/712, as the build seems to be working fine on Unstable (that use yarp master branch) and in the Conda package generation (that use yarp released version 3.4.3). This job would help clarify if the problem is in the commit on top of 3.4.3 in yarp-3.4 branch, or somewhere else.