### PR TITLE
Use YARP unstable checkout before IRangefinder2D interface changes

### DIFF
--- a/cmake/ProjectsTagsUnstable.cmake
+++ b/cmake/ProjectsTagsUnstable.cmake
@@ -13,7 +13,7 @@ set_tag(CppAD_TAG 20210000.8)
 set_tag(casadi 3.5.5.3)
 
 # Robotology projects
-set_tag(YARP_TAG master)
+set_tag(YARP_TAG 72edb969f741fea29d78701dad71905f6fa8d35c)
 set_tag(ICUB_TAG devel)
 set_tag(RobotTestingFramework_TAG devel)
 set_tag(blockTest_TAG devel)


### PR DESCRIPTION
Workaround for https://github.com/robotology/robotology-superbuild/issues/959 .