### PR TITLE
Add Release Github Action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,51 @@
+name: Create a new release
+
+on:
+  workflow_dispatch:
+    inputs:
+      superbuild_tag:
+        description: 'The new robotology-superbuild tag(without the "v")'
+        required: true
+jobs:
+  PrepareRelease:
+    name: Create the ${{ github.event.inputs.superbuild_tag }} release
+    runs-on: [ubuntu-latest]
+    steps:
+    - uses: actions/checkout@v2
+    - name: Modify the yaml file
+      run: |
+        cd releases
+        cp ./latest.releases.yaml ./${{ github.event.inputs.superbuild_tag }}.yaml
+
+    - name: Configure Git
+      run: |
+        git config --global push.default upstream
+        git config --global user.name "GitHub Actions"
+        git config --global user.email "actions@github.com"
+        git remote set-url origin https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.git
+
+    - name: Commit and push the ${{ github.event.inputs.superbuild_tag }} yaml
+      run: |
+        git add .
+        git commit -m "Copying latest.releases.yaml to ${{ github.event.inputs.superbuild_tag }}.yaml"
+        git push
+
+    - name: Prepare and push ${{ github.event.inputs.superbuild_tag }} branch
+      run: |
+        git checkout -b releases/${{ github.event.inputs.superbuild_tag }}
+        sed -i -e 's/set(ROBOTOLOGY_PROJECT_TAGS_CUSTOM_FILE/set(ROBOTOLOGY_PROJECT_TAGS_CUSTOM_FILE "\${CMAKE_CURRENT_SOURCE_DIR}\/releases\/${{ github.event.inputs.superbuild_tag }}.yaml"/g' ./cmake/RobotologySuperbuildOptions.cmake
+        sed -i -e 's/set(ROBOTOLOGY_PROJECT_TAGS "Stable"/set(ROBOTOLOGY_PROJECT_TAGS "Custom"/g' ./cmake/RobotologySuperbuildOptions.cmake
+        git add .
+        git commit -m "Updating RobotologySuperbuildOptions.cmake"
+        sed -i -e 's/set(INSTALLER_VERSION "")/set(INSTALLER_VERSION ${{ github.event.inputs.superbuild_tag }})/g' ./packaging/windows/CMakeLists.txt
+        git add .
+        git commit -m "Updating packaging/windows/CMakeLists.txt"
+        git push --set-upstream origin releases/${{ github.event.inputs.superbuild_tag }}
+
+    - name: Create and push the ${{ github.event.inputs.superbuild_tag }} tag
+      run: |
+        git checkout releases/${{ github.event.inputs.superbuild_tag }}
+        git reset --hard origin/releases/${{ github.event.inputs.superbuild_tag }}
+        git tag v${{ github.event.inputs.superbuild_tag }}
+        git push --tags
+

--- a/packaging/windows/CMakeLists.txt
+++ b/packaging/windows/CMakeLists.txt
@@ -6,7 +6,7 @@
 
 cmake_minimum_required(VERSION 3.12)
 
-set(INSTALLER_VERSION 2021.02)
+set(INSTALLER_VERSION "")
 option(RI_INCLUDE_GAZEBO "If ON include the Gazebo simulator binaries." ON)
 option(RI_BUILD_FULL_INSTALLER "If ON build the full installer, otherwise the dependencies one." ON)
 


### PR DESCRIPTION
This PR add a github action for creating a new `robotology-superbuild` release, it automatize these steps: https://github.com/robotology/robotology-superbuild/blob/master/doc/developers-faqs.md#how-to-do-a-new-release

For doing this I changed the CMakeLists of windows packaging https://github.com/robotology/robotology-superbuild/commit/a2e8999f97d87940dd0c527266e528d711a1b215 for make easier the sed command, the idea is that on master the `INSTALLER_VERSION` is empty(or we can put something like  `master` and then it is versioned in the `releases/yyyy.mm` branch.

This Action can be triggered only by hand specifying the version of the release you want to create:

![immagine](https://user-images.githubusercontent.com/19152494/118816309-52eec000-b8b2-11eb-9920-f4a1917635c3.png)

Here are the steps:

- Copy `latest.yml` into `yyyy.mm.yml` commit and push it on master https://github.com/Nicogene/robotology-superbuild/commit/0efd5cb406d7d9e4eafbbba4b6f314f8d22ff6ab
- Switch then on [`releases/yyyy.mm`](https://github.com/Nicogene/robotology-superbuild/tree/releases/2021.05) and does these 2 commits https://github.com/Nicogene/robotology-superbuild/commit/96279a0de5c7249e55f9935f54d0297fbb8d1e49 and https://github.com/Nicogene/robotology-superbuild/commit/e3b9b7d6953b9a4c8ef767f142e1a4df7383ab20
- Tag on that branch https://github.com/Nicogene/robotology-superbuild/releases/tag/v2021.05

It fixes #636 