### PR TITLE
Use again fixed checkout for bipedal-locomotion-framework Stable

### DIFF
--- a/cmake/ProjectsTagsStable.cmake
+++ b/cmake/ProjectsTagsStable.cmake
@@ -16,3 +16,5 @@ set_tag(YCM_TAG ycm-0.12)
 set_tag(YARP_TAG yarp-3.4)
 set_tag(yarp-matlab-bindings_TAG yarp-3.4)
 
+# Temporary workaround for manif incompatibiltiy
+set_tag(bipedal-locomotion-framework_TAG 5b76dc40b0f9e825e29f8de5e100240b9f7d640c)


### PR DESCRIPTION
This was removed in https://github.com/robotology/robotology-superbuild/pull/739, but now the CI is failing with:
~~~
2021-05-19T03:10:22.9978261Z /usr/bin/c++ -DSPDLOG_COMPILED_LIB -DTSID_EXPORTS -D_USE_MATH_DEFINES -I/home/runner/work/robotology-superbuild/robotology-superbuild/src/bipedal-locomotion-framework/src/TSID/include -I/home/runner/work/robotology-superbuild/robotology-superbuild/src/bipedal-locomotion-framework/src/Contacts/include -I/home/runner/work/robotology-superbuild/robotology-superbuild/src/bipedal-locomotion-framework/src/Math/include -I/home/runner/work/robotology-superbuild/robotology-superbuild/src/bipedal-locomotion-framework/src/ParametersHandler/include -I/home/runner/work/robotology-superbuild/robotology-superbuild/src/bipedal-locomotion-framework/src/GenericContainer/include -I/home/runner/work/robotology-superbuild/robotology-superbuild/src/bipedal-locomotion-framework/src/TextLogging/include -I/home/runner/work/robotology-superbuild/robotology-superbuild/src/bipedal-locomotion-framework/src/System/include -I/home/runner/work/robotology-superbuild/robotology-superbuild/src/bipedal-locomotion-framework/src/Conversions/include -isystem /usr/include/eigen3 -isystem /home/runner/work/robotology-superbuild/robotology-superbuild/build/install/include -isystem /home/runner/work/robotology-superbuild/robotology-superbuild/build/install/include/osqp -O3 -DNDEBUG -fPIC -std=gnu++17 -MD -MT src/TSID/CMakeFiles/TSID.dir/src/SE3Task.cpp.o -MF src/TSID/CMakeFiles/TSID.dir/src/SE3Task.cpp.o.d -o src/TSID/CMakeFiles/TSID.dir/src/SE3Task.cpp.o -c /home/runner/work/robotology-superbuild/robotology-superbuild/src/bipedal-locomotion-framework/src/TSID/src/SE3Task.cpp
2021-05-19T03:10:22.9989409Z /home/runner/work/robotology-superbuild/robotology-superbuild/src/bipedal-locomotion-framework/src/TSID/src/SE3Task.cpp: In member function ‘bool BipedalLocomotion::TSID::SE3Task::setSetPoint(const SE3d&, const Tangent&, const Tangent&)’:
2021-05-19T03:10:22.9992504Z /home/runner/work/robotology-superbuild/robotology-superbuild/src/bipedal-locomotion-framework/src/TSID/src/SE3Task.cpp:201:83: error: ‘const Tangent’ {aka ‘const struct manif::SE3Tangent<double>’} has no member named ‘lin’
2021-05-19T03:10:23.0002920Z   201 |     ok = ok && m_R3Controller.setDesiredState({I_H_F.translation(), mixedVelocity.lin()});
2021-05-19T03:10:23.0003845Z       |                                                                                   ^~~
2021-05-19T03:10:23.0006562Z /home/runner/work/robotology-superbuild/robotology-superbuild/src/bipedal-locomotion-framework/src/TSID/src/SE3Task.cpp:201:89: error: cannot convert ‘<brace-enclosed initializer list>’ to ‘const State&’ {aka ‘const std::tuple<manif::Rn<double, 3>, manif::RnTangent<double, 3> >&’}
2021-05-19T03:10:23.0008695Z   201 |     ok = ok && m_R3Controller.setDesiredState({I_H_F.translation(), mixedVelocity.lin()});
2021-05-19T03:10:23.0009603Z       |                                                                                         ^
2021-05-19T03:10:23.0011490Z In file included from /home/runner/work/robotology-superbuild/robotology-superbuild/build/install/include/LieGroupControllers/impl/ProportionalDerivativeController/Controller.h:15,
~~~

This PR restores a blf version compatible with manif 0.0.3 .
