### PR TITLE
Workaround problem of multiple append in the same if in conda activation scripts in command prompt

### DIFF
--- a/conda/multisheller/wb-toolbox_activate.msh
+++ b/conda/multisheller/wb-toolbox_activate.msh
@@ -1,6 +1,6 @@
-# For some reason appending two times the same variable inside the same if does not work in command prompt
+# For some reason, appending two times the same variable inside the same "if" statement does not work in command prompt.
 # See https://github.com/mamba-org/multisheller/issues/9
-# As a workaround, we move each append in its own if
+# As a workaround, we move each append in its own "if" statement.
 
 if_(is_set("COMSPEC")).then_([
 	sys.list_append("MATLABPATH", path.join(env("CONDA_PREFIX"), "Library\\share\\WBToolbox"))

--- a/conda/multisheller/wb-toolbox_activate.msh
+++ b/conda/multisheller/wb-toolbox_activate.msh
@@ -1,7 +1,15 @@
+# For some reason appending two times the same variable inside the same if does not work in command prompt
+# See https://github.com/mamba-org/multisheller/issues/9
+# As a workaround, we move each append in its own if
+
 if_(is_set("COMSPEC")).then_([
-	sys.list_append("MATLABPATH", path.join(env("CONDA_PREFIX"), "Library\\share\\WBToolbox")),
+	sys.list_append("MATLABPATH", path.join(env("CONDA_PREFIX"), "Library\\share\\WBToolbox"))
+]).else_([
+	sys.list_append("MATLABPATH", path.join(env("CONDA_PREFIX"), "share/WBToolbox"))
+])
+
+if_(is_set("COMSPEC")).then_([
 	sys.list_append("MATLABPATH", path.join(env("CONDA_PREFIX"), "Library\\share\\WBToolbox\\images"))
 ]).else_([
-	sys.list_append("MATLABPATH", path.join(env("CONDA_PREFIX"), "share/WBToolbox")),
 	sys.list_append("MATLABPATH", path.join(env("CONDA_PREFIX"), "share/WBToolbox/images"))
 ])

--- a/conda/multisheller/wb-toolbox_deactivate.msh
+++ b/conda/multisheller/wb-toolbox_deactivate.msh
@@ -1,7 +1,9 @@
+For some reason appending two times the same variable inside the same if does not work in command prompt
+# See https://github.com/mamba-org/multisheller/issues/9
+# As a workaround, we move each append in its own if
+
 if_(is_set("COMSPEC")).then_([
-	sys.list_remove("MATLABPATH", path.join(env("CONDA_PREFIX"), "Library\\share\\WBToolbox")),
-	sys.list_remove("MATLABPATH", path.join(env("CONDA_PREFIX"), "Library\\share\\WBToolbox\\images"))
+	sys.list_remove("MATLABPATH", path.join(env("CONDA_PREFIX"), "Library\\share\\WBToolbox"))
 ]).else_([
-	sys.list_remove("MATLABPATH", path.join(env("CONDA_PREFIX"), "share/WBToolbox")),
-	sys.list_remove("MATLABPATH", path.join(env("CONDA_PREFIX"), "share/WBToolbox/images"))
+	sys.list_remove("MATLABPATH", path.join(env("CONDA_PREFIX"), "share/WBToolbox"))
 ])

--- a/conda/multisheller/wb-toolbox_deactivate.msh
+++ b/conda/multisheller/wb-toolbox_deactivate.msh
@@ -7,3 +7,9 @@ if_(is_set("COMSPEC")).then_([
 ]).else_([
 	sys.list_remove("MATLABPATH", path.join(env("CONDA_PREFIX"), "share/WBToolbox"))
 ])
+
+if_(is_set("COMSPEC")).then_([
+	sys.list_remove("MATLABPATH", path.join(env("CONDA_PREFIX"), "Library\\share\\WBToolbox\\images"))
+]).else_([
+	sys.list_remove("MATLABPATH", path.join(env("CONDA_PREFIX"), "share/WBToolbox/images"))
+])

--- a/conda/multisheller/wb-toolbox_deactivate.msh
+++ b/conda/multisheller/wb-toolbox_deactivate.msh
@@ -1,6 +1,6 @@
-For some reason appending two times the same variable inside the same if does not work in command prompt
+# For some reason, appending two times the same variable inside the same "if" statement does not work in command prompt.
 # See https://github.com/mamba-org/multisheller/issues/9
-# As a workaround, we move each append in its own if
+# As a workaround, we move each append in its own "if" statement.
 
 if_(is_set("COMSPEC")).then_([
 	sys.list_remove("MATLABPATH", path.join(env("CONDA_PREFIX"), "Library\\share\\WBToolbox"))

--- a/conda/multisheller/whole-body-controllers_activate.msh
+++ b/conda/multisheller/whole-body-controllers_activate.msh
@@ -1,9 +1,21 @@
+# For some reason appending two times the same variable inside the same if does not work in command prompt
+# See https://github.com/mamba-org/multisheller/issues/9
+# As a workaround, we move each append in its own if
+
 if_(is_set("COMSPEC")).then_([
 	sys.list_append("MATLABPATH", path.join(env("CONDA_PREFIX"), "Library\\mex\\+wbc\\simulink")),
-	sys.list_append("MATLABPATH", path.join(env("CONDA_PREFIX"), "Library\\mex\\+wbc\\simulink\\MomentumVelocityControl")),
-	sys.list_append("MATLABPATH", path.join(env("CONDA_PREFIX"), "Library\\mex\\+wbc\\examples"))
 ]).else_([
 	sys.list_append("MATLABPATH", path.join(env("CONDA_PREFIX"), "mex/+wbc/simulink")),
+])
+
+if_(is_set("COMSPEC")).then_([
+	sys.list_append("MATLABPATH", path.join(env("CONDA_PREFIX"), "Library\\mex\\+wbc\\simulink\\MomentumVelocityControl")),
+]]).else_([
 	sys.list_append("MATLABPATH", path.join(env("CONDA_PREFIX"), "mex/+wbc/simulink/MomentumVelocityControl")),
+])
+
+if_(is_set("COMSPEC")).then_([
+	sys.list_append("MATLABPATH", path.join(env("CONDA_PREFIX"), "Library\\mex\\+wbc\\examples"))
+]).else_([
 	sys.list_append("MATLABPATH", path.join(env("CONDA_PREFIX"), "mex/+wbc/examples"))
 ])

--- a/conda/multisheller/whole-body-controllers_activate.msh
+++ b/conda/multisheller/whole-body-controllers_activate.msh
@@ -3,15 +3,15 @@
 # As a workaround, we move each append in its own if
 
 if_(is_set("COMSPEC")).then_([
-	sys.list_append("MATLABPATH", path.join(env("CONDA_PREFIX"), "Library\\mex\\+wbc\\simulink")),
+	sys.list_append("MATLABPATH", path.join(env("CONDA_PREFIX"), "Library\\mex\\+wbc\\simulink"))
 ]).else_([
-	sys.list_append("MATLABPATH", path.join(env("CONDA_PREFIX"), "mex/+wbc/simulink")),
+	sys.list_append("MATLABPATH", path.join(env("CONDA_PREFIX"), "mex/+wbc/simulink"))
 ])
 
 if_(is_set("COMSPEC")).then_([
-	sys.list_append("MATLABPATH", path.join(env("CONDA_PREFIX"), "Library\\mex\\+wbc\\simulink\\MomentumVelocityControl")),
+	sys.list_append("MATLABPATH", path.join(env("CONDA_PREFIX"), "Library\\mex\\+wbc\\simulink\\MomentumVelocityControl"))
 ]]).else_([
-	sys.list_append("MATLABPATH", path.join(env("CONDA_PREFIX"), "mex/+wbc/simulink/MomentumVelocityControl")),
+	sys.list_append("MATLABPATH", path.join(env("CONDA_PREFIX"), "mex/+wbc/simulink/MomentumVelocityControl"))
 ])
 
 if_(is_set("COMSPEC")).then_([

--- a/conda/multisheller/whole-body-controllers_activate.msh
+++ b/conda/multisheller/whole-body-controllers_activate.msh
@@ -1,6 +1,6 @@
-# For some reason appending two times the same variable inside the same if does not work in command prompt
+# For some reason, appending two times the same variable inside the same "if" statement does not work in command prompt.
 # See https://github.com/mamba-org/multisheller/issues/9
-# As a workaround, we move each append in its own if
+# As a workaround, we move each append in its own "if" statement.
 
 if_(is_set("COMSPEC")).then_([
 	sys.list_append("MATLABPATH", path.join(env("CONDA_PREFIX"), "Library\\mex\\+wbc\\simulink"))

--- a/conda/multisheller/whole-body-controllers_deactivate.msh
+++ b/conda/multisheller/whole-body-controllers_deactivate.msh
@@ -1,6 +1,6 @@
-# For some reason appending two times the same variable inside the same if does not work in command prompt
+# For some reason, appending two times the same variable inside the same "if" statement does not work in command prompt.
 # See https://github.com/mamba-org/multisheller/issues/9
-# As a workaround, we move each append in its own if
+# As a workaround, we move each append in its own "if" statement.
 
 if_(is_set("COMSPEC")).then_([
 	sys.list_remove("MATLABPATH", path.join(env("CONDA_PREFIX"), "Library\\mex\\+wbc\\simulink"))

--- a/conda/multisheller/whole-body-controllers_deactivate.msh
+++ b/conda/multisheller/whole-body-controllers_deactivate.msh
@@ -1,9 +1,21 @@
+# For some reason appending two times the same variable inside the same if does not work in command prompt
+# See https://github.com/mamba-org/multisheller/issues/9
+# As a workaround, we move each append in its own if
+
 if_(is_set("COMSPEC")).then_([
-	sys.list_remove("MATLABPATH", path.join(env("CONDA_PREFIX"), "Library\\mex\\+wbc\\simulink")),
-	sys.list_remove("MATLABPATH", path.join(env("CONDA_PREFIX"), "Library\\mex\\+wbc\\simulink\\MomentumVelocityControl")),
+	sys.list_remove("MATLABPATH", path.join(env("CONDA_PREFIX"), "Library\\mex\\+wbc\\simulink"))
+]).else_([
+	sys.list_remove("MATLABPATH", path.join(env("CONDA_PREFIX"), "mex/+wbc/simulink"))
+])
+
+if_(is_set("COMSPEC")).then_([
+	sys.list_remove("MATLABPATH", path.join(env("CONDA_PREFIX"), "Library\\mex\\+wbc\\simulink\\MomentumVelocityControl"))
+]).else_([
+	sys.list_remove("MATLABPATH", path.join(env("CONDA_PREFIX"), "mex/+wbc/simulink/MomentumVelocityControl"))
+])
+
+if_(is_set("COMSPEC")).then_([
 	sys.list_remove("MATLABPATH", path.join(env("CONDA_PREFIX"), "Library\\mex\\+wbc\\examples"))
 ]).else_([
-	sys.list_remove("MATLABPATH", path.join(env("CONDA_PREFIX"), "mex/+wbc/simulink")),
-	sys.list_remove("MATLABPATH", path.join(env("CONDA_PREFIX"), "mex/+wbc/simulink/MomentumVelocityControl")),
 	sys.list_remove("MATLABPATH", path.join(env("CONDA_PREFIX"), "mex/+wbc/examples"))
 ])


### PR DESCRIPTION
Fix https://github.com/robotology/wb-toolbox/issues/228, using the same workaround that was already used in icub-models also in whole-body-controllers and wb-toolbox . 

For a brief explanation of what is going on, [multisheller](https://github.com/mamba-org/multisheller) is the project that we are using to generate "activation scripts" (i.e. the scripts that set the right enviromental variables when you type `conda activate <env>`) for our conda packages for all the terminal we are supporting (bash, zsh, command prompt). For a longer explanation, see last part of  https://github.com/robotology/robotology-superbuild/blob/0bf40cf7d2c05e130b6f7fc1c86b7a87c6fcd373/doc/developers-faqs.md#how-to-ensure-that-binary-packages-are-correctly-generated-for-a-new-package .

The problem is that multisheller on command prompt has a bug, that is described in https://github.com/mamba-org/multisheller/issues/9: when we are appending the same env var in the same if, in command prompt it is not set directly. As I do not know how to tackle the original issue, this PR just workaround the problem by ensuring that in wb-toolbox and whole-body-controllers a separate if is used for each call to append.