### PR TITLE
Remove leftover walking-teleoperation_CONDA_VERSION

### DIFF
--- a/cmake/Buildwalking-teleoperation.cmake
+++ b/cmake/Buildwalking-teleoperation.cmake
@@ -19,4 +19,3 @@ ycm_ep_helper(walking-teleoperation TYPE GIT
                       YARP)
 
 set(walking-teleoperation_CONDA_DEPENDENCIES "eigen")
-set(walking-teleoperation_CONDA_VERSION "0.0.1")


### PR DESCRIPTION
Fix https://github.com/robotology/robotology-superbuild/issues/726 . The `<pkgname>_CONDA_VERSION` variables are useful when for any reason we want to override the version specified in the tag, but by default it should not be set, as the tag version (removing the `v`  prefix) is typically used instead (see https://github.com/robotology/robotology-superbuild/blob/master/conda/recipe_template/meta.yaml#L5).