### PR TITLE
Add enable Visualizer to HumanDynamicsEstimation

### DIFF
--- a/cmake/Buildhuman-dynamics-estimation.cmake
+++ b/cmake/Buildhuman-dynamics-estimation.cmake
@@ -16,6 +16,7 @@ ycm_ep_helper(human-dynamics-estimation TYPE GIT
               TAG master
               COMPONENT human_dynamics
               FOLDER src
+              CMAKE_ARGS -DHUMANSTATEPROVIDER_ENABLE_VISUALIZER:BOOL=ON
               DEPENDS iDynTree
                       YARP
                       wearables


### PR DESCRIPTION
Some time ago, we added `HUMANSTATEPROVIDER_ENABLE_VISUALIZER` cmake option for enabling the human-dynamics-estimation visualizer (https://github.com/robotology/human-dynamics-estimation/pull/230).

Since it is quite stable now, I think it makes sense to enable it as default `on`