### PR TITLE
Install boost-cpp instead of boost in conda instructions and CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,7 +78,7 @@ jobs:
         # Compilation related dependencies 
         mamba install cmake compilers make ninja pkg-config
         # Actual dependencies
-        mamba install ace asio boost eigen gazebo glew glfw gsl ipopt irrlicht libjpeg-turbo libmatio libode libxml2 nlohmann_json opencv pkg-config portaudio qt sdl sdl2 sqlite tinyxml spdlog
+        mamba install ace asio boost-cpp eigen gazebo glew glfw gsl ipopt irrlicht libjpeg-turbo libmatio libode libxml2 nlohmann_json opencv pkg-config portaudio qt sdl sdl2 sqlite tinyxml spdlog
         # Python 
         mamba install numpy swig
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,8 +77,8 @@ jobs:
       run: |
         # Compilation related dependencies 
         mamba install cmake compilers make ninja pkg-config
-        # Actual dependencies
-        mamba install ace asio boost-cpp eigen gazebo glew glfw gsl ipopt irrlicht libjpeg-turbo libmatio libode libxml2 nlohmann_json opencv pkg-config portaudio qt sdl sdl2 sqlite tinyxml spdlog
+        # Actual dependencies (using conda as a workaround for https://github.com/mamba-org/mamba/issues/986)
+        conda install ace asio boost-cpp eigen gazebo glew glfw gsl ipopt irrlicht libjpeg-turbo libmatio libode libxml2 nlohmann_json opencv pkg-config portaudio qt sdl sdl2 sqlite tinyxml spdlog
         # Python 
         mamba install numpy swig
 

--- a/doc/conda-forge.md
+++ b/doc/conda-forge.md
@@ -108,7 +108,7 @@ of the robotology-superbuild.**
 Once you activated it, you can install packages in it. In particular the dependencies for the robotology-superbuild can be installed as:
 ~~~
 conda install -c conda-forge cmake compilers make ninja pkg-config
-conda install -c conda-forge ace asio boost eigen gazebo glew glfw gsl ipopt libjpeg-turbo libmatio libode libxml2 nlohmann_json opencv pkg-config portaudio qt sdl sdl2 sqlite tinyxml spdlog
+conda install -c conda-forge ace asio boost-cpp eigen gazebo glew glfw gsl ipopt libjpeg-turbo libmatio libode libxml2 nlohmann_json opencv pkg-config portaudio qt sdl sdl2 sqlite tinyxml spdlog
 ~~~
 
 If you are on **Linux**, you also need to install also the following packages:


### PR DESCRIPTION
This is a correct fix in general, as our use of boost do not depend on boost-python, so just depending on boost-cpp is enough. Furthermore, it also act as a workaround for https://github.com/robotology/robotology-superbuild/issues/785 .