### PR TITLE
Fix documentation of how to install Miniforge3 on Windows

### DIFF
--- a/doc/install-miniforge.md
+++ b/doc/install-miniforge.md
@@ -114,17 +114,19 @@ First of all, download the installer from https://github.com/conda-forge/minifor
 
 If you already have a Python that you use in your system, make sure that you deselect the "Register Miniforge3 Python as my default Python" during the installation.
 
-After the installation has been completed, Miniforge should have been installed in `%HOME%\Miniforge3`.
+After the installation has been completed, Miniforge should have been installed in `%HOME%\AppData\Local\miniforge3`. 
+
+If you explicitly selected the for All Users install, Miniforge will be installed in `%ProgramData%\miniforge3`, in that case substitute `%HOME%\AppData\Local\miniforge3` with `%ProgramData%\miniforge3` in the rest of the documentation.
 
 To ensure that the `conda` binary can be used in your terminal, open a Command Prompt and run:
 ~~~
-%HOME%\Miniforge3\condabin\conda init
+%HOME%\AppData\Local\miniforge3\condabin\conda init
 ~~~
 
 By default, this command also automatically initialize the [`base` conda environment](https://conda.io/projects/conda/en/latest/user-guide/tasks/manage-environments.html#activating-an-environment) whenever you start a terminal.
 As this could interfere with other uses of your system (for example compilation against libraries installed not installed via `conda`), it is recommended to disable this by setting:
 ~~~
-%HOME%\Miniforge3\condabin\conda config --set auto_activate_base false
+%HOME%\AppData\Local\miniforge3\condabin\conda config --set auto_activate_base false
 ~~~
 
 After this configuration, whenever you open a new terminal, you should be able to access the `conda` command, but no environment should be enabled by default, i.e. if you execute `conda info` you should see:
@@ -143,7 +145,7 @@ conda activate base
 ### Uninstall
 First of all, open a command prompt and run:
 ~~~
-%HOME%\Miniforge3\condabin\conda init --reverse
+%HOME%\AppData\Local\miniforge3\condabin\conda init --reverse
 ~~~
 
 Then go to "Add or remove programs", search for Miniforge3 and uninstall it.


### PR DESCRIPTION
The default installation path has been modified.

Fix https://github.com/robotology/robotology-superbuild/issues/790 .