### PR TITLE
Fix non-deterministic compilation failure in walking-teleoperation when ROBOTOLOGY_ENABLE_HUMAN_DYNAMICS and ROBOTOLOGY_ENABLE_TELEOPERATION are enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ The format of this document is based on [Keep a Changelog](https://keepachangelo
 - The `idyntree-yarp-tools` was added to the Dynamics component of the superbuild (https://github.com/robotology/robotology-superbuild/pull/818).
 - An `apt.txt` file and a `scripts/install_apt_dependencies.sh` script have been added to the superbuild to report the required apt packages in a machine readable form. People that mantain either Docker recipes or documentation on how to instal the robotology-superbuild are suggest to switch to use these files instead of hardcoding the dependencies manually (https://github.com/robotology/robotology-superbuild/pull/825). 
 
+### Fixed
+- The `human-dynamics-estimation` project as been renamed to `HumanDynamicsEstimation` for consistency with the CMake name of the project (https://github.com/robotology/robotology-superbuild/pull/844).
+- Added the missing dependency of `walking-teleoperation` on `HumanDynamicsEstimation` (https://github.com/robotology/robotology-superbuild/pull/844).
 
 ## [2021.05] - 2021-05-31
 

--- a/cmake/BuildHumanDynamicsEstimation.cmake
+++ b/cmake/BuildHumanDynamicsEstimation.cmake
@@ -25,4 +25,4 @@ ycm_ep_helper(HumanDynamicsEstimation TYPE GIT
                       OsqpEigen
                       ICUB)
 
-set(human-dynamics-estimation_CONDA_DEPENDENCIES eigen)
+set(HumanDynamicsEstimation_CONDA_DEPENDENCIES eigen)

--- a/cmake/BuildHumanDynamicsEstimation.cmake
+++ b/cmake/BuildHumanDynamicsEstimation.cmake
@@ -11,7 +11,7 @@ find_or_build_package(wearables QUIET)
 find_or_build_package(osqp QUIET)
 find_or_build_package(OsqpEigen QUIET)
 
-ycm_ep_helper(human-dynamics-estimation TYPE GIT
+ycm_ep_helper(HumanDynamicsEstimation TYPE GIT
               STYLE GITHUB
               REPOSITORY robotology/human-dynamics-estimation.git
               TAG master

--- a/cmake/Buildwalking-teleoperation.cmake
+++ b/cmake/Buildwalking-teleoperation.cmake
@@ -7,6 +7,7 @@ include(FindOrBuildPackage)
 find_or_build_package(YARP QUIET)
 find_or_build_package(ICUB QUIET)
 find_or_build_package(iDynTree QUIET)
+find_or_build_package(HumanDynamicsEstimation QUIET)
 
 ycm_ep_helper(walking-teleoperation TYPE GIT
               STYLE GITHUB
@@ -16,6 +17,7 @@ ycm_ep_helper(walking-teleoperation TYPE GIT
               FOLDER src
               DEPENDS iDynTree
                       ICUB
-                      YARP)
+                      YARP
+                      HumanDynamicsEstimation)
 
 set(walking-teleoperation_CONDA_DEPENDENCIES "eigen")

--- a/cmake/ProjectsTagsStable.cmake
+++ b/cmake/ProjectsTagsStable.cmake
@@ -16,3 +16,6 @@ set_tag(casadi 3.5.5.3)
 set_tag(YCM_TAG ycm-0.13)
 set_tag(YARP_TAG yarp-3.4)
 set_tag(yarp-matlab-bindings_TAG yarp-3.4)
+
+# Workaround for https://github.com/robotology/robotology-superbuild/pull/844#issuecomment-893293323
+set_tag(walking-teleoperation_TAG devel)

--- a/cmake/ProjectsTagsUnstable.cmake
+++ b/cmake/ProjectsTagsUnstable.cmake
@@ -32,3 +32,6 @@ set_tag(whole-body-controllers_TAG master)
 set_tag(OsqpEigen_TAG master)
 set_tag(YARP_telemetry_TAG master)
 set_tag(gym-ignition_TAG master)
+# Workaround for https://github.com/robotology/robotology-superbuild/pull/844#issuecomment-893293323
+set_tag(walking-teleoperation_TAG devel)
+

--- a/cmake/RobotologySuperbuildLogic.cmake
+++ b/cmake/RobotologySuperbuildLogic.cmake
@@ -77,7 +77,7 @@ endif()
 if(ROBOTOLOGY_ENABLE_HUMAN_DYNAMICS)
   find_or_build_package(forcetorque-yarp-devices)
   find_or_build_package(wearables)
-  find_or_build_package(human-dynamics-estimation)
+  find_or_build_package(HumanDynamicsEstimation)
   find_or_build_package(human-gazebo)
 endif()
 

--- a/releases/latest.releases.yaml
+++ b/releases/latest.releases.yaml
@@ -119,7 +119,7 @@ repositories:
     type: git
     url: https://github.com/robotology/wearables.git
     version: v1.2.1
-  human-dynamics-estimation:
+  HumanDynamicsEstimation:
     type: git
     url: https://github.com/robotology/human-dynamics-estimation.git
     version: v2.2.0


### PR DESCRIPTION
Fix https://github.com/robotology/walking-teleoperation/issues/65 .

The problem was two fold: 
* `HumanDynamicsEstimation`  was called `human-dynamics-estimation`, even if its CMake config file is   `HumanDynamicsEstimation` 
* The dependency of `walking-teleoperation`  on `HumanDynamicsEstimation`  was not part of the configuration files, so there was nothing ensuring that `walking-teleoperation`  was built after `HumanDynamicsEstimation` 