### PR TITLE
Remove release v2021.02 from CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -238,7 +238,7 @@ jobs:
       matrix:
         build_type: [Release]
         os: [ubuntu-18.04, ubuntu-20.04, macos-10.15, windows-2019]
-        project_tags: [Default, Unstable, LatestReleases, Release202102]
+        project_tags: [Default, Unstable, LatestReleases]
         include:
           - os: ubuntu-18.04
             build_type: Release
@@ -255,8 +255,6 @@ jobs:
             project_tags_cmake_options: "-DROBOTOLOGY_PROJECT_TAGS=Unstable"
           - project_tags: LatestReleases
             project_tags_cmake_options: "-DROBOTOLOGY_PROJECT_TAGS=Custom -DROBOTOLOGY_PROJECT_TAGS_CUSTOM_FILE=${GITHUB_WORKSPACE}/releases/latest.releases.yaml"
-          - project_tags: Release202102
-            project_tags_cmake_options: "-DROBOTOLOGY_PROJECT_TAGS=Custom -DROBOTOLOGY_PROJECT_TAGS_CUSTOM_FILE=${GITHUB_WORKSPACE}/releases/2021.02.yaml"
     steps:
     - uses: actions/checkout@master
     


### PR DESCRIPTION
Several changes have been done to the superbuild since that release (introduction of YARP_telemetry among the others), so that release does not contain tags for some subprojects. To avoid confusion, it is better to now remove it from the CI. In any case, the fact that those release has been compiling fine on Ubuntu 20.04 has been already tested.