### PR TITLE
Use ubuntu-20.04 and macos-10.15 in generate-conda-packages

### DIFF
--- a/.github/workflows/generate-conda-packages.yaml
+++ b/.github/workflows/generate-conda-packages.yaml
@@ -21,9 +21,9 @@ jobs:
             fail-fast: false
             matrix:
               include:
-                - os: ubuntu-latest
+                - os: ubuntu-20.04
                   conda_platform: linux-64
-                - os: macos-latest
+                - os: macos-10.15
                   conda_platform: osx-64
                 - os: windows-2019
                   conda_platform: win-64


### PR DESCRIPTION
In https://github.com/robotology/robotology-superbuild/issues/955 an issue between conda compilers and macOS SDK in Xcode 13 (that is installed in macos-latest) was found. This PR avoids that issue in  `generate-conda-packages` action by switching to `macos-10.15` image. For consistency, on Linux we use ubuntu-20.04 instead of ubuntu-latest.