### PR TITLE
Handle different names of libdc1394 package in different distributions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -227,11 +227,6 @@ jobs:
        cd build
        cmake -DROBOTOLOGY_ENABLE_DYNAMICS_FULL_DEPS:BOOL=OFF .
 
-    - name: Install additional dependencies not available on Ubuntu Bionic [Docker except ubuntu:bionic]
-      if: (matrix.docker_image != 'ubuntu:bionic')
-      run: |
-        apt-get -y install nlohmann-json3-dev
-
     - name: Build  [Docker]
       run: |
         cd build
@@ -412,11 +407,6 @@ jobs:
         cd ${ROBOTOLOGY_SUPERBUILD_SOURCE_DIR}
         cd build
         cmake -DROBOTOLOGY_ENABLE_DYNAMICS_FULL_DEPS:BOOL=OFF .
-
-    - name: Install dependencies unsupported in Ubuntu 18.04
-      if: contains(matrix.os, '20.04')
-      run: |
-        sudo apt-get -y install nlohmann-json3-dev
 
     - name: Configure [Windows]
       if: contains(matrix.os, 'windows')

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -176,6 +176,14 @@ jobs:
     steps:
     - uses: actions/checkout@master
 
+    - name: Upgrade apt packages Debian Sid [Debian Sid]
+      if: matrix.docker_image == 'debian:sid'
+      run: |
+        # The Debian sid docker image is generated only
+        # once a month, so to actually test with the latest
+        # packages we need to manually upgrade the packages
+        apt-get -y upgrade
+
     - name: Dependencies [Docker]
       run: |
         chmod +x ./.ci/install_debian.sh
@@ -185,14 +193,6 @@ jobs:
       if: matrix.docker_image == 'debian:buster-backports'
       run: |
         apt-get -y -t buster-backports install cmake
-
-    - name: Upgrade apt packages Debian Sid [Debian Sid]
-      if: matrix.docker_image == 'debian:sid'
-      run: |
-        # The Debian sid docker image is generated only
-        # once a month, so to actually test with the latest
-        # packages we need to manually upgrade the packages
-        apt-get -y upgrade
 
     - name: Install CMake from Kitware APT Repository [Docker/Ubuntu Bionic]
       if: matrix.docker_image == 'ubuntu:bionic'

--- a/README.md
+++ b/README.md
@@ -111,10 +111,7 @@ cd robotology-superbuild
 sudo bash ./scripts/install_apt_dependencies.sh
 ~~~
 
-If you are **not** using Ubuntu 18.04, you also need to install:
-~~~
-sudo apt-get install nlohmann-json3-dev
-~~~
+Besides the packages listed in `apt.txt` file, the script `install_apt_dependencies.sh` also installs some other packages depending on the distribution used, please inspect the script for more information.
 
 For what regards CMake, the robotology-superbuild requires CMake 3.16 . If you are using a recent Debian-based system such as Ubuntu 20.04, the default CMake is recent enough and you do not need to do further steps.
 

--- a/apt.txt
+++ b/apt.txt
@@ -20,6 +20,7 @@ libsdl1.2-dev
 libtinyxml-dev
 libv4l-dev
 libxml2-dev
+lsb-release
 portaudio19-dev
 qml-module-qt-labs-folderlistmodel
 qml-module-qt-labs-settings

--- a/apt.txt
+++ b/apt.txt
@@ -9,7 +9,6 @@ libace-dev
 libboost-filesystem-dev
 libboost-system-dev
 libboost-thread-dev
-libdc1394-22-dev
 libedit-dev
 libeigen3-dev
 libgsl0-dev

--- a/scripts/install_apt_dependencies.sh
+++ b/scripts/install_apt_dependencies.sh
@@ -3,6 +3,8 @@
 # Install dependencies of robotology-superbuild 
 # using apt on Ubuntu or Debian 
 
+lsb_release -a
+
 # Get location of the script
 SCRIPT_DIR=$(cd "$(dirname "$BASH_SOURCE")"; cd -P "$(dirname "$(readlink "$BASH_SOURCE" || echo .)")"; pwd)
 

--- a/scripts/install_apt_dependencies.sh
+++ b/scripts/install_apt_dependencies.sh
@@ -7,3 +7,26 @@
 SCRIPT_DIR=$(cd "$(dirname "$BASH_SOURCE")"; cd -P "$(dirname "$(readlink "$BASH_SOURCE" || echo .)")"; pwd)
 
 xargs -a ${SCRIPT_DIR}/../apt.txt apt-get install -y
+
+# Handle libdc1394 package (see https://github.com/robotology/robotology-superbuild/issues/854)
+# On Ubuntu 18.04 or Debian Buster install libdc1394-22-dev, otherwise libdc1394-dev
+# Remove once Ubuntu 18.04 and Debian Buster compatibility is dropped
+ROBSUP_DISTRO_NAME=$(lsb_release -i | cut -d: -f2 | sed s/'^\t'//)
+ROBSUP_DISTRO_VERSION=$(lsb_release -r | cut -d: -f2 | sed s/'^\t'//)
+ROBSUP_DISTRO_CODENAME=$(lsb_release -c | cut -d: -f2 | sed s/'^\t'//)
+
+if [[ ("$ROBSUP_DISTRO_NAME" == "Ubuntu" && "$ROBSUP_DISTRO_VERSION" == "22.04") || ("$ROBSUP_DISTRO_NAME" == "Debian" && "$ROBSUP_DISTRO_CODENAME" == "bookworm") ]]
+then
+  apt-get install -y libdc1394-dev
+else
+  apt-get install -y libdc1394-22-dev
+fi
+
+# Handle nlohmann-json3-dev dependency
+# Remove once Ubuntu 18.04 compatibility is dropped
+if [[ ("$ROBSUP_DISTRO_NAME" == "Ubuntu" && "$ROBSUP_DISTRO_VERSION" == "18.04") ]]
+then
+  :
+else
+  apt-get install -y nlohmann-json3-dev
+fi

--- a/scripts/install_apt_dependencies.sh
+++ b/scripts/install_apt_dependencies.sh
@@ -8,8 +8,6 @@ SCRIPT_DIR=$(cd "$(dirname "$BASH_SOURCE")"; cd -P "$(dirname "$(readlink "$BASH
 
 xargs -a ${SCRIPT_DIR}/../apt.txt apt-get install -y
 
-lsb_release -a
-
 # Handle libdc1394 package (see https://github.com/robotology/robotology-superbuild/issues/854)
 # On Ubuntu 18.04 or Debian Buster install libdc1394-22-dev, otherwise libdc1394-dev
 # Remove once Ubuntu 18.04 and Debian Buster compatibility is dropped
@@ -17,7 +15,7 @@ ROBSUP_DISTRO_NAME=$(lsb_release -i | cut -d: -f2 | sed s/'^\t'//)
 ROBSUP_DISTRO_VERSION=$(lsb_release -r | cut -d: -f2 | sed s/'^\t'//)
 ROBSUP_DISTRO_CODENAME=$(lsb_release -c | cut -d: -f2 | sed s/'^\t'//)
 
-if [[ ("$ROBSUP_DISTRO_NAME" == "Ubuntu" && "$ROBSUP_DISTRO_VERSION" == "22.04") || ("$ROBSUP_DISTRO_NAME" == "Debian" && "$ROBSUP_DISTRO_CODENAME" == "bookworm") ]]
+if [[ ("$ROBSUP_DISTRO_NAME" == "Ubuntu" && "$ROBSUP_DISTRO_VERSION" == "22.04") || ("$ROBSUP_DISTRO_NAME" == "Debian" && "$ROBSUP_DISTRO_CODENAME" == "bullseye") || ("$ROBSUP_DISTRO_NAME" == "Debian" && "$ROBSUP_DISTRO_CODENAME" == "bookworm") ]]
 then
   apt-get install -y libdc1394-dev
 else

--- a/scripts/install_apt_dependencies.sh
+++ b/scripts/install_apt_dependencies.sh
@@ -3,12 +3,12 @@
 # Install dependencies of robotology-superbuild 
 # using apt on Ubuntu or Debian 
 
-lsb_release -a
-
 # Get location of the script
 SCRIPT_DIR=$(cd "$(dirname "$BASH_SOURCE")"; cd -P "$(dirname "$(readlink "$BASH_SOURCE" || echo .)")"; pwd)
 
 xargs -a ${SCRIPT_DIR}/../apt.txt apt-get install -y
+
+lsb_release -a
 
 # Handle libdc1394 package (see https://github.com/robotology/robotology-superbuild/issues/854)
 # On Ubuntu 18.04 or Debian Buster install libdc1394-22-dev, otherwise libdc1394-dev


### PR DESCRIPTION
This fixes https://github.com/robotology/robotology-superbuild/issues/854 . I took the occasion to also move in `install_apt_dependencies.sh` the installation of nlohmman-json library.