### PR TITLE
install_robotology_packages MATLAB helper: do not print messages after directory name

### DIFF
--- a/scripts/install_robotology_packages.m
+++ b/scripts/install_robotology_packages.m
@@ -70,7 +70,7 @@ function install_robotology_packages(varargin)
     system(sprintf('%s install -y -c conda-forge -c robotology yarp-matlab-bindings idyntree wb-toolbox osqp-matlab whole-body-controllers matlab-whole-body-simulator icub-models', conda_full_path));
     fprintf('Installation of robotology packages completed\n');
 
-    fprintf('Creating setup script in %s', setup_script);
+    fprintf('Creating setup script in %s\n', setup_script);
     % Generate robotology_setup.m
     setupID = fopen(setup_script,'w');
     fprintf(setupID, '%% Specify OS-specific locations\n');
@@ -102,7 +102,7 @@ function install_robotology_packages(varargin)
     fprintf(setupID, 'setenv("BLOCKFACTORY_PLUGIN_PATH",fullfile(robotology_install_prefix,rob_shlib_install_dir,"blockfactory"));\n');
     fclose(setupID);
 
-    fprintf('Deleting mambaforge installer');
+    fprintf('Deleting mambaforge installer\n');
     delete(mambaforge_installer_name);
 
     fprintf('robotology MATLAB and Simulink packages are successfully installed!\n');

--- a/scripts/install_robotology_packages.m
+++ b/scripts/install_robotology_packages.m
@@ -11,7 +11,8 @@ function install_robotology_packages(varargin)
     setup_script = fullfile(pwd, 'robotology_setup.m');
 
     if exist(install_prefix)
-        fprintf('Directory %s already present. Please use it or delete to proceed with the install', install_prefix);
+        fprintf('Directory %s already present.\n', install_prefix);
+        fprintf('Please use it or delete to proceed with the install.\n');
         return;
     end
 
@@ -59,7 +60,8 @@ function install_robotology_packages(varargin)
 
 
     if ~exist(install_prefix, 'dir')
-        fprintf('Installation in %s failed for unknown reason, please open an issue at https://github.com/robotology/robotology-superbuild/issues/new\n', install_prefix);
+        fprintf('Installation in %s failed for unknown reason.\n', install_prefix);
+        fprintf('Please open an issue at https://github.com/robotology/robotology-superbuild/issues/new .\n);
         return;
     end
 
@@ -106,5 +108,5 @@ function install_robotology_packages(varargin)
     fprintf('robotology MATLAB and Simulink packages are successfully installed!\n');
     fprintf('Please run %s before using the packages,\n',setup_script)
     fprintf('or just add that script to your startup.m file, to run it whenever you open MATLAB.\n');
-    fprintf('To uninstall these packages, just delete the folder %s.\n', install_prefix);
+    fprintf('To uninstall these packages, just delete the folder %s .\n', install_prefix);
 end

--- a/scripts/install_robotology_packages.m
+++ b/scripts/install_robotology_packages.m
@@ -61,7 +61,7 @@ function install_robotology_packages(varargin)
 
     if ~exist(install_prefix, 'dir')
         fprintf('Installation in %s failed for unknown reason.\n', install_prefix);
-        fprintf('Please open an issue at https://github.com/robotology/robotology-superbuild/issues/new .\n);
+        fprintf('Please open an issue at https://github.com/robotology/robotology-superbuild/issues/new .\n');
         return;
     end
 


### PR DESCRIPTION
The directory name can be very long, and this would mean that the message directed to the user is hidden on the right part of the screen. Add a new line to ensure that the error is printed in a visible part of the screen.

@DanielePucci if you want to test this new version, you can do by running:
~~~matlab
websave('install_robotology_packages.m', 'https://raw.githubusercontent.com/robotology/robotology-superbuild/fix/777/scripts/install_robotology_packages.m')
install_robotology_packages
robotology_setup
~~~

(I just took https://github.com/robotology/robotology-superbuild/blob/master/doc/matlab-one-line-install.md and substituted `master` with `fix/777`)

Fix https://github.com/robotology/robotology-superbuild/issues/777 .