### PR TITLE
Fix regression in generate-conda-recipes created by PR 957

### DIFF
--- a/conda/multisheller/whole-body-controllers_activate.msh
+++ b/conda/multisheller/whole-body-controllers_activate.msh
@@ -1,6 +1,6 @@
-# For some reason, appending two times the same variable inside the same "if" statement does not work in command prompt.
+# For some reason, appending two times the same variable inside the same if statement does not work in command prompt.
 # See https://github.com/mamba-org/multisheller/issues/9
-# As a workaround, we move each append in its own "if" statement.
+# As a workaround, we move each append in its own if statement.
 
 if_(is_set("COMSPEC")).then_([
 	sys.list_append("MATLABPATH", path.join(env("CONDA_PREFIX"), "Library\\mex\\+wbc\\simulink"))

--- a/conda/multisheller/whole-body-controllers_activate.msh
+++ b/conda/multisheller/whole-body-controllers_activate.msh
@@ -7,15 +7,3 @@ if_(is_set("COMSPEC")).then_([
 ]).else_([
 	sys.list_append("MATLABPATH", path.join(env("CONDA_PREFIX"), "mex/+wbc/simulink"))
 ])
-
-if_(is_set("COMSPEC")).then_([
-	sys.list_append("MATLABPATH", path.join(env("CONDA_PREFIX"), "Library\\mex\\+wbc\\simulink\\MomentumVelocityControl"))
-]]).else_([
-	sys.list_append("MATLABPATH", path.join(env("CONDA_PREFIX"), "mex/+wbc/simulink/MomentumVelocityControl"))
-])
-
-if_(is_set("COMSPEC")).then_([
-	sys.list_append("MATLABPATH", path.join(env("CONDA_PREFIX"), "Library\\mex\\+wbc\\examples"))
-]).else_([
-	sys.list_append("MATLABPATH", path.join(env("CONDA_PREFIX"), "mex/+wbc/examples"))
-])

--- a/conda/multisheller/whole-body-controllers_activate.msh
+++ b/conda/multisheller/whole-body-controllers_activate.msh
@@ -1,6 +1,6 @@
-# For some reason, appending two times the same variable inside the same if statement does not work in command prompt.
+# For some reason, appending two times the same variable inside the same "if" statement does not work in command prompt.
 # See https://github.com/mamba-org/multisheller/issues/9
-# As a workaround, we move each append in its own if statement.
+# As a workaround, we move each append in its own "if" statement.
 
 if_(is_set("COMSPEC")).then_([
 	sys.list_append("MATLABPATH", path.join(env("CONDA_PREFIX"), "Library\\mex\\+wbc\\simulink"))

--- a/conda/multisheller/whole-body-controllers_activate.msh
+++ b/conda/multisheller/whole-body-controllers_activate.msh
@@ -7,3 +7,15 @@ if_(is_set("COMSPEC")).then_([
 ]).else_([
 	sys.list_append("MATLABPATH", path.join(env("CONDA_PREFIX"), "mex/+wbc/simulink"))
 ])
+
+if_(is_set("COMSPEC")).then_([
+	sys.list_append("MATLABPATH", path.join(env("CONDA_PREFIX"), "Library\\mex\\+wbc\\simulink"))
+]).else_([
+	sys.list_append("MATLABPATH", path.join(env("CONDA_PREFIX"), "mex/+wbc/simulink"))
+])
+
+if_(is_set("COMSPEC")).then_([
+	sys.list_append("MATLABPATH", path.join(env("CONDA_PREFIX"), "Library\\mex\\+wbc\\simulink"))
+]).else_([
+	sys.list_append("MATLABPATH", path.join(env("CONDA_PREFIX"), "mex/+wbc/simulink"))
+])

--- a/conda/multisheller/whole-body-controllers_deactivate.msh
+++ b/conda/multisheller/whole-body-controllers_deactivate.msh
@@ -1,6 +1,6 @@
 # For some reason, appending two times the same variable inside the same if statement does not work in command prompt.
 # See https://github.com/mamba-org/multisheller/issues/9
-# As a workaround, we move each append in its own if statement.
+# As a workaround, we move each append in its own "if" statement.
 
 if_(is_set("COMSPEC")).then_([
 	sys.list_remove("MATLABPATH", path.join(env("CONDA_PREFIX"), "Library\\mex\\+wbc\\simulink"))

--- a/conda/multisheller/whole-body-controllers_deactivate.msh
+++ b/conda/multisheller/whole-body-controllers_deactivate.msh
@@ -1,6 +1,6 @@
-# For some reason, appending two times the same variable inside the same "if" statement does not work in command prompt.
+# For some reason, appending two times the same variable inside the same if statement does not work in command prompt.
 # See https://github.com/mamba-org/multisheller/issues/9
-# As a workaround, we move each append in its own "if" statement.
+# As a workaround, we move each append in its own if statement.
 
 if_(is_set("COMSPEC")).then_([
 	sys.list_remove("MATLABPATH", path.join(env("CONDA_PREFIX"), "Library\\mex\\+wbc\\simulink"))

--- a/conda/multisheller/whole-body-controllers_deactivate.msh
+++ b/conda/multisheller/whole-body-controllers_deactivate.msh
@@ -7,15 +7,3 @@ if_(is_set("COMSPEC")).then_([
 ]).else_([
 	sys.list_remove("MATLABPATH", path.join(env("CONDA_PREFIX"), "mex/+wbc/simulink"))
 ])
-
-if_(is_set("COMSPEC")).then_([
-	sys.list_remove("MATLABPATH", path.join(env("CONDA_PREFIX"), "Library\\mex\\+wbc\\simulink\\MomentumVelocityControl"))
-]).else_([
-	sys.list_remove("MATLABPATH", path.join(env("CONDA_PREFIX"), "mex/+wbc/simulink/MomentumVelocityControl"))
-])
-
-if_(is_set("COMSPEC")).then_([
-	sys.list_remove("MATLABPATH", path.join(env("CONDA_PREFIX"), "Library\\mex\\+wbc\\examples"))
-]).else_([
-	sys.list_remove("MATLABPATH", path.join(env("CONDA_PREFIX"), "mex/+wbc/examples"))
-])


### PR DESCRIPTION
PR https://github.com/robotology/robotology-superbuild/pull/957 create a regression that broke the `generate-conda-recipes` job. This PR fixes it.