### PR TITLE
Switch conda CI to macos-10.15 workers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
       matrix:
         build_type: [Release]
         # Windows is disabled due to the missing ipopt package
-        os: [ubuntu-latest, macos-latest, windows-2019]
+        os: [ubuntu-latest, macos-10.15, windows-2019]
         project_tags:
           - Default
           - Unstable


### PR DESCRIPTION
Workaround for https://github.com/robotology/robotology-superbuild/issues/955 . Indeed, switching to macos-10.15 works as Xcode 12 is used. However, the problem remains withw Xcode 13.