### PR TITLE
Add workaround for non-relocatable qt used in conda-forge

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -130,6 +130,13 @@ if(WIN32)
                               ${YCM_EP_INSTALL_DIR}/share/${PROJECT_NAME}/removePathsFromUserEnvVariables.ps1 @ONLY)
 endif()
 
+# Install qt.conf on Windows on conda as a workaround for the non-relocatable qt version used 
+# See https://github.com/robotology/robotology-superbuild/issues/871 and
+# https://github.com/robotology/robotology-superbuild/issues/882
+if(WIN32 AND ROBOTOLOGY_CONFIGURING_UNDER_CONDA AND EXISTS $ENV{CONDA_PREFIX}/qt.conf)
+  configure_file($ENV{CONDA_PREFIX}/qt.conf ${YCM_EP_INSTALL_DIR}/bin/qt.conf COPYONLY)
+endif()
+
 ycm_write_dot_file(${CMAKE_CURRENT_BINARY_DIR}/robotology-superbuild.dot)
 
 set_package_properties(Git PROPERTIES TYPE RUNTIME)


### PR DESCRIPTION
Fix https://github.com/robotology/robotology-superbuild/issues/871 . 

Based on my understanding, the problem is that the binary created by conda is not relocatable, so it contains the wrong paths (in particular, the one of the build machine, not the one of the machine in which it is installed).

In theory, this is a problem that should be solved at https://github.com/conda-forge/qt-feedstock . However, there is already a lot going on on that repo, so it is not even sure if a fix would be merged. Furthermore, updating to Qt 5.15 would solve the problem (thanks to https://www.qt.io/blog/qt-is-relocatable), so it is better to simply wait for 5.15 to arrive in qt-feedstock. In the meanwhile, a simple workaround is to have the superbuild copy the `qt.conf` in the right directory if it detect that is is being compiled on Windows in a conda environment. This is far from a perfect solution (it does not work if you compile projects on their own outside of the robotology-superbuild) but it will work in the short term. 

