### PR TITLE
Backport useful fixes to releases/2021.08 branch

### DIFF
--- a/.ci/install_debian.sh
+++ b/.ci/install_debian.sh
@@ -21,5 +21,20 @@ apt-get install -y python3-dev python3-numpy python3-pybind11 pybind11-dev
 # Octave
 apt-get install -y liboctave-dev
 
-# Gazebo (use distro packages to support both Ubuntu and Debian)
-apt-get install -y libgazebo*-dev
+# Gazebo
+lsb_dist="$(. /etc/os-release && echo "$ID")"
+dist_version="$(lsb_release -c | cut -d: -f2 | sed s/'^\t'//)"
+echo "lsb_dist: ${lsb_dist}"
+echo "dist_version: ${dist_version}"
+# bullseye is not supported by OpenRobotics' repo, but it has already 
+# the right version of Gazebo in its repo, so we just skip everything
+if [[ ("sid" != "$dist_version" &&  "bullseye" != "$dist_version") ]]; then
+    mkdir -p /etc/apt/sources.list.d
+    echo deb http://packages.osrfoundation.org/gazebo/$lsb_dist\-stable $dist_version main > /etc/apt/sources.list.d/gazebo-stable.list
+    apt-key adv --keyserver keyserver.ubuntu.com --recv-keys D2486D2DD83DB69272AFE98867170598AF249743
+    apt-get update
+    apt-get install -y libgazebo11-dev
+else
+    apt-get install -y libgazebo-dev
+fi
+

--- a/.github/workflows/icubTechIIT_code.yml
+++ b/.github/workflows/icubTechIIT_code.yml
@@ -13,10 +13,21 @@ jobs:
         - name: Get the version
           id: get_version
           run: echo ::set-output name=VERSION::$(echo $GITHUB_REF | cut -d / -f 3)
+          
+        - name: Get Token
+          id: get_workflow_token
+          uses: tibdex/github-app-token@v1
+          with:
+            private_key: ${{ secrets.ICUB_TECH_CODE_KEY }}
+            app_id: ${{ secrets.ICUB_TECH_CODE_ID }}
+            repository: icub-tech-iit/code
+            
         - name: Repository Dispatch
           uses: peter-evans/repository-dispatch@v1
+          env:
+            GITHUB_APPS_TOKEN: ${{ steps.get_workflow_token.outputs.token }}
           with:
-            token: ${{ secrets.ICUB_TECH_TEAM_CODE_ACCESS_TOKEN }}
+            token: ${{ env.GITHUB_APPS_TOKEN }}
             repository: icub-tech-iit/code
             event-type: repository_trigger
             client-payload: '{"version": "${{ steps.get_version.outputs.VERSION }}", "type": "repository_trigger", "img_list": "superbuild superbuild-tensorflow-cpu superbuild-tensorflow-gpu superbuild-pytorch superbuild-icubhead superbuild-nvidia superbuild-gazebo"}'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format of this document is based on [Keep a Changelog](https://keepachangelo
 
 ## [Unreleased]
 
+## [2021.08] - 2021-08-31
+
 ### Added
 - Add `nlohmann-json` dependency to the superbuild (https://github.com/robotology/robotology-superbuild/pull/776).
 - In `YARP`, all the `fake***` YARP devices are now enabled (https://github.com/robotology/robotology-superbuild/pull/797).
@@ -12,6 +14,10 @@ The format of this document is based on [Keep a Changelog](https://keepachangelo
 - `ycm-cmake-modules`, `osqp-eigen`, `robot-testing-framework` and `idyntree` conda packages are now part of the `conda-forge` channel. The new `idyntree-matlab-bindings` package is now contained in the `robotology` channel (https://github.com/robotology/robotology-superbuild/pull/807, https://github.com/robotology/robotology-superbuild/pull/817).
 - The `idyntree-yarp-tools` was added to the Dynamics component of the superbuild (https://github.com/robotology/robotology-superbuild/pull/818).
 - An `apt.txt` file and a `scripts/install_apt_dependencies.sh` script have been added to the superbuild to report the required apt packages in a machine readable form. People that mantain either Docker recipes or documentation on how to instal the robotology-superbuild are suggest to switch to use these files instead of hardcoding the dependencies manually (https://github.com/robotology/robotology-superbuild/pull/825). 
+
+### Deprecated
+- This release is the last one with Gazebo 9/10 support. From the next release, Gazebo 11 will be required (https://github.com/robotology/community/discussions/534).
+- The Homebrew-based installation procedure is deprecated, and the release 2021.11 will be the last one with support for it (https://github.com/robotology/robotology-superbuild/issues/842).
 
 ### Fixed
 - The `human-dynamics-estimation` project as been renamed to `HumanDynamicsEstimation` for consistency with the CMake name of the project (https://github.com/robotology/robotology-superbuild/pull/844).

--- a/cmake/BuildYARP_telemetry.cmake
+++ b/cmake/BuildYARP_telemetry.cmake
@@ -4,7 +4,6 @@
 
 include(YCMEPHelper)
 
-find_or_build_package(YCM QUIET)
 find_or_build_package(YARP QUIET)
 find_or_build_package(matioCpp QUIET)
 

--- a/cmake/Buildblocktestcore.cmake
+++ b/cmake/Buildblocktestcore.cmake
@@ -4,8 +4,6 @@
 
 include(YCMEPHelper)
 
-find_or_build_package(YCM QUIET)
-
 ycm_ep_helper(blocktestcore TYPE GIT
               STYLE GITHUB
               REPOSITORY robotology/blocktest.git

--- a/cmake/Buildevent-driven.cmake
+++ b/cmake/Buildevent-driven.cmake
@@ -5,7 +5,6 @@ include(YCMEPHelper)
 include(FindOrBuildPackage)
 
 find_or_build_package(YARP QUIET)
-find_or_build_package(YCM QUIET)
 
 ycm_ep_helper(event-driven TYPE GIT
               STYLE GITHUB

--- a/cmake/Buildicub_firmware_shared.cmake
+++ b/cmake/Buildicub_firmware_shared.cmake
@@ -5,8 +5,6 @@
 include(YCMEPHelper)
 include(FindOrBuildPackage)
 
-find_or_build_package(YCM QUIET)
-
 ycm_ep_helper(icub_firmware_shared TYPE GIT
                                    STYLE GITHUB
                                    REPOSITORY robotology/icub-firmware-shared.git

--- a/cmake/Buildyarp-device-ovrheadset.cmake
+++ b/cmake/Buildyarp-device-ovrheadset.cmake
@@ -4,7 +4,6 @@
 include(YCMEPHelper)
 include(FindOrBuildPackage)
 
-find_or_build_package(YCM QUIET)
 find_or_build_package(YARP QUIET)
 
 ycm_ep_helper(yarp-device-ovrheadset TYPE GIT

--- a/cmake/IncludeUrl.cmake
+++ b/cmake/IncludeUrl.cmake
@@ -1,92 +1,83 @@
-#.rst:
-# IncludeUrl
-# ----------
-#
-# Adds the :command:`include_url` command that useful to download and include
-# other CMake modules from a given url.
-#
-# .. command:: include_url
-#
-# Downloads a file from given url and includes it::
-#
-#  include_url(<url>                 # Url to be downloaded
-#     [DESTINATION <destination>]    # Where the file will be saved
-#     [EXPECTED_HASH <ALGO=value>]   # Verify downloaded file's hash
-#     [EXPECTED_MD5 <sum>]           # Short-hand for "EXPECTED_HASH MD5=sum"
-#     [DOWNLOAD_ONCE]                # Download the file only once
-#     [DOWNLOAD_ALWAYS]              # Download the file every time
-#     [OPTIONAL]                     # Do not fail file cannot be included
-#     [RESULT_VARIABLE <variable>]   # The local path for the file included
-#     [RETRIES <retries>]            # Try download <retries> times (default 3)
-#     [QUIET]                        # Don't print anything
-#    #--Download arguments-----------
-#     [INACTIVITY_TIMEOUT <timeout>] # Timeout after <timeout> seconds of inactivity
-#     [TIMEOUT <timeout>]            # Timeout after <timeout> seconds
-#     [STATUS <status>]              # Download status variable
-#     [LOG <log>]                    # Download log variable
-#     [SHOW_PROGRESS]                # Show download progress
-#     [TLS_VERIFY <on|off>]          # Check certificates
-#     [TLS_CAINFO <file>]            # Custom Certificate Authority file
-#    #--Include arguments------------
-#     [NO_POLICY_SCOPE]              # Do not manage a new policy entry
-#     )
-#
-# The ``include_url`` macro downloads a file from given url and includes it.
-# It works both in -P script mode and when configuring a CMakeLists.txt file.
-#
-# If ``DESTINATION`` is specified, the file is saved at the given location with
-# the original  file name, if ``<destination>`` is a directory, or with the
-# given file  name, if ``<destination>`` is a file name.
-#
-# The arguments ``EXPECTED_HASH``, ``EXPECTED_MD5`` are used to ensure that the
-# file included is the one expected. If the ``<url>`` is a local file (i.e.
-# starts with ``file://``) the hash check is performed also on the file
-# converted to the non-native end-of-line style.  See the documentation of the
-# :command:`file()` command for further information about these arguments.
-#
-# If the ``DOWNLOAD_ONCE`` option is specified, the file is not
-# downloaded if the file already exists and the hash is correct.
-# If the ``DOWNLOAD_ALWAYS`` option is specified, the file is downloaded at
-# every CMake execution, and an error is raised on failure.
-# If none of these two option is specifies, the default behaviour is to try to
-# download the file at every CMake execution, but no error is raised if the
-# download fails if a version of the file already exists. This is useful when
-# CMake should try to update the file to the latest version, before including
-# it.
-#
-# If the ``OPTIONAL`` option is specified, no error will be caused if for any
-# reason the file cannot be downloaded or included.
-# If ``RESULT_VARIABLE`` is given, the variable will be set to the full
-# filename which has been downloaded and included or NOTFOUND if it failed.
-# See the documentation of the :command:`file()` command for further information
-# about these arguments.
-#
-# If the ``RETRIES`` option is specified, the download will be tried
-# If the ``QUIET`` option is specified, the command will emit no output.
-#
-# The arguments ``INACTIVITY_TIMEOUT``, ``TIMEOUT``, ``STATUS``, ``LOG``,
-# ``SHOW_PROGRESS``, ``TLS_VERIFY``, and ``TLS_CAINFO`` are passed to the
-# :command:`file(DOWNLOAD)` command.  See the documentation of the
-# :command:`file()` command for a detailed description of these arguments.
-#
-# The arguments ``NO_POLICY_SCOPE`` is passed to the :command:`include()`
-# command.  See the documentation of the :command:`include()` and
-# :command:`cmake_policy()` commands for a detailed description of this
-# argument.
+# SPDX-FileCopyrightText: 2012-2021 Istituto Italiano di Tecnologia (IIT)
+# SPDX-FileCopyrightText: 2013-2015 Daniele E. Domenichelli <ddomenichelli@drdanz.it>
+# SPDX-License-Identifier: BSD-3-Clause
 
-#=============================================================================
-# Copyright 2013-2015 Istituto Italiano di Tecnologia (IIT)
-# Copyright 2013-2015 Daniele E. Domenichelli <ddomenichelli@drdanz.it>
-#
-# Distributed under the OSI-approved BSD License (the "License");
-# see accompanying file Copyright.txt for details.
-#
-# This software is distributed WITHOUT ANY WARRANTY; without even the
-# implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
-# See the License for more information.
-#=============================================================================
-# (To distribute this file outside of CMake, substitute the full
-#  License text for the above reference.)
+#[=======================================================================[.rst:
+IncludeUrl
+----------
+
+Adds the :command:`include_url` command that useful to download and include
+other CMake modules from a given url.
+
+.. command:: include_url
+
+Downloads a file from given url and includes it::
+
+ include_url(<url>                 # Url to be downloaded
+    [DESTINATION <destination>]    # Where the file will be saved
+    [EXPECTED_HASH <ALGO=value>]   # Verify downloaded file's hash
+    [EXPECTED_MD5 <sum>]           # Short-hand for "EXPECTED_HASH MD5=sum"
+    [DOWNLOAD_ONCE]                # Download the file only once
+    [DOWNLOAD_ALWAYS]              # Download the file every time
+    [OPTIONAL]                     # Do not fail file cannot be included
+    [RESULT_VARIABLE <variable>]   # The local path for the file included
+    [RETRIES <retries>]            # Try download <retries> times (default 3)
+    [QUIET]                        # Don't print anything
+   #--Download arguments-----------
+    [INACTIVITY_TIMEOUT <timeout>] # Timeout after <timeout> seconds of inactivity
+    [TIMEOUT <timeout>]            # Timeout after <timeout> seconds
+    [STATUS <status>]              # Download status variable
+    [LOG <log>]                    # Download log variable
+    [SHOW_PROGRESS]                # Show download progress
+    [TLS_VERIFY <on|off>]          # Check certificates
+    [TLS_CAINFO <file>]            # Custom Certificate Authority file
+   #--Include arguments------------
+    [NO_POLICY_SCOPE]              # Do not manage a new policy entry
+    )
+
+The ``include_url`` macro downloads a file from given url and includes it.
+It works both in -P script mode and when configuring a CMakeLists.txt file.
+
+If ``DESTINATION`` is specified, the file is saved at the given location with
+the original  file name, if ``<destination>`` is a directory, or with the
+given file  name, if ``<destination>`` is a file name.
+
+The arguments ``EXPECTED_HASH``, ``EXPECTED_MD5`` are used to ensure that the
+file included is the one expected. If the ``<url>`` is a local file (i.e.
+starts with ``file://``) the hash check is performed also on the file
+converted to the non-native end-of-line style.  See the documentation of the
+:command:`file()` command for further information about these arguments.
+
+If the ``DOWNLOAD_ONCE`` option is specified, the file is not
+downloaded if the file already exists and the hash is correct.
+If the ``DOWNLOAD_ALWAYS`` option is specified, the file is downloaded at
+every CMake execution, and an error is raised on failure.
+If none of these two option is specifies, the default behaviour is to try to
+download the file at every CMake execution, but no error is raised if the
+download fails if a version of the file already exists. This is useful when
+CMake should try to update the file to the latest version, before including
+it.
+
+If the ``OPTIONAL`` option is specified, no error will be caused if for any
+reason the file cannot be downloaded or included.
+If ``RESULT_VARIABLE`` is given, the variable will be set to the full
+filename which has been downloaded and included or NOTFOUND if it failed.
+See the documentation of the :command:`file()` command for further information
+about these arguments.
+
+If the ``RETRIES`` option is specified, the download will be tried
+If the ``QUIET`` option is specified, the command will emit no output.
+
+The arguments ``INACTIVITY_TIMEOUT``, ``TIMEOUT``, ``STATUS``, ``LOG``,
+``SHOW_PROGRESS``, ``TLS_VERIFY``, and ``TLS_CAINFO`` are passed to the
+:command:`file(DOWNLOAD)` command.  See the documentation of the
+:command:`file()` command for a detailed description of these arguments.
+
+The arguments ``NO_POLICY_SCOPE`` is passed to the :command:`include()`
+command.  See the documentation of the :command:`include()` and
+:command:`cmake_policy()` commands for a detailed description of this
+argument.
+#]=======================================================================]
 
 
 if(DEFINED __INCLUDE_URL_INCLUDED)

--- a/cmake/ProjectsTagsUnstable.cmake
+++ b/cmake/ProjectsTagsUnstable.cmake
@@ -34,4 +34,3 @@ set_tag(YARP_telemetry_TAG master)
 set_tag(gym-ignition_TAG master)
 # Workaround for https://github.com/robotology/robotology-superbuild/pull/844#issuecomment-893293323
 set_tag(walking-teleoperation_TAG devel)
-

--- a/cmake/YCMBootstrap.cmake
+++ b/cmake/YCMBootstrap.cmake
@@ -1,17 +1,5 @@
-#=============================================================================
-# Copyright 2013-2014 Istituto Italiano di Tecnologia (IIT)
-#   Authors: Daniele E. Domenichelli <daniele.domenichelli@iit.it>
-#
-# Distributed under the OSI-approved BSD License (the "License");
-# see accompanying file Copyright.txt for details.
-#
-# This software is distributed WITHOUT ANY WARRANTY; without even the
-# implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
-# See the License for more information.
-#=============================================================================
-# (To distribute this file outside of YCM, substitute the full
-#  License text for the above reference.)
-
+# SPDX-FileCopyrightText: 2012-2021 Istituto Italiano di Tecnologia (IIT)
+# SPDX-License-Identifier: BSD-3-Clause
 
 # This module is intentionally kept as small as possible in order to
 # avoid the spreading of different modules.

--- a/scripts/install_apt_dependencies.sh
+++ b/scripts/install_apt_dependencies.sh
@@ -15,7 +15,10 @@ ROBSUP_DISTRO_NAME=$(lsb_release -i | cut -d: -f2 | sed s/'^\t'//)
 ROBSUP_DISTRO_VERSION=$(lsb_release -r | cut -d: -f2 | sed s/'^\t'//)
 ROBSUP_DISTRO_CODENAME=$(lsb_release -c | cut -d: -f2 | sed s/'^\t'//)
 
-if [[ ("$ROBSUP_DISTRO_NAME" == "Ubuntu" && "$ROBSUP_DISTRO_VERSION" == "22.04") || ("$ROBSUP_DISTRO_NAME" == "Debian" && "$ROBSUP_DISTRO_CODENAME" == "bullseye") || ("$ROBSUP_DISTRO_NAME" == "Debian" && "$ROBSUP_DISTRO_CODENAME" == "bookworm") ]]
+echo "ROBSUP_DISTRO_NAME: ${ROBSUP_DISTRO_NAME}"
+echo "ROBSUP_DISTRO_VERSION: ${ROBSUP_DISTRO_VERSION}"
+echo "ROBSUP_DISTRO_CODENAME: ${ROBSUP_DISTRO_CODENAME}"
+if [[ ("$ROBSUP_DISTRO_NAME" == "Ubuntu" && "$ROBSUP_DISTRO_VERSION" == "22.04") || ("$ROBSUP_DISTRO_NAME" == "Debian" && "$ROBSUP_DISTRO_CODENAME" == "bullseye") || ("$ROBSUP_DISTRO_NAME" == "Debian" && "$ROBSUP_DISTRO_CODENAME" == "bookworm") || ("$ROBSUP_DISTRO_NAME" == "Debian" && "$ROBSUP_DISTRO_CODENAME" == "sid") ]]
 then
   apt-get install -y libdc1394-dev
 else


### PR DESCRIPTION
In view of `2021.08-feat01` release.

PR backported:
* https://github.com/robotology/robotology-superbuild/pull/862
* https://github.com/robotology/robotology-superbuild/pull/864
* https://github.com/robotology/robotology-superbuild/pull/865
* https://github.com/robotology/robotology-superbuild/pull/866
* https://github.com/robotology/robotology-superbuild/pull/873