### PR TITLE
conda-forge Documentation: Fix documentation on required additional dependencies on Linux

### DIFF
--- a/doc/conda-forge.md
+++ b/doc/conda-forge.md
@@ -132,7 +132,7 @@ mamba install -c conda-forge ace asio assimp boost eigen gazebo glew glfw gsl ip
 
 If you are on **Linux**, you also need to install also the following packages:
 ~~~
-mamba install -c conda-forge bash-completion expat-cos7-x86_64 freeglut libdc1394 libselinux-cos7-x86_64 libxau-cos7-x86_64 libxcb-cos7-x86_64 libxdamage-cos7-x86_64 libxext-cos7-x86_64 libxfixes-cos7-x86_64 libxxf86vm-cos7-x86_64 mesa-libgl-cos7-x86_64 libxshmfence-cos7-x86_64 libxshmfence-devel-cos7-x86_64 
+mamba install -c conda-forge bash-completion expat-cos7-x86_64 freeglut libdc1394 libselinux-cos7-x86_64 libxau-cos7-x86_64 libxcb-cos7-x86_64 libxdamage-cos7-x86_64 libxext-cos7-x86_64 libxfixes-cos7-x86_64 libxxf86vm-cos7-x86_64 mesa-libgl-cos7-x86_64 mesa-libgl-devel-cos7-x86_64 libxshmfence-cos7-x86_64 libxshmfence-devel-cos7-x86_64 
 ~~~
 
 If you are on **Windows**, you also need to install also the following packages:


### PR DESCRIPTION
The documentation and the CI were not coherent. In particular, in the docs the `mesa-libgl-devel-cos7-x86_64` package (that contains the `GL/gl.h` header) was missing.