### PR TITLE
In Conda documentaton, document that the preferred shell on Windows is Command Prompt and that the environment should be as clean as possible

### DIFF
--- a/doc/conda-forge.md
+++ b/doc/conda-forge.md
@@ -51,6 +51,8 @@ conda activate robotologyenv
 
 **IMPORTANT: if you open a new terminal, you need to manually activate the environment also there.**
 
+**IMPORTANT: On Windows, it is recommended to use Command Prompt to manage conda environments, as some packages (see https://github.com/conda-forge/gazebo-feedstock/issues/42 and https://github.com/RoboStack/ros-noetic/issues/21) have problems in activating environments on Powershell.** 
+
 ### Install robotology packages
 
 Once you are in an activated environment, you can install robotology packages by just running the command:
@@ -104,6 +106,8 @@ conda activate robsub
 
 **IMPORTANT: if you open a new terminal, you need to manually activate the environment also there. If you compiled a robotology-superbuild in a given conda environment, remember to activate it before trying to compile or run any package 
 of the robotology-superbuild.** 
+
+**IMPORTANT: On Windows, it is recommended to use Command Prompt to manage conda environments, as some packages (see https://github.com/conda-forge/gazebo-feedstock/issues/42 and https://github.com/RoboStack/ros-noetic/issues/21) have problems in activating environments on Powershell.** 
 
 Once you activated it, you can install packages in it. In particular the dependencies for the robotology-superbuild can be installed as:
 ~~~

--- a/doc/conda-forge.md
+++ b/doc/conda-forge.md
@@ -51,6 +51,8 @@ conda activate robotologyenv
 
 **IMPORTANT: if you open a new terminal, you need to manually activate the environment also there.**
 
+**IMPORTANT: To avoid strange conflicts in environment variables, it is a good idea to remove from  the environment any variable that refers to libraries or software not installed with conda. For example, if you have a robotology-superbuild installed with apt dependencies, it is a good idea to remove the source of the `setup.sh` from the `.bashrc` before using conda environments, or in Windows it can make sense to check with [Rapid Environment Editor](https://www.rapidee.com) that the environment is clean.**
+
 **IMPORTANT: On Windows, it is recommended to use Command Prompt to manage conda environments, as some packages (see https://github.com/conda-forge/gazebo-feedstock/issues/42 and https://github.com/RoboStack/ros-noetic/issues/21) have problems in activating environments on Powershell.** 
 
 ### Install robotology packages
@@ -105,7 +107,9 @@ conda activate robsub
 ~~~
 
 **IMPORTANT: if you open a new terminal, you need to manually activate the environment also there. If you compiled a robotology-superbuild in a given conda environment, remember to activate it before trying to compile or run any package 
-of the robotology-superbuild.** 
+of the robotology-superbuild.**
+
+**IMPORTANT: To avoid strange conflicts in environment variables, it is a good idea to remove from  the environment any variable that refers to libraries or software not installed with conda. For example, if you have a robotology-superbuild installed with apt dependencies, it is a good idea to remove the source of the `setup.sh` from the `.bashrc` before using conda environments, or in Windows it can make sense to check with [Rapid Environment Editor](https://www.rapidee.com) that the environment is clean.**
 
 **IMPORTANT: On Windows, it is recommended to use Command Prompt to manage conda environments, as some packages (see https://github.com/conda-forge/gazebo-feedstock/issues/42 and https://github.com/RoboStack/ros-noetic/issues/21) have problems in activating environments on Powershell.** 
 


### PR DESCRIPTION
On Windows command prompt is preferred as some projects have problem in activating their environment in Powershell, while in general it is a good idea to reduce the possibility of conflicts in environment variables.