### PR TITLE
OsqpEigen, YCM and robot-testing-framework: Switch to use conda-forge binary package when generating conda packages

### DIFF
--- a/.github/workflows/generate-conda-packages.yaml
+++ b/.github/workflows/generate-conda-packages.yaml
@@ -100,7 +100,6 @@ jobs:
             # We manually specify the build order as conda build is too slow, and conda mambabuild does not support correctly multiple recipes
             # see https://github.com/mamba-org/boa/issues/117
             conda mambabuild -m ${CONDA_PREFIX}/conda_build_config.yaml -m ${GITHUB_WORKSPACE}/conda/conda_build_config.yml blockfactory
-            conda mambabuild -m ${CONDA_PREFIX}/conda_build_config.yaml -m ${GITHUB_WORKSPACE}/conda/conda_build_config.yml osqp-eigen
             conda mambabuild -m ${CONDA_PREFIX}/conda_build_config.yaml -m ${GITHUB_WORKSPACE}/conda/conda_build_config.yml ycm-cmake-modules
             conda mambabuild -m ${CONDA_PREFIX}/conda_build_config.yaml -m ${GITHUB_WORKSPACE}/conda/conda_build_config.yml robot-testing-framework
             conda mambabuild -m ${CONDA_PREFIX}/conda_build_config.yaml -m ${GITHUB_WORKSPACE}/conda/conda_build_config.yml yarp

--- a/.github/workflows/generate-conda-packages.yaml
+++ b/.github/workflows/generate-conda-packages.yaml
@@ -100,7 +100,6 @@ jobs:
             # We manually specify the build order as conda build is too slow, and conda mambabuild does not support correctly multiple recipes
             # see https://github.com/mamba-org/boa/issues/117
             conda mambabuild -m ${CONDA_PREFIX}/conda_build_config.yaml -m ${GITHUB_WORKSPACE}/conda/conda_build_config.yml blockfactory
-            conda mambabuild -m ${CONDA_PREFIX}/conda_build_config.yaml -m ${GITHUB_WORKSPACE}/conda/conda_build_config.yml robot-testing-framework
             conda mambabuild -m ${CONDA_PREFIX}/conda_build_config.yaml -m ${GITHUB_WORKSPACE}/conda/conda_build_config.yml yarp
             conda mambabuild -m ${CONDA_PREFIX}/conda_build_config.yaml -m ${GITHUB_WORKSPACE}/conda/conda_build_config.yml matio-cpp
             conda mambabuild -m ${CONDA_PREFIX}/conda_build_config.yaml -m ${GITHUB_WORKSPACE}/conda/conda_build_config.yml yarp-telemetry

--- a/.github/workflows/generate-conda-packages.yaml
+++ b/.github/workflows/generate-conda-packages.yaml
@@ -100,7 +100,6 @@ jobs:
             # We manually specify the build order as conda build is too slow, and conda mambabuild does not support correctly multiple recipes
             # see https://github.com/mamba-org/boa/issues/117
             conda mambabuild -m ${CONDA_PREFIX}/conda_build_config.yaml -m ${GITHUB_WORKSPACE}/conda/conda_build_config.yml blockfactory
-            conda mambabuild -m ${CONDA_PREFIX}/conda_build_config.yaml -m ${GITHUB_WORKSPACE}/conda/conda_build_config.yml ycm-cmake-modules
             conda mambabuild -m ${CONDA_PREFIX}/conda_build_config.yaml -m ${GITHUB_WORKSPACE}/conda/conda_build_config.yml robot-testing-framework
             conda mambabuild -m ${CONDA_PREFIX}/conda_build_config.yaml -m ${GITHUB_WORKSPACE}/conda/conda_build_config.yml yarp
             conda mambabuild -m ${CONDA_PREFIX}/conda_build_config.yaml -m ${GITHUB_WORKSPACE}/conda/conda_build_config.yml matio-cpp

--- a/cmake/BuildOsqpEigen.cmake
+++ b/cmake/BuildOsqpEigen.cmake
@@ -15,4 +15,5 @@ ycm_ep_helper(OsqpEigen TYPE GIT
               CMAKE_ARGS -DBUILD_TESTING:BOOL=OFF
               DEPENDS osqp)
 
-set(OsqpEigen_CONDA_DEPENDENCIES "eigen")
+set(OsqpEigen_CONDA_PKG_NAME osqp-eigen)
+set(OsqpEigen_CONDA_PKG_CONDA_FORGE_OVERRIDE ON)

--- a/cmake/BuildRobotTestingFramework.cmake
+++ b/cmake/BuildRobotTestingFramework.cmake
@@ -13,3 +13,5 @@ ycm_ep_helper(RobotTestingFramework TYPE GIT
                                     COMPONENT core
                                     FOLDER src)
 
+set(RobotTestingFramework_CONDA_PKG_NAME robot-testing-framework)
+set(RobotTestingFramework_CONDA_PKG_CONDA_FORGE_OVERRIDE ON)

--- a/cmake/Buildevent-driven.cmake
+++ b/cmake/Buildevent-driven.cmake
@@ -14,3 +14,5 @@ ycm_ep_helper(event-driven TYPE GIT
                       YCM
               COMPONENT event-driven
               FOLDER src)
+
+set(event-driven_CONDA_DEPENDENCIES libopencv qt)

--- a/conda/cmake/RobotologySuperbuildGenerateCondaRecipes.cmake
+++ b/conda/cmake/RobotologySuperbuildGenerateCondaRecipes.cmake
@@ -186,6 +186,7 @@ set_property(GLOBAL PROPERTY YCM_PROJECTS ${_projects})
 set(_YH_YCM_REPOSITORY robotology/ycm.git)
 # Use ycm-cmake-modules as name as in debian
 set(YCM_CONDA_PKG_NAME ycm-cmake-modules)
+set(YCM_CONDA_PKG_CONDA_FORGE_OVERRIDE ON)
 
 include(RobotologySuperbuildLogic)
 include(CondaGenerationOptions)

--- a/conda/cmake/RobotologySuperbuildGenerateCondaRecipes.cmake
+++ b/conda/cmake/RobotologySuperbuildGenerateCondaRecipes.cmake
@@ -132,6 +132,24 @@ macro(generate_metametadata_file)
         string(APPEND metametadata_file_contents "      - ${_dep}\n")
       endforeach()
     endif()
+    
+    # By default we rely on properly set run_exports configurations in conda recipes
+    # to avoid to manually set run dependencies. However, in some cases (cmake-only 
+    # libraries, header-only libraries) run_exports is not used, so it is necessary 
+    # to manually specify them as run dependencies
+    if("ycm-cmake-modules" IN_LIST ${_cmake_pkg}_CONDA_DEPENDENCIES)
+      list(APPEND ${_cmake_pkg}_CONDA_RUN_DEPENDENCIES_EXPLICIT "ycm-cmake-modules")
+    endif()
+    if("eigen" IN_LIST ${_cmake_pkg}_CONDA_DEPENDENCIES)
+      list(APPEND ${_cmake_pkg}_CONDA_RUN_DEPENDENCIES_EXPLICIT "eigen")
+    endif()
+    if(NOT "${${_cmake_pkg}_CONDA_RUN_DEPENDENCIES_EXPLICIT}" STREQUAL "")
+      string(APPEND metametadata_file_contents "    run_dependencies_explicit:\n")
+      foreach(_dep IN LISTS ${_cmake_pkg}_CONDA_RUN_DEPENDENCIES_EXPLICIT)
+        string(APPEND metametadata_file_contents "      - ${_dep}\n")
+      endforeach()
+    endif()
+
 
     # If some dependency require opengl to build and we are on Linux, add the required packages
     # See https://conda-forge.org/docs/maintainer/knowledge_base.html?#libgl

--- a/conda/recipe_template/meta.yaml
+++ b/conda/recipe_template/meta.yaml
@@ -38,7 +38,7 @@ requirements:
     - {{ cdt('expat') }}  {% endraw %}{% endif %}
 
   host:
-{# List all dependencies just a host. Run dependenencies should be correctly set by run_exports #}
+{# List all dependencies just a host. Run dependenencies should be correctly set by run_exports, except the one listed in #}
 {% for dep in dependencies %}    - {{ dep }}
 {% endfor %}
 {# Handle specific packages required for gl on Linux, see https://conda-forge.org/docs/maintainer/knowledge_base.html?#libgl #}
@@ -46,6 +46,9 @@ requirements:
 {# Handle the constraint of macos >= 10.13 #}
   run:
     - __osx >={{ MACOSX_DEPLOYMENT_TARGET|default("10.9") }}  # [osx and x86_64]
+{# List additional run dependencies that are not covered by run_exports #}
+{% for dep in run_dependencies_explicit %}    - {{ dep }}
+{% endfor %}
 {% if add_python_runtime_dep %}    - python {% endif %}
 {% if add_numpy_runtime_dep %}{% raw %}    - {{ pin_compatible('numpy') }}  {% endraw %}{% endif %}
 


### PR DESCRIPTION
As osqp-eigen and YCM are now available in conda-forge (see https://github.com/conda-forge/staged-recipes/pull/15309 and https://github.com/conda-forge/osqp-eigen-feedstock) we can now avoid building our own `osqp-eigen`, `ycm-cmake-modules` and `robot-testing-framework` packages in the robotology channel, and just rely on the one provided by `conda-forge`. 

This is done by defining in `Build<project>.cmake` the `<project>_CONDA_PKG_NAME` and `<project>_CONDA_PKG_CONDA_FORGE_OVERRIDE` variables, as described in https://github.com/robotology/robotology-superbuild/blob/master/doc/developers-faqs.md#how-to-ensure-that-binary-packages-are-correctly-generated-for-a-new-package . We also removed the `<project>_CONDA_DEPENDENCIES` as that was used just in the conda binary generation phase.

Part of https://github.com/robotology/robotology-superbuild/issues/752 .