### PR TITLE
Fix Continuos Integration on Unstable branches

### DIFF
--- a/cmake/ProjectsTagsStable.cmake
+++ b/cmake/ProjectsTagsStable.cmake
@@ -17,7 +17,3 @@ set_tag(YCM_TAG ycm-0.13)
 set_tag(YARP_TAG yarp-3.5)
 set_tag(yarp-matlab-bindings_TAG yarp-3.5)
 set_tag(gym-ignition_TAG v1.2.2)
-
-# Workaround for https://github.com/robotology/robotology-superbuild/issues/900
-# and https://github.com/robotology/wearables/issues/132
-set_tag(wearables_TAG 0ba0bfc5c3e84afd1ebaa14811aad5d55e8a70a9)


### PR DESCRIPTION
There was a regression in YARP master probably due to https://github.com/robotology/yarp/pull/2709 . Until it is fixed or all the downstream projects are fixed, let's stick to an older YARP commit so CI is green and if necessary we can detect other regressions.

~Furthermore, there was a regression in wearables due to https://github.com/robotology/wearables/pull/131 .~ That was fixed in wearables.

See https://github.com/robotology/robotology-superbuild/issues/900 for more details.