### PR TITLE
Pin libsolv to 0.7.18 in conda CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,6 +76,8 @@ jobs:
     - name: Dependencies [Conda]
       shell: bash -l {0}
       run: |
+        # Workaround for https://github.com/robotology/robotology-superbuild/issues/785
+        conda install --name base libsolv=0.7.18
         # Compilation related dependencies 
         mamba install cmake compilers make ninja pkg-config
         # Actual dependencies


### PR DESCRIPTION
This is much less invasive workaround for https://github.com/robotology/robotology-superbuild/issues/785 .