### PR TITLE
Update apt.txt wrt `lua`

### DIFF
--- a/apt.txt
+++ b/apt.txt
@@ -13,7 +13,8 @@ libedit-dev
 libeigen3-dev
 libgsl0-dev
 libjpeg-dev
-liblua5.1-dev
+liblua5.2-dev
+lua5.2
 libode-dev
 libopencv-dev
 libsdl1.2-dev


### PR DESCRIPTION
I remember back in time that the IOL demo needed also the plain `lua` package: see the [YARP doc](https://github.com/robotology/yarp/commit/fa5035fad77d2668ff1cbd82372a3813d4e4e2d4) I updated in this respect.
It's maybe also the right time to upgrade to version `5.2`.