### PR TITLE
Conda: Add require_opengl_linux option in metametadata entry for libraries that depend on iDynTree

### DIFF
--- a/conda/cmake/RobotologySuperbuildGenerateCondaRecipes.cmake
+++ b/conda/cmake/RobotologySuperbuildGenerateCondaRecipes.cmake
@@ -129,7 +129,8 @@ macro(generate_metametadata_file)
     if(${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
       if("qt" IN_LIST ${_cmake_pkg}_CONDA_DEPENDENCIES OR
          "freeglut" IN_LIST ${_cmake_pkg}_CONDA_DEPENDENCIES OR
-         "irrlicht" IN_LIST ${_cmake_pkg}_CONDA_DEPENDENCIES)
+         "irrlicht" IN_LIST ${_cmake_pkg}_CONDA_DEPENDENCIES OR
+         "idyntree" IN_LIST ${_cmake_pkg}_CONDA_DEPENDENCIES)
         string(APPEND metametadata_file_contents "    require_opengl_linux: true\n")
       endif()
     endif()


### PR DESCRIPTION
Fix https://github.com/robotology/robotology-superbuild/issues/744 .