### PR TITLE
Remove use of devel branch for walking-teleoperation stable branch

### DIFF
--- a/cmake/ProjectsTagsStable.cmake
+++ b/cmake/ProjectsTagsStable.cmake
@@ -16,6 +16,3 @@ set_tag(casadi 3.5.5.3)
 set_tag(YCM_TAG ycm-0.13)
 set_tag(YARP_TAG yarp-3.4)
 set_tag(yarp-matlab-bindings_TAG yarp-3.4)
-
-# Workaround for https://github.com/robotology/robotology-superbuild/pull/844#issuecomment-893293323
-set_tag(walking-teleoperation_TAG devel)

--- a/cmake/ProjectsTagsUnstable.cmake
+++ b/cmake/ProjectsTagsUnstable.cmake
@@ -32,6 +32,5 @@ set_tag(whole-body-controllers_TAG master)
 set_tag(OsqpEigen_TAG master)
 set_tag(YARP_telemetry_TAG master)
 set_tag(gym-ignition_TAG master)
-# Workaround for https://github.com/robotology/robotology-superbuild/pull/844#issuecomment-893293323
 set_tag(walking-teleoperation_TAG devel)
 


### PR DESCRIPTION
The need for it emerged in https://github.com/robotology/robotology-superbuild/pull/844#issuecomment-893293323 but was fixed by https://github.com/robotology/walking-teleoperation/pull/67 .