### PR TITLE
Fix regression in generation of whole-body-controllers recipe introduced by PR 957

### DIFF
--- a/conda/multisheller/whole-body-controllers_activate.msh
+++ b/conda/multisheller/whole-body-controllers_activate.msh
@@ -10,7 +10,7 @@ if_(is_set("COMSPEC")).then_([
 
 if_(is_set("COMSPEC")).then_([
 	sys.list_append("MATLABPATH", path.join(env("CONDA_PREFIX"), "Library\\mex\\+wbc\\simulink\\MomentumVelocityControl"))
-]]).else_([
+]).else_([
 	sys.list_append("MATLABPATH", path.join(env("CONDA_PREFIX"), "mex/+wbc/simulink/MomentumVelocityControl"))
 ])
 


### PR DESCRIPTION
PR https://github.com/robotology/robotology-superbuild/pull/957 create a regression that broke the `generate-conda-recipes` job. This PR fixes it.