### PR TITLE
Ad nlohmann-json as dependency of the superbuild

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -203,6 +203,8 @@ jobs:
         apt-get -y update
         apt-get -y upgrade
 
+
+
     - name: Configure [Docker]
       run: |
         mkdir -p build
@@ -219,11 +221,16 @@ jobs:
        cd build
        cmake -DROBOTOLOGY_ENABLE_DYNAMICS_FULL_DEPS:BOOL=OFF .
 
-    - name: Disable profiles that are not supported in Ubuntu Bionic in Unstable [Docker ubuntu:bionic]
-      if: (matrix.docker_image == 'ubuntu:bionic' && contains(matrix.project_tags, 'Unstable'))
+    - name: Disable profiles that are not supported in Ubuntu Bionic [Docker ubuntu:bionic]
+      if: (matrix.docker_image == 'ubuntu:bionic')
       run: |
        cd build
        cmake -DROBOTOLOGY_ENABLE_DYNAMICS_FULL_DEPS:BOOL=OFF .
+
+    - name: Install additional dependencies not available on Ubuntu Bionic [Docker except ubuntu:bionic]
+      if: (matrix.docker_image != 'ubuntu:bionic')
+      run: |
+        apt-get -y install nlohmann-json3-dev
 
     - name: Build  [Docker]
       run: |
@@ -405,6 +412,11 @@ jobs:
         cd ${ROBOTOLOGY_SUPERBUILD_SOURCE_DIR}
         cd build
         cmake -DROBOTOLOGY_ENABLE_DYNAMICS_FULL_DEPS:BOOL=OFF .
+
+    - name: Install dependencies unsupported in Ubuntu 18.04
+      if: contains(matrix.os, '20.04')
+      run: |
+        sudo apt-get -y install nlohmann-json3-dev
 
     - name: Configure [Windows]
       if: contains(matrix.os, 'windows')

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,7 +78,7 @@ jobs:
         # Compilation related dependencies 
         mamba install cmake compilers make ninja pkg-config
         # Actual dependencies
-        mamba install ace asio boost eigen gazebo glew glfw gsl ipopt irrlicht libjpeg-turbo libmatio libode libxml2 opencv pkg-config portaudio qt sdl sdl2 sqlite tinyxml spdlog
+        mamba install ace asio boost eigen gazebo glew glfw gsl ipopt irrlicht libjpeg-turbo libmatio libode libxml2 nlohmann-json opencv pkg-config portaudio qt sdl sdl2 sqlite tinyxml spdlog
         # Python 
         mamba install numpy swig
 
@@ -345,7 +345,7 @@ jobs:
         brew upgrade
         brew install --cask xquartz
         # Core dependencies
-        brew install ace bash-completion boost cmake eigen gsl ipopt jpeg libedit opencv pkg-config portaudio qt@5 sqlite swig tinyxml
+        brew install ace bash-completion boost cmake eigen gsl ipopt jpeg libedit nlohmann-json opencv pkg-config portaudio qt@5 sqlite swig tinyxml
         # ROBOTOLOGY_ENABLE_DYNAMICS dependencies
         brew install libmatio irrlicht spdlog
         # ROBOTOLOGY_ENABLE_DYNAMICS_FULL_DEPS (qhull and cppad are installed  with brew)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -372,7 +372,7 @@ jobs:
         # To avoid problems with non-relocatable packages, we unzip the archive exactly in the same directory
         # that has been used to create the pre-compiled archive
         cd C:/
-        wget https://github.com/robotology/robotology-superbuild-dependencies-vcpkg/releases/download/v0.6.4/vcpkg-robotology-with-gazebo.zip
+        wget https://github.com/robotology/robotology-superbuild-dependencies-vcpkg/releases/latest/download/vcpkg-robotology-with-gazebo.zip
         unzip vcpkg-robotology-with-gazebo.zip -d C:/
         rm vcpkg-robotology-with-gazebo.zip
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,7 +78,7 @@ jobs:
         # Compilation related dependencies 
         mamba install cmake compilers make ninja pkg-config
         # Actual dependencies
-        mamba install ace asio boost eigen gazebo glew glfw gsl ipopt irrlicht libjpeg-turbo libmatio libode libxml2 nlohmann-json opencv pkg-config portaudio qt sdl sdl2 sqlite tinyxml spdlog
+        mamba install ace asio boost eigen gazebo glew glfw gsl ipopt irrlicht libjpeg-turbo libmatio libode libxml2 nlohmann_json opencv pkg-config portaudio qt sdl sdl2 sqlite tinyxml spdlog
         # Python 
         mamba install numpy swig
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,14 @@ The format of this document is based on [Keep a Changelog](https://keepachangelo
 
 ## [Unreleased]
 
+### Added
+- Add `nlohmann-json` dependency to the superbuild (https://github.com/robotology/robotology-superbuild/pull/776)
+
 ## [2021.05] - 2021-05-31
 
 ### Added
 - Add support for installing robotology superbuild packages as Conda binary packages (https://github.com/robotology/robotology-superbuild/blob/master/doc/conda-forge.md, https://github.com/robotology/robotology-superbuild/pull/652).
-- Add spdlog dependency to the superbuild (https://github.com/robotology/robotology-superbuild/pull/645)
+- Add `spdlog` dependency to the superbuild (https://github.com/robotology/robotology-superbuild/pull/645)
 - Add `YARP_telemetry` component to the Dynamics profile (https://github.com/robotology/robotology-superbuild/pull/677).
 - Append `<superbuild_install_prefix>/share` to `XDG_DATA_DIRS` to enable YARP auto completion on Bash terminal (https://github.com/robotology/robotology-superbuild/pull/759).
 - Add `casadi-matlab-bindings` package containing the MATLAB bindings for CasADi. The package is enabled if ROBOTOLOGY_ENABLE_DYNAMICS_FULL_DEPS is ON and ROBOTOLOGY_USES_MATLAB is ON (https://github.com/robotology/robotology-superbuild/pull/747).

--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ If for any reason you do not want to use the provided `setup.sh` script and you 
 ### System Dependencies
 To install the system dependencies, it is possible to use [Homebrew](http://brew.sh/):
 ```
-brew install ace bash-completion boost cmake eigen gsl ipopt jpeg libedit opencv pkg-config portaudio qt@5 sqlite swig tinyxml libmatio irrlicht spdlog
+brew install ace bash-completion boost cmake eigen gsl ipopt jpeg libedit nlohmann-json opencv pkg-config portaudio qt@5 sqlite swig tinyxml libmatio irrlicht spdlog
 ```
 
 Since Qt5 is not symlinked in `/usr/local` by default in the homebrew formula, `Qt5_DIR` needs to be properly set to make sure that CMake-based projects are able to find Qt5.

--- a/README.md
+++ b/README.md
@@ -121,6 +121,11 @@ On Debian based systems (as Ubuntu) you can install the C++ toolchain, Git, CMak
 sudo apt-get install bash-completion build-essential cmake cmake-curses-gui coinor-libipopt-dev freeglut3-dev git libace-dev libboost-filesystem-dev libboost-system-dev libboost-thread-dev libdc1394-22-dev libedit-dev libeigen3-dev libgsl0-dev libjpeg-dev liblua5.1-dev libode-dev libopencv-dev libsdl1.2-dev libtinyxml-dev libv4l-dev libxml2-dev lua5.1 portaudio19-dev qml-module-qt-labs-folderlistmodel qml-module-qt-labs-settings qml-module-qtmultimedia qml-module-qtquick-controls qml-module-qtquick-dialogs qml-module-qtquick-window2 qml-module-qtquick2 qtbase5-dev qtdeclarative5-dev qtmultimedia5-dev swig libmatio-dev libirrlicht-dev libspdlog-dev libblas-dev liblapack-dev
 ```
 
+If you are **not** using Ubuntu 18.04, you also need to install:
+~~~
+sudo apt-get install nlohmann-json3-dev
+~~~
+
 For what regards CMake, the robotology-superbuild requires CMake 3.16 . If you are using a recent Debian-based system such as Ubuntu 20.04, the default CMake is recent enough and you do not need to do further steps.
 
 If instead you use an older distro in which the default version of CMake is older, you can easily install a newer CMake version in several ways. For the following distributions, we recommend the following methods:  

--- a/cmake/Buildbipedal-locomotion-framework.cmake
+++ b/cmake/Buildbipedal-locomotion-framework.cmake
@@ -58,6 +58,7 @@ ycm_ep_helper(bipedal-locomotion-framework TYPE GIT
               DEPENDS ${bipedal-locomotion-framework_DEPENDS})
 
 set(bipedal-locomotion-framework_CONDA_DEPENDENCIES eigen)
+list(APPEND bipedal-locomotion-framework_CONDA_DEPENDENCIES nlohmann_json)
 
 if(ROBOTOLOGY_USES_PYTHON)
   list(APPEND bipedal-locomotion-framework_CONDA_DEPENDENCIES pybind11)

--- a/doc/conda-forge.md
+++ b/doc/conda-forge.md
@@ -108,7 +108,7 @@ of the robotology-superbuild.**
 Once you activated it, you can install packages in it. In particular the dependencies for the robotology-superbuild can be installed as:
 ~~~
 conda install -c conda-forge cmake compilers make ninja pkg-config
-conda install -c conda-forge ace asio boost eigen gazebo glew glfw gsl ipopt libjpeg-turbo libmatio libode libxml2 opencv pkg-config portaudio qt sdl sdl2 sqlite tinyxml spdlog
+conda install -c conda-forge ace asio boost eigen gazebo glew glfw gsl ipopt libjpeg-turbo libmatio libode libxml2 nlohmann-json opencv pkg-config portaudio qt sdl sdl2 sqlite tinyxml spdlog
 ~~~
 
 If you are on **Linux**, you also need to install also the following packages:

--- a/doc/conda-forge.md
+++ b/doc/conda-forge.md
@@ -108,7 +108,7 @@ of the robotology-superbuild.**
 Once you activated it, you can install packages in it. In particular the dependencies for the robotology-superbuild can be installed as:
 ~~~
 conda install -c conda-forge cmake compilers make ninja pkg-config
-conda install -c conda-forge ace asio boost eigen gazebo glew glfw gsl ipopt libjpeg-turbo libmatio libode libxml2 nlohmann-json opencv pkg-config portaudio qt sdl sdl2 sqlite tinyxml spdlog
+conda install -c conda-forge ace asio boost eigen gazebo glew glfw gsl ipopt libjpeg-turbo libmatio libode libxml2 nlohmann_json opencv pkg-config portaudio qt sdl sdl2 sqlite tinyxml spdlog
 ~~~
 
 If you are on **Linux**, you also need to install also the following packages:

--- a/doc/vcpkg-dependencies.md
+++ b/doc/vcpkg-dependencies.md
@@ -6,4 +6,5 @@ the ports that are required are the following:
 ./vcpkg.exe install --triplet x64-windows ace asio boost-asio boost-any boost-bind boost-date-time boost-filesystem boost-format boost-interprocess boost-iostreams boost-program-options boost-property-tree boost-regex boost-smart-ptr boost-system boost-thread boost-variant boost-uuid freeglut gsl eigen3 glew glfw3 ode openssl libxml2 libjpeg-turbo nlohmann-json opencv portaudio matio sdl1 sdl2 qt5-base[latest] qt5-declarative qt5-multimedia qt5-quickcontrols qt5-quickcontrols2 sqlite3[core,tool] irrlicht
 ~~~
 
+
 Furthermore, we also require the custom `ipopt-binary` and `esdcan-binary` ports that are available in the [`robotology/robotology-vcpkg-ports`](https://github.com/robotology/robotology-vcpkg-ports) repo.

--- a/doc/vcpkg-dependencies.md
+++ b/doc/vcpkg-dependencies.md
@@ -3,7 +3,7 @@
 If you prefer to install dependencies of the `robotology-superbuild` on your own existing [`vcpkg`](https://github.com/microsoft/vcpkg) installation,
 the ports that are required are the following: 
 ~~~
-./vcpkg.exe install --triplet x64-windows ace asio boost-asio boost-any boost-bind boost-date-time boost-filesystem boost-format boost-interprocess boost-iostreams boost-program-options boost-property-tree boost-regex boost-smart-ptr boost-system boost-thread boost-variant boost-uuid freeglut gsl eigen3 glew glfw3 ode openssl libxml2 libjpeg-turbo opencv portaudio matio sdl1 sdl2 qt5-base[latest] qt5-declarative qt5-multimedia qt5-quickcontrols qt5-quickcontrols2 sqlite3[core,tool] irrlicht
+./vcpkg.exe install --triplet x64-windows ace asio boost-asio boost-any boost-bind boost-date-time boost-filesystem boost-format boost-interprocess boost-iostreams boost-program-options boost-property-tree boost-regex boost-smart-ptr boost-system boost-thread boost-variant boost-uuid freeglut gsl eigen3 glew glfw3 ode openssl libxml2 libjpeg-turbo nlohmann-json opencv portaudio matio sdl1 sdl2 qt5-base[latest] qt5-declarative qt5-multimedia qt5-quickcontrols qt5-quickcontrols2 sqlite3[core,tool] irrlicht
 ~~~
 
 Furthermore, we also require the custom `ipopt-binary` and `esdcan-binary` ports that are available in the [`robotology/robotology-vcpkg-ports`](https://github.com/robotology/robotology-vcpkg-ports) repo.


### PR DESCRIPTION
Fix https://github.com/robotology/robotology-superbuild/issues/763 . I added it as a dependency in all points, I am just missing https://github.com/robotology/robotology-superbuild-dependencies-vcpkg/pull/45 to also bump the version of vcpkg dependencies used in CI. 