### PR TITLE
Bump icub-models to v1.21.1

### DIFF
--- a/releases/latest.releases.yaml
+++ b/releases/latest.releases.yaml
@@ -50,7 +50,7 @@ repositories:
   icub-models:
     type: git
     url: https://github.com/robotology/icub-models.git
-    version: v1.21.0
+    version: v1.21.1
   yarp-matlab-bindings:
     type: git
     url: https://github.com/robotology/yarp-matlab-bindings.git


### PR DESCRIPTION
See https://github.com/robotology/robotology-superbuild/pull/877#issuecomment-913145087 .