### PR TITLE
generate-conda-packages: Remove mamba and boa pinning

### DIFF
--- a/.github/workflows/generate-conda-packages.yaml
+++ b/.github/workflows/generate-conda-packages.yaml
@@ -70,9 +70,7 @@ jobs:
         - name: Dependencies for conda recipes generation and upload
           shell: bash -l {0}
           run: |
-            # Workaround for https://github.com/robotology/robotology-superbuild/issues/822
-            # and https://github.com/mamba-org/boa/issues/165 .
-            mamba install pyyaml jinja2 conda-build ninja anaconda-client conda-forge-pinning mamba=0.14.1 boa=0.5.0
+            mamba install pyyaml jinja2 conda-build ninja anaconda-client conda-forge-pinning mamba boa
             # Use multisheller version that include the fix https://github.com/mamba-org/multisheller/pull/13
             python -m pip install git+https://github.com/mamba-org/multisheller.git@31883c2fe325464a8d3510380afdc83e8f64c349
 


### PR DESCRIPTION
All the issue should be solved now, see:
* https://github.com/robotology/robotology-superbuild/issues/822
* https://github.com/mamba-org/boa/issues/165 .