### PR TITLE
Add in CI and document workaround for macOS/Homebrew Gazebo/tbb failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -400,6 +400,15 @@ jobs:
         cd build
         # Disable ROBOTOLOGY_USES_PYTHON in macOS
         cmake -DROBOTOLOGY_USES_OCTAVE:BOOL=OFF -DROBOTOLOGY_USES_PYTHON:BOOL=OFF .
+       
+    # Workaround for https://github.com/robotology/robotology-superbuild/issues/753
+    # taken from https://github.com/osrf/homebrew-simulation/issues/1486#issuecomment-850218440
+    - name: Add Gazebo-specific Homebrew workaround
+      if: contains(matrix.os, 'macos')
+      run: |
+           echo "CMAKE_PREFIX_PATH=${CMAKE_PREFIX_PATH}:/usr/local/opt/tbb@2020_u3" >> $GITHUB_ENV
+           echo "CPATH=${CPATH}:/usr/local/opt/tbb@2020_u3/include" >> $GITHUB_ENV
+           echo "LIBRARY_PATH=${CMAKE_PREFIX_PATH}:${LIBRARY_PATH}:/usr/local/opt/tbb@2020_u3/lib" >> $GITHUB_ENV
 
     - name: Disable options unsupported on Ubuntu 18.04
       if: contains(matrix.os, '18.04')

--- a/doc/cmake-options.md
+++ b/doc/cmake-options.md
@@ -232,6 +232,18 @@ Make sure to install also the development files, i.e. `libgazebo*-dev` on Debian
 On Windows, make sure that you install the Windows dependencies using the `vcpkg-robotology-with-gazebo.zip` archive and you set
 the correct enviroment variables as documented in [`robotology-superbuild-dependencies-vcpkg` documentation](https://github.com/robotology/robotology-superbuild-dependencies-vcpkg).
 
+#### macOS with Homebrew workaround
+
+On macOS with Homebrew dependencies, due to an incompatibility of Gazebo with the latest version of tbb (https://github.com/osrf/gazebo/issues/2867), to correctly compiled `robotology-superbuild` with the `ROBOTOLOGY_USES_GAZEBO` option enabled,
+it is necessary to define the following environment variables:
+~~~
+export CMAKE_PREFIX_PATH=${CMAKE_PREFIX_PATH}:/usr/local/opt/tbb@2020_u3
+export CPATH=${CPATH}:/usr/local/opt/tbb@2020_u3/include
+export LIBRARY_PATH=${LIBRARY_PATH}:/usr/local/opt/tbb@2020_u3/lib
+~~~
+See https://github.com/osrf/homebrew-simulation/issues/1486 for more info.
+
+
 ### Check the installation
 Follow the steps in https://github.com/robotology/icub-gazebo#usage and/or https://github.com/robotology/icub-models#use-the-models-with-gazebo to check if the Gazebo-based iCub simulation works fine.
 

--- a/releases/latest.releases.yaml
+++ b/releases/latest.releases.yaml
@@ -65,7 +65,7 @@ repositories:
     version: v1.20.0
   blocktestcore:
     type: git
-    url: https://github.com/rbotology/blocktest.git
+    url: https://github.com/robotology/blocktest.git
     version: v2.3.2
   blocktest-yarp-plugins:
     type: git

--- a/releases/latest.releases.yaml
+++ b/releases/latest.releases.yaml
@@ -65,8 +65,8 @@ repositories:
     version: v1.20.0
   blocktestcore:
     type: git
-    url: https://github.com/robotology/blocktest.git
-    version: v2.3.1
+    url: https://github.com/rbotology/blocktest.git
+    version: v2.3.2
   blocktest-yarp-plugins:
     type: git
     url: https://github.com/robotology/blocktest-yarp-plugins.git


### PR DESCRIPTION
Workaround for https://github.com/robotology/robotology-superbuild/issues/753 taken from https://github.com/osrf/homebrew-simulation/issues/1486#issuecomment-850218440