### PR TITLE
Fix conda package generation by pinning boa and mamba to known working versions

### DIFF
--- a/.github/workflows/generate-conda-packages.yaml
+++ b/.github/workflows/generate-conda-packages.yaml
@@ -120,8 +120,8 @@ jobs:
             conda mambabuild -m ${CONDA_PREFIX}/conda_build_config.yaml -m ${GITHUB_WORKSPACE}/conda/conda_build_config.yml icub-contrib-common
             conda mambabuild -m ${CONDA_PREFIX}/conda_build_config.yaml -m ${GITHUB_WORKSPACE}/conda/conda_build_config.yml icub-firmware-shared
             conda mambabuild -m ${CONDA_PREFIX}/conda_build_config.yaml -m ${GITHUB_WORKSPACE}/conda/conda_build_config.yml robots-configuration
-            # icub-main needs robotology channel as it also depends on esdcan
-            conda mambabuild -m ${CONDA_PREFIX}/conda_build_config.yaml -m ${GITHUB_WORKSPACE}/conda/conda_build_config.yml -c conda-forge -c robotology icub-main
+            # icub-main needs robotology channel as it also depends on esdcan, and local to avoid that robotology packages are used instead of local built one
+            conda mambabuild -m ${CONDA_PREFIX}/conda_build_config.yaml -m ${GITHUB_WORKSPACE}/conda/conda_build_config.yml -c local -c conda-forge -c robotology icub-main
             conda mambabuild -m ${CONDA_PREFIX}/conda_build_config.yaml -m ${GITHUB_WORKSPACE}/conda/conda_build_config.yml lie-group-controllers
             conda mambabuild -m ${CONDA_PREFIX}/conda_build_config.yaml -m ${GITHUB_WORKSPACE}/conda/conda_build_config.yml qpoases
             conda mambabuild -m ${CONDA_PREFIX}/conda_build_config.yaml -m ${GITHUB_WORKSPACE}/conda/conda_build_config.yml yarp-matlab-bindings

--- a/.github/workflows/generate-conda-packages.yaml
+++ b/.github/workflows/generate-conda-packages.yaml
@@ -111,9 +111,10 @@ jobs:
             # See https://docs.conda.io/projects/conda-build/en/latest/resources/variants.html#creating-conda-build-variant-config-files
             # We manually specify the build order as conda build is too slow, and conda mambabuild does not support correctly multiple recipes
             # see https://github.com/mamba-org/boa/issues/117
+            conda mambabuild -m ${CONDA_PREFIX}/conda_build_config.yaml -m ${GITHUB_WORKSPACE}/conda/conda_build_config.yml yarp
+            conda mambabuild -m ${CONDA_PREFIX}/conda_build_config.yaml -m ${GITHUB_WORKSPACE}/conda/conda_build_config.yml gazebo-yarp-plugins
             conda mambabuild -m ${CONDA_PREFIX}/conda_build_config.yaml -m ${GITHUB_WORKSPACE}/conda/conda_build_config.yml idyntree-matlab-bindings
             conda mambabuild -m ${CONDA_PREFIX}/conda_build_config.yaml -m ${GITHUB_WORKSPACE}/conda/conda_build_config.yml blockfactory
-            conda mambabuild -m ${CONDA_PREFIX}/conda_build_config.yaml -m ${GITHUB_WORKSPACE}/conda/conda_build_config.yml yarp
             conda mambabuild -m ${CONDA_PREFIX}/conda_build_config.yaml -m ${GITHUB_WORKSPACE}/conda/conda_build_config.yml matio-cpp
             conda mambabuild -m ${CONDA_PREFIX}/conda_build_config.yaml -m ${GITHUB_WORKSPACE}/conda/conda_build_config.yml yarp-telemetry
             conda mambabuild -m ${CONDA_PREFIX}/conda_build_config.yaml -m ${GITHUB_WORKSPACE}/conda/conda_build_config.yml icub-contrib-common

--- a/.github/workflows/generate-conda-packages.yaml
+++ b/.github/workflows/generate-conda-packages.yaml
@@ -120,7 +120,8 @@ jobs:
             conda mambabuild -m ${CONDA_PREFIX}/conda_build_config.yaml -m ${GITHUB_WORKSPACE}/conda/conda_build_config.yml icub-contrib-common
             conda mambabuild -m ${CONDA_PREFIX}/conda_build_config.yaml -m ${GITHUB_WORKSPACE}/conda/conda_build_config.yml icub-firmware-shared
             conda mambabuild -m ${CONDA_PREFIX}/conda_build_config.yaml -m ${GITHUB_WORKSPACE}/conda/conda_build_config.yml robots-configuration
-            conda mambabuild -m ${CONDA_PREFIX}/conda_build_config.yaml -m ${GITHUB_WORKSPACE}/conda/conda_build_config.yml icub-main
+            # icub-main needs robotology channel as it also depends on esdcan
+            conda mambabuild -m ${CONDA_PREFIX}/conda_build_config.yaml -m ${GITHUB_WORKSPACE}/conda/conda_build_config.yml -c conda-forge -c robotology icub-main
             conda mambabuild -m ${CONDA_PREFIX}/conda_build_config.yaml -m ${GITHUB_WORKSPACE}/conda/conda_build_config.yml lie-group-controllers
             conda mambabuild -m ${CONDA_PREFIX}/conda_build_config.yaml -m ${GITHUB_WORKSPACE}/conda/conda_build_config.yml qpoases
             conda mambabuild -m ${CONDA_PREFIX}/conda_build_config.yaml -m ${GITHUB_WORKSPACE}/conda/conda_build_config.yml yarp-matlab-bindings

--- a/.github/workflows/generate-conda-packages.yaml
+++ b/.github/workflows/generate-conda-packages.yaml
@@ -70,7 +70,9 @@ jobs:
         - name: Dependencies for conda recipes generation and upload
           shell: bash -l {0}
           run: |
-            mamba install pyyaml jinja2 conda-build ninja anaconda-client conda-forge-pinning mamba boa
+            # Pin mamba and boa versions
+            # to avoid https://github.com/robotology/robotology-superbuild/issues/927#issuecomment-979765045
+            mamba install pyyaml jinja2 conda-build ninja anaconda-client conda-forge-pinning mamba=0.18 boa=0.8
             # Use multisheller version that include the fix https://github.com/mamba-org/multisheller/pull/13
             python -m pip install git+https://github.com/mamba-org/multisheller.git@31883c2fe325464a8d3510380afdc83e8f64c349
 

--- a/.github/workflows/generate-conda-packages.yaml
+++ b/.github/workflows/generate-conda-packages.yaml
@@ -72,7 +72,7 @@ jobs:
           run: |
             # Pin mamba and boa versions
             # to avoid https://github.com/robotology/robotology-superbuild/issues/927#issuecomment-979765045
-            mamba install pyyaml jinja2 conda-build ninja anaconda-client conda-forge-pinning mamba=0.18 boa=0.8
+            mamba install pyyaml jinja2 conda-build ninja anaconda-client conda-forge-pinning mamba=0.17 boa=0.7
             # Use multisheller version that include the fix https://github.com/mamba-org/multisheller/pull/13
             python -m pip install git+https://github.com/mamba-org/multisheller.git@31883c2fe325464a8d3510380afdc83e8f64c349
 

--- a/cmake/BuildGazeboYARPPlugins.cmake
+++ b/cmake/BuildGazeboYARPPlugins.cmake
@@ -41,4 +41,4 @@ ycm_ep_helper(GazeboYARPPlugins TYPE GIT
                                         gazebo
                                 CMAKE_ARGS -DGAZEBO_YARP_PLUGINS_HAS_OPENCV:BOOL=ON)
 
-set(GazeboYARPPlugins_CONDA_DEPENDENCIES libopencv gazebo)
+set(GazeboYARPPlugins_CONDA_DEPENDENCIES libopencv gazebo=11.8)

--- a/conda/recipe_template/build.sh
+++ b/conda/recipe_template/build.sh
@@ -18,6 +18,12 @@ cmake .. \
 {% for cmake_arg in cmake_args %}    {{ cmake_arg }} \
 {% endfor %}
 
+# Workaround for https://github.com/robotology/robotology-superbuild/issues/927#issuecomment-985522905
+if [[ "$PKG_NAME" == gazebo-yarp-plugins ]]; then
+    echo "Setting CPU_COUNT=1 for gazebo-yarp-plugins"
+    export CPU_COUNT=1
+fi
+
 cmake --build . --config Release --parallel $CPU_COUNT
 cmake --build . --config Release --target install
 

--- a/conda/recipe_template/build.sh
+++ b/conda/recipe_template/build.sh
@@ -18,12 +18,6 @@ cmake .. \
 {% for cmake_arg in cmake_args %}    {{ cmake_arg }} \
 {% endfor %}
 
-# Workaround for https://github.com/robotology/robotology-superbuild/issues/927#issuecomment-985522905
-if [[ "$PKG_NAME" == gazebo-yarp-plugins ]]; then
-    echo "Setting CPU_COUNT=1 for gazebo-yarp-plugins"
-    export CPU_COUNT=1
-fi
-
 cmake --build . --config Release --parallel $CPU_COUNT
 cmake --build . --config Release --target install
 


### PR DESCRIPTION
* `boa` and `mamba` were quite unstable lately, so pin them to safe version at least for the near future.
* There are strange internal compiler errors when building gazebo-yarp-plugins, so let's build stick to build it against gazebo 11.8 for which this problem do not emerge.
* Add the channel `robotology` when icub-main is built so that the `esdcan` dependency is correctly found (see https://github.com/robotology/robotology-superbuild/pull/935)

Fix https://github.com/robotology/robotology-superbuild/issues/927 .