### PR TITLE
Add mamba list to generate-conda-packages job and pin mamba and boa to 0.5.0 and 0.14.1

### DIFF
--- a/.github/workflows/generate-conda-packages.yaml
+++ b/.github/workflows/generate-conda-packages.yaml
@@ -70,7 +70,9 @@ jobs:
         - name: Dependencies for conda recipes generation and upload
           shell: bash -l {0}
           run: |
-            mamba install pyyaml jinja2 conda-build ninja anaconda-client conda-forge-pinning boa
+            # Workaround for https://github.com/robotology/robotology-superbuild/issues/822
+            # and https://github.com/mamba-org/boa/issues/165 .
+            mamba install pyyaml jinja2 conda-build ninja anaconda-client conda-forge-pinning mamba=0.14.1 boa=0.5.0
             # Use multisheller version that include the fix https://github.com/mamba-org/multisheller/pull/13
             python -m pip install git+https://github.com/mamba-org/multisheller.git@31883c2fe325464a8d3510380afdc83e8f64c349
 

--- a/.github/workflows/generate-conda-packages.yaml
+++ b/.github/workflows/generate-conda-packages.yaml
@@ -74,6 +74,12 @@ jobs:
             # Use multisheller version that include the fix https://github.com/mamba-org/multisheller/pull/13
             python -m pip install git+https://github.com/mamba-org/multisheller.git@31883c2fe325464a8d3510380afdc83e8f64c349
 
+        - name: Print used environment
+          shell: bash -l {0}
+          run: |
+            mamba list
+            env
+
         - name: Generate recipes [Linux&macOS]
           if: contains(matrix.os, 'macos') || contains(matrix.os, 'ubuntu')
           shell: bash -l {0}


### PR DESCRIPTION
As it was clear in https://github.com/robotology/robotology-superbuild/issues/822, unfortunatly we were not dumping the exact environment used to run the `generate-conda-packages` job, and this lead us to a regression that it is difficult to debug. Better to add a `mamba list` step for the CI for the future.

Furthermore, pin mamba to 0.14.1 and boa to 0.5.0 as a workaround for https://github.com/robotology/robotology-superbuild/issues/822 and https://github.com/mamba-org/boa/issues/165 .

Fix https://github.com/robotology/robotology-superbuild/issues/822 .