### PR TITLE
Align list of conda-forge robotology-superbuild dependencies between CI and docs

### DIFF
--- a/doc/conda-forge.md
+++ b/doc/conda-forge.md
@@ -127,7 +127,7 @@ of the robotology-superbuild.**
 Once you activated it, you can install packages in it. In particular the dependencies for the robotology-superbuild can be installed as:
 ~~~
 mamba install -c conda-forge cmake compilers make ninja pkg-config
-mamba install -c conda-forge ace asio boost eigen gazebo glew glfw gsl ipopt libjpeg-turbo libmatio libode libxml2 nlohmann_json opencv pkg-config portaudio qt sdl sdl2 sqlite tinyxml spdlog
+mamba install -c conda-forge ace asio boost eigen gazebo glew glfw gsl ipopt irrlicht libjpeg-turbo libmatio libode libxml2 nlohmann_json opencv pkg-config portaudio qt sdl sdl2 sqlite tinyxml spdlog
 ~~~
 
 If you are on **Linux**, you also need to install also the following packages:


### PR DESCRIPTION
I just copied the list from https://github.com/robotology/robotology-superbuild/blob/83a0c595765b96a6de4305406346bcfb33a8f98b/.github/workflows/ci.yml#L81 in the docs. 

This should fix https://github.com/robotology/robotology-superbuild/issues/893 .