### PR TITLE
Add workaround for Homebrew failure related to mongodb-community

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -350,6 +350,8 @@ jobs:
       run: |
         cd ${ROBOTOLOGY_SUPERBUILD_SOURCE_DIR}
         cmake --version
+        # Workaround for https://github.com/actions/virtual-environments/issues/3733
+        brew uninstall mongodb-community
         # Update homebrew 
         brew update
         brew upgrade


### PR DESCRIPTION
Workaround for:
* https://github.com/robotology/robotology-superbuild/issues/826
* https://github.com/actions/virtual-environments/issues/3733
