### PR TITLE
Add idyntree-yarp-tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format of this document is based on [Keep a Changelog](https://keepachangelo
 - Add `nlohmann-json` dependency to the superbuild (https://github.com/robotology/robotology-superbuild/pull/776).
 - In `YARP`, all the `fake***` YARP devices are now enabled (https://github.com/robotology/robotology-superbuild/pull/797).
 - `pybind11` has been added as dependency for the `ROBOTOLOGY_USES_PYTHON` option (https://github.com/robotology/robotology-superbuild/pull/800), to enable compilation of Python bindings of `manif` and `bipedal-locomotion-framework`.
+- The `idyntree-yarp-tools` was added to the Dynamics component of the superbuild (https://github.com/robotology/robotology-superbuild/pull/818).
 
 ## [2021.05] - 2021-05-31
 

--- a/cmake/Buildhuman-dynamics-estimation.cmake
+++ b/cmake/Buildhuman-dynamics-estimation.cmake
@@ -5,6 +5,7 @@ include(YCMEPHelper)
 include(FindOrBuildPackage)
 
 find_or_build_package(YARP QUIET)
+find_or_build_package(ICUB QUIET)
 find_or_build_package(iDynTree QUIET)
 find_or_build_package(wearables QUIET)
 find_or_build_package(osqp QUIET)
@@ -21,6 +22,7 @@ ycm_ep_helper(human-dynamics-estimation TYPE GIT
                       YARP
                       wearables
                       osqp
-                      OsqpEigen)
+                      OsqpEigen
+                      ICUB)
 
 set(human-dynamics-estimation_CONDA_DEPENDENCIES eigen)

--- a/cmake/BuildiDynTree.cmake
+++ b/cmake/BuildiDynTree.cmake
@@ -5,13 +5,9 @@
 include(YCMEPHelper)
 include(FindOrBuildPackage)
 
-find_or_build_package(YARP QUIET)
-find_or_build_package(ICUB QUIET)
 find_or_build_package(OsqpEigen QUIET)
 
 set(iDynTree_DEPENDS "")
-list(APPEND iDynTree_DEPENDS YARP)
-list(APPEND iDynTree_DEPENDS ICUB)
 list(APPEND iDynTree_DEPENDS OsqpEigen)
 
 # For what regards Python installation, the options changes depending
@@ -32,17 +28,16 @@ ycm_ep_helper(iDynTree TYPE GIT
               COMPONENT dynamics
               FOLDER src
               CMAKE_ARGS -DIDYNTREE_USES_IPOPT:BOOL=ON
-                         -DIDYNTREE_USES_YARP:BOOL=ON
-                         -DIDYNTREE_USES_ICUB_MAIN:BOOL=ON
                          -DIDYNTREE_USES_OSQPEIGEN:BOOL=ON
                          -DIDYNTREE_USES_IRRLICHT:BOOL=ON
                          -DIDYNTREE_USES_MATLAB:BOOL=${ROBOTOLOGY_USES_MATLAB}
                          -DIDYNTREE_USES_PYTHON:BOOL=${ROBOTOLOGY_USES_PYTHON}
                          -DIDYNTREE_USES_OCTAVE:BOOL=${ROBOTOLOGY_USES_OCTAVE}
+                         -DIDYNTREE_COMPILES_YARP_TOOLS:BOOL=OFF
                          ${iDynTree_OPTIONAL_CMAKE_ARGS}
               DEPENDS ${iDynTree_DEPENDS})
 
-set(iDynTree_CONDA_DEPENDENCIES libxml2 ipopt eigen qt irrlicht)
+set(iDynTree_CONDA_DEPENDENCIES libxml2 ipopt eigen irrlicht)
 
 if(ROBOTOLOGY_USES_PYTHON)
   list(APPEND iDynTree_CONDA_DEPENDENCIES swig)

--- a/cmake/Buildidyntree-yarp-tools.cmake
+++ b/cmake/Buildidyntree-yarp-tools.cmake
@@ -1,0 +1,22 @@
+# Copyright (C) Fondazione Istituto Italiano di Tecnologia
+# CopyPolicy: Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
+
+include(YCMEPHelper)
+
+find_or_build_package(iDynTree QUIET)
+find_or_build_package(YARP QUIET)
+find_or_build_package(ICUB QUIET)
+
+ycm_ep_helper(idyntree-yarp-tools TYPE GIT
+              STYLE GITHUB
+              REPOSITORY robotology/idyntree-yarp-tools.git
+              TAG main
+              COMPONENT dynamics
+              FOLDER src
+              DEPENDS iDynTree
+                      YARP
+                      ICUB
+              CMAKE_ARGS -DIDYNTREE_YARP_TOOLS_USES_ICUB_MAIN:BOOL=ON
+                         -DIDYNTREE_YARP_TOOLS_USES_QT:BOOL=ON)
+
+set(idyntree-yarp-tools_CONDA_DEPENDENCIES eigen qt)

--- a/cmake/Buildidyntree-yarp-tools.cmake
+++ b/cmake/Buildidyntree-yarp-tools.cmake
@@ -17,6 +17,7 @@ ycm_ep_helper(idyntree-yarp-tools TYPE GIT
                       YARP
                       ICUB
               CMAKE_ARGS -DIDYNTREE_YARP_TOOLS_USES_ICUB_MAIN:BOOL=ON
-                         -DIDYNTREE_YARP_TOOLS_USES_QT:BOOL=ON)
+                         -DIDYNTREE_YARP_TOOLS_USES_QT:BOOL=ON
+                         -DIDYNTREE_YARP_TOOLS_USES_QT_CHARTS:BOOL=OFF)
 
 set(idyntree-yarp-tools_CONDA_DEPENDENCIES eigen qt)

--- a/cmake/RobotologySuperbuildLogic.cmake
+++ b/cmake/RobotologySuperbuildLogic.cmake
@@ -37,6 +37,7 @@ endif()
 # Dynamics
 if(ROBOTOLOGY_ENABLE_DYNAMICS)
   find_or_build_package(iDynTree)
+  find_or_build_package(idyntree-yarp-tools)
   find_or_build_package(qpOASES)
   find_or_build_package(BlockFactory)
   find_or_build_package(WBToolbox)

--- a/releases/latest.releases.yaml
+++ b/releases/latest.releases.yaml
@@ -74,7 +74,7 @@ repositories:
   iDynTree:
     type: git
     url: https://github.com/robotology/idyntree.git
-    version: v3.2.1
+    version: v3.3.0
   BlockFactory:
     type: git
     url: https://github.com/robotology/blockfactory.git
@@ -203,3 +203,7 @@ repositories:
     type: git
     url: https://github.com/dic-iit/casadi-matlab-bindings.git
     version: v3.5.5.1
+  idyntree-yarp-tools:
+    type: git
+    url: https://github.com/robotology/idyntree-yarp-tools.git
+    version: v0.0.1

--- a/releases/latest.releases.yaml
+++ b/releases/latest.releases.yaml
@@ -206,4 +206,4 @@ repositories:
   idyntree-yarp-tools:
     type: git
     url: https://github.com/robotology/idyntree-yarp-tools.git
-    version: v0.0.1
+    version: v0.0.2


### PR DESCRIPTION
Furthermore, remove any dependy on YARP or ICUB on iDynTree.

Currently missing points:
* A release of iDynTree including https://github.com/robotology/idyntree/pull/887
* A release of idyntree-yarp-tools 
