### PR TITLE
install_robotology_packages: Install also casadi-matlab-bindings

### DIFF
--- a/scripts/install_robotology_packages.m
+++ b/scripts/install_robotology_packages.m
@@ -79,7 +79,7 @@ function install_robotology_packages(varargin)
 
     % Install all the robotology packages related to MATLAB or Simulink
     fprintf('Installing robotology packages\n');
-    system(sprintf('"%s" install -y -c conda-forge -c robotology yarp-matlab-bindings idyntree wb-toolbox osqp-matlab whole-body-controllers matlab-whole-body-simulator icub-models', conda_full_path));
+    system(sprintf('"%s" install -y -c conda-forge -c robotology yarp-matlab-bindings idyntree wb-toolbox osqp-matlab casadi-matlab-bindings whole-body-controllers matlab-whole-body-simulator icub-models', conda_full_path));
     fprintf('Installation of robotology packages completed\n');
 
     fprintf('Creating setup script in %s\n', setup_script);


### PR DESCRIPTION
As per discussion in https://github.com/robotology/robotology-superbuild/pull/783 we are not going to make `casadi-matlab-bindings` as dependency of whole-body-controllers, I think it make sense that in install_robotology_packages script (used in the one-line matlab installation, see https://github.com/robotology/robotology-superbuild/blob/master/doc/matlab-one-line-install.md) also installs `casadi-matlab-bindings`. 