### PR TITLE
In ICUB enable compilation of bcbBattery if ROBOTOLOGY_ENABLE_ICUB_HEAD option is enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format of this document is based on [Keep a Changelog](https://keepachangelo
 
 ## [Unreleased]
 
+### Changed
+- Enable the compilation of the `bcbBattery` device on `icub-main` when using the `ICUB_HEAD` profile (https://github.com/robotology/robotology-superbuild/pull/912).
+
 ### Fixed
 - Fixed the values assigned to the `AMENT_PREFIX_PATH` environment variable for ROS2 compatibility (https://github.com/robotology/robotology-superbuild/pull/868).
 - Fixed the missing dependency of `bipedal-locomotion-framework` on `UnicyclePlanner` (https://github.com/robotology/robotology-superbuild/pull/909).

--- a/cmake/BuildICUB.cmake
+++ b/cmake/BuildICUB.cmake
@@ -61,6 +61,7 @@ ycm_ep_helper(ICUB TYPE GIT
                                     -DENABLE_icubmod_dragonfly2:BOOL=${ENABLE_DRAGONFLY2}
                                     -DENABLE_icubmod_portaudio:BOOL=${ROBOTOLOGY_ENABLE_ICUB_HEAD}
                                     -DENABLE_icubmod_sharedcan:BOOL=${ROBOTOLOGY_ENABLE_ICUB_HEAD}
+                                    -DENABLE_icubmod_bcbBattery:BOOL=${ROBOTOLOGY_ENABLE_ICUB_HEAD}
                                     -DENABLE_icubmod_canmotioncontrol:BOOL=${ROBOTOLOGY_ENABLE_ICUB_HEAD}
                                     -DENABLE_icubmod_canBusAnalogSensor:BOOL=${ROBOTOLOGY_ENABLE_ICUB_HEAD}
                                     -DENABLE_icubmod_canBusInertialMTB:BOOL=${ROBOTOLOGY_ENABLE_ICUB_HEAD}


### PR DESCRIPTION
Fix https://github.com/robotology/robotology-superbuild/issues/894 .