### PR TITLE
Remove use of find_or_build_package(YCM ...) to avoid warning

### DIFF
--- a/cmake/BuildYARP_telemetry.cmake
+++ b/cmake/BuildYARP_telemetry.cmake
@@ -4,7 +4,6 @@
 
 include(YCMEPHelper)
 
-find_or_build_package(YCM QUIET)
 find_or_build_package(YARP QUIET)
 find_or_build_package(matioCpp QUIET)
 

--- a/cmake/Buildblocktestcore.cmake
+++ b/cmake/Buildblocktestcore.cmake
@@ -4,8 +4,6 @@
 
 include(YCMEPHelper)
 
-find_or_build_package(YCM QUIET)
-
 ycm_ep_helper(blocktestcore TYPE GIT
               STYLE GITHUB
               REPOSITORY robotology/blocktest.git

--- a/cmake/Buildevent-driven.cmake
+++ b/cmake/Buildevent-driven.cmake
@@ -5,7 +5,6 @@ include(YCMEPHelper)
 include(FindOrBuildPackage)
 
 find_or_build_package(YARP QUIET)
-find_or_build_package(YCM QUIET)
 
 ycm_ep_helper(event-driven TYPE GIT
               STYLE GITHUB

--- a/cmake/Buildicub_firmware_shared.cmake
+++ b/cmake/Buildicub_firmware_shared.cmake
@@ -5,8 +5,6 @@
 include(YCMEPHelper)
 include(FindOrBuildPackage)
 
-find_or_build_package(YCM QUIET)
-
 ycm_ep_helper(icub_firmware_shared TYPE GIT
                                    STYLE GITHUB
                                    REPOSITORY robotology/icub-firmware-shared.git

--- a/cmake/Buildyarp-device-ovrheadset.cmake
+++ b/cmake/Buildyarp-device-ovrheadset.cmake
@@ -4,7 +4,6 @@
 include(YCMEPHelper)
 include(FindOrBuildPackage)
 
-find_or_build_package(YCM QUIET)
 find_or_build_package(YARP QUIET)
 
 ycm_ep_helper(yarp-device-ovrheadset TYPE GIT


### PR DESCRIPTION
Using `find_or_build_package(YCM)` result in a warning being generated: 
~~~
 CMake Warning (dev) at
 build/install/share/YCM/modules/FindOrBuildPackage.cmake:212 (message):
   A YCM target already exists before including BuildYCM.
 Call Stack (most recent call first):
   cmake/BuildYARP_telemetry.cmake:7 (find_or_build_package)
   build/install/share/YCM/modules/FindOrBuildPackage.cmake:215 (include)
   cmake/RobotologySuperbuildLogic.cmake:50 (find_or_build_package)
   CMakeLists.txt:63 (include)
 This warning is for project developers.  Use -Wno-dev to suppress it.
~~~

This happens because there is no `BuildYCM.cmake`  file, and YCM is handled a bit differently from other projects, so the target is always present without the need of using `find_or_build_package(YCM ...)`


Fix https://github.com/robotology/robotology-superbuild/issues/764 . 
