### PR TITLE
BuildYARP: Enable all fake** devices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format of this document is based on [Keep a Changelog](https://keepachangelo
 
 ### Added
 - Add `nlohmann-json` dependency to the superbuild (https://github.com/robotology/robotology-superbuild/pull/776)
+- In `YARP`, all the `fake***` YARP devices are now enabled (https://github.com/robotology/robotology-superbuild/pull/797).
 
 ## [2021.05] - 2021-05-31
 

--- a/cmake/BuildYARP.cmake
+++ b/cmake/BuildYARP.cmake
@@ -83,6 +83,18 @@ ycm_ep_helper(YARP TYPE GIT
                               -DENABLE_yarpmod_portaudio:BOOL=ON
                               -DENABLE_yarpmod_portaudioPlayer:BOOL=ON
                               -DENABLE_yarpmod_portaudioRecorder:BOOL=ON
+                              # Enable all "fake" devices in YARP, as they are quite useful for tutorials
+                              -DENABLE_yarpmod_fakeAnalogSensor:BOOL=ON
+                              -DENABLE_yarpmod_fakeBattery:BOOL=ON
+                              -DENABLE_yarpmod_fakeDepthCamera:BOOL=ON
+                              -DENABLE_yarpmod_fakeFrameGrabber:BOOL=ON
+                              -DENABLE_yarpmod_fakeIMU:BOOL=ON
+                              -DENABLE_yarpmod_fakeLaser:BOOL=ON
+                              -DENABLE_yarpmod_fakeLocalizer:BOOL=ON
+                              -DENABLE_yarpmod_fakeMicrophone:BOOL=ON
+                              -DENABLE_yarpmod_fakeMotionControl:BOOL=ON
+                              -DENABLE_yarpmod_fakeNavigation:BOOL=ON
+                              -DENABLE_yarpmod_fakeSpeaker:BOOL=ON
                               -DYARP_COMPILE_EXPERIMENTAL_WRAPPERS:BOOL=ON
                               -DYARP_COMPILE_RobotTestingFramework_ADDONS:BOOL=${ROBOTOLOGY_ENABLE_ROBOT_TESTING}
                               -DYARP_COMPILE_BINDINGS:BOOL=${YARP_COMPILE_BINDINGS}


### PR DESCRIPTION
All the fake*** devices are quite useful for tutorials and tests and they do not have strange deps, so let's enable them. 

Let's check CI with attention as it is possible that some of this devices have compilation problems in some platforms tested by CI.