### PR TITLE
Bump cppad to 20210000.8

### DIFF
--- a/cmake/ProjectsTagsStable.cmake
+++ b/cmake/ProjectsTagsStable.cmake
@@ -9,7 +9,7 @@ set_tag(osqp_TAG v0.6.2)
 set_tag(manif_REPOSITORY robotology-dependencies/manif.git)
 set_tag(manif_TAG 0.0.4.1)
 set_tag(qhull_TAG v8.0.2)
-set_tag(CppAD_TAG 20210000.4)
+set_tag(CppAD_TAG 20210000.8)
 set_tag(casadi 3.5.5.3)
 
 # Robotology projects

--- a/cmake/ProjectsTagsUnstable.cmake
+++ b/cmake/ProjectsTagsUnstable.cmake
@@ -9,7 +9,7 @@ set_tag(osqp_TAG v0.6.2)
 set_tag(manif_REPOSITORY robotology-dependencies/manif.git)
 set_tag(manif_TAG 0.0.4.1)
 set_tag(qhull_TAG v8.0.2)
-set_tag(CppAD_TAG 20210000.4)
+set_tag(CppAD_TAG 20210000.8)
 set_tag(casadi 3.5.5.3)
 
 # Robotology projects

--- a/releases/latest.releases.yaml
+++ b/releases/latest.releases.yaml
@@ -18,7 +18,7 @@ repositories:
   CppAD:
     type: git
     url: https://github.com/coin-or/CppAD.git
-    version: 20210000.4
+    version: 20210000.8
   casadi:
     type: git
     url: https://github.com/dic-iit/casadi.git


### PR DESCRIPTION
Fix https://github.com/robotology/robotology-superbuild/issues/856 thanks to https://github.com/coin-or/CppAD/issues/116 and https://github.com/coin-or/CppAD/commit/97bb08348f107bfa9445a362a674889a02bc57ce that is included in `20210000.8` release.

fyi @CarlottaSartore @VenusPasandi 