### PR TITLE
Add YARP_telemetry dependency for wearables

### DIFF
--- a/cmake/Buildwearables.cmake
+++ b/cmake/Buildwearables.cmake
@@ -6,6 +6,7 @@ include(FindOrBuildPackage)
 
 find_or_build_package(YARP QUIET)
 find_or_build_package(iDynTree QUIET)
+find_or_build_package(YARP_telemetry QUIET)
 
 set(WEARABLES_CMAKE_ARGS "")
 if(WIN32)
@@ -20,4 +21,5 @@ ycm_ep_helper(wearables TYPE GIT
               FOLDER src
               DEPENDS YARP
                       iDynTree
+                      YARP_telemetry
               CMAKE_ARGS ${WEARABLES_CMAKE_ARGS})


### PR DESCRIPTION
The PR in `wearables` https://github.com/robotology/wearables/pull/113 adds `YARP_telemetry` as one of its dependency. 

This PR complements that change.
