### PR TITLE
bipedal-locomotion-framework: Add missing dependency on UnicyclePlanner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format of this document is based on [Keep a Changelog](https://keepachangelo
 
 ### Fixed
 - Fixed the values assigned to the `AMENT_PREFIX_PATH` environment variable for ROS2 compatibility (https://github.com/robotology/robotology-superbuild/pull/868).
+- Fixed the missing dependency of `bipedal-locomotion-framework` on `UnicyclePlanner` (https://github.com/robotology/robotology-superbuild/pull/909).
 
 ## [2021.08] - 2021-08-31
 

--- a/cmake/Buildbipedal-locomotion-framework.cmake
+++ b/cmake/Buildbipedal-locomotion-framework.cmake
@@ -8,11 +8,13 @@ include(FindOrBuildPackage)
 find_or_build_package(YARP QUIET)
 find_or_build_package(iDynTree QUIET)
 find_or_build_package(matioCpp QUIET)
+find_or_build_package(UnicyclePlanner QUIET)
 
 set(bipedal-locomotion-framework_DEPENDS "")
 list(APPEND bipedal-locomotion-framework_DEPENDS YARP)
 list(APPEND bipedal-locomotion-framework_DEPENDS iDynTree)
 list(APPEND bipedal-locomotion-framework_DEPENDS matioCpp)
+list(APPEND bipedal-locomotion-framework_DEPENDS UnicyclePlanner)
 
 set(bipedal-locomotion-framework_USES_CppAD OFF)
 


### PR DESCRIPTION
While debugging https://github.com/robotology/robotology-superbuild/issues/907, I noticed that the dependency on `UnicyclePlanner` was missing from `bipedal-locomotion-framework`. Even if this does not fix https://github.com/robotology/robotology-superbuild/issues/907, it is an issue worth fixing.