### PR TITLE
Add casadi-matlab-bindings and remove qpOASES dependency in whole-body-controllers 

### DIFF
--- a/cmake/Buildwhole-body-controllers.cmake
+++ b/cmake/Buildwhole-body-controllers.cmake
@@ -1,12 +1,11 @@
-# Copyright (C) 2017  iCub Facility, Istituto Italiano di Tecnologia
-# Authors: Silvio Traversaro <silvio.traversaro@iit.it>
+# Copyright (C) 2021 Fondazione Istituto Italiano di Tecnologia
 # CopyPolicy: Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
 
 include(YCMEPHelper)
 include(FindOrBuildPackage)
 
 find_or_build_package(WBToolbox QUIET)
-find_or_build_package(qpOASES QUIET)
+find_or_build_package(casadi-matlab-bindings QUIET)
 
 ycm_ep_helper(whole-body-controllers TYPE GIT
               STYLE GITHUB
@@ -15,4 +14,4 @@ ycm_ep_helper(whole-body-controllers TYPE GIT
               COMPONENT dynamics
               FOLDER src
               DEPENDS WBToolbox
-                      qpOASES)
+                      casadi-matlab-bindings)


### PR DESCRIPTION
Related to https://github.com/robotology/robotology-superbuild/issues/782 . This ensure that casadi-matlab-bindings are installed also when `whole-body-controllers` is installed via conda binary packages, as it happens for the MATLAB/Simulink one line installation process (https://github.com/robotology/robotology-superbuild/blob/master/doc/matlab-one-line-install.md) @DanielePucci . 

Note that the problem fixed by this PR and described in https://github.com/robotology/robotology-superbuild/issues/782  **does not affect** running controllers that **do not** use CasADi, such as the YOGA++ .

