### PR TITLE
Fix multisheller scripts for YARP

### DIFF
--- a/conda/multisheller/yarp_activate.msh
+++ b/conda/multisheller/yarp_activate.msh
@@ -1,7 +1,7 @@
 if_(is_set("COMSPEC")).then_([
-	sys.list_append("YARP_DATA_DIRS", path.join(env("CONDA_PREFIX"), "Library\\share\\yarp"))
+	sys.list_append("YARP_DATA_DIRS", path.join(env("CONDA_PREFIX"), "Library\\share\\yarp")),
 	sys.list_append("XDG_DATA_DIRS", path.join(env("CONDA_PREFIX"), "Library\\share"))
 ]).else_([
-	sys.list_append("YARP_DATA_DIRS", path.join(env("CONDA_PREFIX"), "share/yarp"))
+	sys.list_append("YARP_DATA_DIRS", path.join(env("CONDA_PREFIX"), "share/yarp")),
 	sys.list_append("XDG_DATA_DIRS", path.join(env("CONDA_PREFIX"), "share"))
 ])

--- a/conda/multisheller/yarp_deactivate.msh
+++ b/conda/multisheller/yarp_deactivate.msh
@@ -1,7 +1,7 @@
 if_(is_set("COMSPEC")).then_([
-	sys.list_remove("YARP_DATA_DIRS", path.join(env("CONDA_PREFIX"), "Library\\share\\yarp"))
+	sys.list_remove("YARP_DATA_DIRS", path.join(env("CONDA_PREFIX"), "Library\\share\\yarp")),
 	sys.list_remove("XDG_DATA_DIRS", path.join(env("CONDA_PREFIX"), "Library\\share"))
 ]).else_([
-	sys.list_remove("YARP_DATA_DIRS", path.join(env("CONDA_PREFIX"), "share/yarp"))
+	sys.list_remove("YARP_DATA_DIRS", path.join(env("CONDA_PREFIX"), "share/yarp")),
 	sys.list_remove("XDG_DATA_DIRS", path.join(env("CONDA_PREFIX"), "share"))
 ])


### PR DESCRIPTION
Without that, you get this error:
~~~
generate_conda_recipes_from_metadatadata: generating recipe for package ycm-cmake-modules
/home/runner/work/robotology-superbuild/robotology-superbuild/build/conda/generated_recipes/ycm-cmake-modules
Traceback (most recent call last):
  File "/home/runner/work/robotology-superbuild/robotology-superbuild/conda/python/generate_conda_recipes_from_metametadata.py", line 139, in <module>
    main()
  File "/home/runner/work/robotology-superbuild/robotology-superbuild/conda/python/generate_conda_recipes_from_metametadata.py", line 124, in main
    generate_scripts_from_multisheller_file(multisheller_scripts_dir + "/" + activation_script_msh, recipe_dir, "activate")
  File "/home/runner/work/robotology-superbuild/robotology-superbuild/conda/python/generate_conda_recipes_from_metametadata.py", line 64, in generate_scripts_from_multisheller_file
    tree = ast.parse(contents)
  File "/usr/share/miniconda/envs/test/lib/python3.8/ast.py", line 47, in parse
    return compile(source, filename, mode, flags,
  File "<unknown>", line 3
    sys.list_append("XDG_DATA_DIRS", path.join(env("CONDA_PREFIX"), "Library\\share"))
    ^
SyntaxError: invalid syntax
~~~
this was a regression in https://github.com/robotology/robotology-superbuild/pull/759 .
