### PR TITLE
Remove workaround for  https://github.com/actions/virtual-environments/issues/3733

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -348,8 +348,6 @@ jobs:
       run: |
         cd ${ROBOTOLOGY_SUPERBUILD_SOURCE_DIR}
         cmake --version
-        # Workaround for https://github.com/actions/virtual-environments/issues/3733
-        brew uninstall mongodb-community
         # Update homebrew 
         brew update
         brew upgrade


### PR DESCRIPTION
Now `mongodb-community` is not installed, so tryng to uninstall it result in failure. 