### PR TITLE
Add workaround for gazebo-yarp-plugins internal compiler error by switching to clang

### DIFF
--- a/cmake/BuildGazeboYARPPlugins.cmake
+++ b/cmake/BuildGazeboYARPPlugins.cmake
@@ -43,4 +43,4 @@ ycm_ep_helper(GazeboYARPPlugins TYPE GIT
 
 # Workaround for https://github.com/conda-forge/gazebo-feedstock/issues/107
 # and https://github.com/robotology/yarp.js/issues/28#issuecomment-997459819
-set(GazeboYARPPlugins_CONDA_DEPENDENCIES libopencv gazebo=11.8 dartsim)
+set(GazeboYARPPlugins_CONDA_DEPENDENCIES libopencv gazebo dartsim)

--- a/conda/recipe_template/build.sh
+++ b/conda/recipe_template/build.sh
@@ -4,6 +4,12 @@
 cd {{ source_subdir }}
 {% endif %}
 
+{# Workaround for https://github.com/robotology/robotology-superbuild/issues/966 #}
+{% if name == "gazebo-yarp-plugins" %}
+export CC=$BUILD_PREFIX/bin/clang
+export CXX=$BUILD_PREFIX/bin/clang++
+{% endif %}
+
 mkdir build
 cd build
 

--- a/conda/recipe_template/meta.yaml
+++ b/conda/recipe_template/meta.yaml
@@ -36,6 +36,12 @@ requirements:
     - {{ cdt('libxfixes') }}
     - {{ cdt('libxau') }}
     - {{ cdt('expat') }}  {% endraw %}{% endif %}
+{# Workaround for https://github.com/robotology/robotology-superbuild/issues/966 #}
+{% if name == "gazebo-yarp-plugins" %}
+    - clang
+    - clangxx
+{% endif %}
+
 
   host:
 {# List all dependencies just a host. Run dependenencies should be correctly set by run_exports, except the one listed in #}


### PR DESCRIPTION
Instead of requiring an old version of Gazebo as done in https://github.com/robotology/robotology-superbuild/pull/937, we switch to use the clang++ compiler if gazebo-yarp-plugins is built. Not a complete fix, but better that use an old version of Gazebo that in the long run forces a old version of all the transitive dependencies of Gazebo.

Fix https://github.com/robotology/robotology-superbuild/issues/966 .