### PR TITLE
Enable generation of blf conda package

### DIFF
--- a/.github/workflows/generate-conda-packages.yaml
+++ b/.github/workflows/generate-conda-packages.yaml
@@ -123,10 +123,7 @@ jobs:
             conda mambabuild -m ${CONDA_PREFIX}/conda_build_config.yaml -m ${GITHUB_WORKSPACE}/conda/conda_build_config.yml yarp-matlab-bindings
             conda mambabuild -m ${CONDA_PREFIX}/conda_build_config.yaml -m ${GITHUB_WORKSPACE}/conda/conda_build_config.yml wb-toolbox
             conda mambabuild -m ${CONDA_PREFIX}/conda_build_config.yaml -m ${GITHUB_WORKSPACE}/conda/conda_build_config.yml unicycle-footstep-planner
-            # blf is currently disabled, see https://github.com/robotology/robotology-superbuild/issues/806
-            # When re-enabled, remember to use conda build and not conda mambabuild for https://github.com/robotology/robotology-superbuild/pull/800#issuecomment-866679447
-            # conda build -m ${CONDA_PREFIX}/conda_build_config.yaml -m ${GITHUB_WORKSPACE}/conda/conda_build_config.yml bipedal-locomotion-framework
-            rm -rf bipedal-locomotion-framework
+            conda mambabuild -m ${CONDA_PREFIX}/conda_build_config.yaml -m ${GITHUB_WORKSPACE}/conda/conda_build_config.yml bipedal-locomotion-framework
             conda mambabuild -m ${CONDA_PREFIX}/conda_build_config.yaml -m ${GITHUB_WORKSPACE}/conda/conda_build_config.yml wearables
             conda mambabuild -m ${CONDA_PREFIX}/conda_build_config.yaml -m ${GITHUB_WORKSPACE}/conda/conda_build_config.yml icub-models
             conda mambabuild -m ${CONDA_PREFIX}/conda_build_config.yaml -m ${GITHUB_WORKSPACE}/conda/conda_build_config.yml blocktest


### PR DESCRIPTION
I tought  https://github.com/robotology/robotology-superbuild/issues/806  was fixed by https://github.com/robotology/robotology-superbuild/pull/838 , but it turns out that indeed another modification was necessary. 

I also tried to use `conda mambabuild`  to check if the issue mentioned in https://github.com/robotology/robotology-superbuild/issues/809#issuecomment-894174951 is still present, if that is the case I will move back to use conda build .