### PR TITLE
Fix typo in cdt package to install on conda-forge documentation

### DIFF
--- a/doc/conda-forge.md
+++ b/doc/conda-forge.md
@@ -132,7 +132,7 @@ mamba install -c conda-forge ace asio assimp boost eigen gazebo glew glfw gsl ip
 
 If you are on **Linux**, you also need to install also the following packages:
 ~~~
-mamba install -c conda-forge bash-completion expat-cos6-x86_64 freeglut libdc1394 libselinux-cos7-x86_64 libxau-cos7-x86_64 libxcb-cos7-x86_64 libxdamage-cos7-x86_64 libxext-cos7-x86_64 libxfixes-cos7-x86_64 libxxf86vm-cos7-x86_64 mesa-libgl-cos7-x86_64 libxshmfence-cos7-x86_64 libxshmfence-devel-cos7-x86_64 
+mamba install -c conda-forge bash-completion expat-cos7-x86_64 freeglut libdc1394 libselinux-cos7-x86_64 libxau-cos7-x86_64 libxcb-cos7-x86_64 libxdamage-cos7-x86_64 libxext-cos7-x86_64 libxfixes-cos7-x86_64 libxxf86vm-cos7-x86_64 mesa-libgl-cos7-x86_64 libxshmfence-cos7-x86_64 libxshmfence-devel-cos7-x86_64 
 ~~~
 
 If you are on **Windows**, you also need to install also the following packages:


### PR DESCRIPTION
`expat-cos6-x86_64` should be `expat-cos7-x86_64`.

See:
* https://github.com/robotology/robotology-superbuild/pull/926 the original pr
* https://github.com/conda-forge/conda-forge.github.io/issues/1436 the indication that probably conda-forge as an whole will be moving to cos7 soon, that actually give even more sense to https://github.com/robotology/robotology-superbuild/pull/926