### PR TITLE
Disable Gazebo testing on Debian Testing

### DIFF
--- a/.ci/install_debian.sh
+++ b/.ci/install_debian.sh
@@ -34,7 +34,8 @@ if [[ ("sid" != "$dist_version" && "bullseye" != "$dist_version" && "bookworm" !
     apt-key adv --keyserver keyserver.ubuntu.com --recv-keys D2486D2DD83DB69272AFE98867170598AF249743
     apt-get update
     apt-get install -y libgazebo11-dev
-else
+# See https://github.com/robotology/robotology-superbuild/issues/944
+elif [[ ("bookworm" != "$dist_version") ]]; then
     apt-get install -y libgazebo-dev
 fi
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -235,6 +235,13 @@ jobs:
        cd build
        cmake -DROBOTOLOGY_ENABLE_DYNAMICS_FULL_DEPS:BOOL=OFF -DROBOTOLOGY_ENABLE_ROBOT_TESTING:BOOL=OFF -DROBOTOLOGY_USES_PYTHON:BOOL=OFF .
 
+    # See https://github.com/robotology/robotology-superbuild/issues/944
+    - name: Disable profiles that are not supported in Debian Testing [Docker ubuntu:testing]
+      if: (matrix.docker_image == 'debian:testing')
+      run: |
+       cd build
+       cmake -DROBOTOLOGY_USES_GAZEBO:BOOL=OFF .
+
     - name: Build  [Docker]
       run: |
         cd build
@@ -415,6 +422,14 @@ jobs:
         cd ${ROBOTOLOGY_SUPERBUILD_SOURCE_DIR}
         cd build
         cmake -DROBOTOLOGY_ENABLE_DYNAMICS_FULL_DEPS:BOOL=OFF -DROBOTOLOGY_ENABLE_ROBOT_TESTING:BOOL=OFF -DROBOTOLOGY_USES_PYTHON:BOOL=OFF .
+
+    - name: Disable options unsupported on Debian Testing
+      if: contains(matrix.os, '18.04')
+      run: |
+        cd ${ROBOTOLOGY_SUPERBUILD_SOURCE_DIR}
+        cd build
+        cmake -DROBOTOLOGY_ENABLE_DYNAMICS_FULL_DEPS:BOOL=OFF -DROBOTOLOGY_ENABLE_ROBOT_TESTING:BOOL=OFF -DROBOTOLOGY_USES_PYTHON:BOOL=OFF .
+
 
     - name: Configure [Windows]
       if: contains(matrix.os, 'windows')


### PR DESCRIPTION
Fix/workaround for https://github.com/robotology/robotology-superbuild/issues/944 . For the time being, we do not test Gazebo support for Debian Testing.