### PR TITLE
Bump YCM to 0.13 in ProjectsTagsStable.cmake

### DIFF
--- a/cmake/ProjectsTagsStable.cmake
+++ b/cmake/ProjectsTagsStable.cmake
@@ -13,6 +13,6 @@ set_tag(CppAD_TAG 20210000.4)
 set_tag(casadi 3.5.5.3)
 
 # Robotology projects
-set_tag(YCM_TAG ycm-0.12)
+set_tag(YCM_TAG ycm-0.13)
 set_tag(YARP_TAG yarp-3.4)
 set_tag(yarp-matlab-bindings_TAG yarp-3.4)


### PR DESCRIPTION
Much smaller prerequisite of https://github.com/robotology/robotology-superbuild/issues/828, I think that it should not be a problem to merge if CI passes, as the possibility of runtime problems created by YCM is relatively low.