### PR TITLE
GazeboYARPPlugins: add dependency on dartsim when generating conda packages

### DIFF
--- a/cmake/BuildGazeboYARPPlugins.cmake
+++ b/cmake/BuildGazeboYARPPlugins.cmake
@@ -41,4 +41,6 @@ ycm_ep_helper(GazeboYARPPlugins TYPE GIT
                                         gazebo
                                 CMAKE_ARGS -DGAZEBO_YARP_PLUGINS_HAS_OPENCV:BOOL=ON)
 
-set(GazeboYARPPlugins_CONDA_DEPENDENCIES libopencv gazebo)
+# Workaround for https://github.com/conda-forge/gazebo-feedstock/issues/107
+# and https://github.com/robotology/yarp.js/issues/28#issuecomment-997459819
+set(GazeboYARPPlugins_CONDA_DEPENDENCIES libopencv gazebo=11.8 dartsim)

--- a/cmake/BuildGazeboYARPPlugins.cmake
+++ b/cmake/BuildGazeboYARPPlugins.cmake
@@ -41,4 +41,4 @@ ycm_ep_helper(GazeboYARPPlugins TYPE GIT
                                         gazebo
                                 CMAKE_ARGS -DGAZEBO_YARP_PLUGINS_HAS_OPENCV:BOOL=ON)
 
-set(GazeboYARPPlugins_CONDA_DEPENDENCIES libopencv gazebo=11.8)
+set(GazeboYARPPlugins_CONDA_DEPENDENCIES libopencv gazebo)


### PR DESCRIPTION
~The use of 11.8 is generating the problem described in https://github.com/robotology/yarp.js/issues/28#issuecomment-997122408, let's try to remove this so the latest gazebo is used.~ 

As gazebo 11.9 still results in internal compiler error, we still require gazebo=11.8 in the build and for now we just add the dependency on dartsim so we get the correct run_exports dependency in gazebo-yarp-plugins.