### PR TITLE
Install lua as dependency in conda-forge-based installation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,7 +78,7 @@ jobs:
         # Compilation related dependencies 
         mamba install cmake compilers make ninja pkg-config
         # Actual dependencies
-        mamba install ace asio assimp boost eigen gazebo glew glfw gsl ipopt irrlicht libjpeg-turbo libmatio libode libxml2 nlohmann_json opencv pkg-config portaudio qt sdl sdl2 sqlite tinyxml spdlog
+        mamba install ace asio assimp boost eigen gazebo glew glfw gsl ipopt irrlicht libjpeg-turbo libmatio libode libxml2 nlohmann_json opencv pkg-config portaudio qt sdl sdl2 sqlite tinyxml spdlog lua
         # Python 
         mamba install numpy swig pybind11
 

--- a/doc/conda-forge.md
+++ b/doc/conda-forge.md
@@ -127,7 +127,7 @@ of the robotology-superbuild.**
 Once you activated it, you can install packages in it. In particular the dependencies for the robotology-superbuild can be installed as:
 ~~~
 mamba install -c conda-forge cmake compilers make ninja pkg-config
-mamba install -c conda-forge ace asio assimp boost eigen gazebo glew glfw gsl ipopt irrlicht libjpeg-turbo libmatio libode libxml2 nlohmann_json opencv pkg-config portaudio qt sdl sdl2 sqlite tinyxml spdlog
+mamba install -c conda-forge ace asio assimp boost eigen gazebo glew glfw gsl ipopt irrlicht libjpeg-turbo libmatio libode libxml2 nlohmann_json opencv pkg-config portaudio qt sdl sdl2 sqlite tinyxml spdlog lua
 ~~~
 
 If you are on **Linux**, you also need to install also the following packages:


### PR DESCRIPTION
This is done to mitigate cross-talking problems when compiling YARP in a conda-environment in Arch-based distributions, see https://github.com/robotology/robotology-superbuild/issues/923 .

This is just a mitigation, as the issue is either in the conda-packaged CMake that is able to find system libraries or in the YARP build system, but given that lua is a relative small dependency is not a problematic mitigation.