### PR TITLE
conda CI: Remove pinning to old libsolv version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,8 +76,6 @@ jobs:
     - name: Dependencies [Conda]
       shell: bash -l {0}
       run: |
-        # Workaround for https://github.com/robotology/robotology-superbuild/issues/785
-        conda install --name base libsolv=0.7.18
         # Compilation related dependencies 
         mamba install cmake compilers make ninja pkg-config
         # Actual dependencies


### PR DESCRIPTION
All the problem should be solved by recent mamba versions, see: 
* https://github.com/robotology/robotology-superbuild/issues/785
* https://github.com/mamba-org/mamba/issues/986