### PR TITLE
Use YARP master branch in Unstable tags

### DIFF
--- a/cmake/ProjectsTagsUnstable.cmake
+++ b/cmake/ProjectsTagsUnstable.cmake
@@ -13,7 +13,7 @@ set_tag(CppAD_TAG 20210000.8)
 set_tag(casadi 3.5.5.3)
 
 # Robotology projects
-set_tag(YARP_TAG 72edb969f741fea29d78701dad71905f6fa8d35c)
+set_tag(YARP_TAG master)
 set_tag(ICUB_TAG devel)
 set_tag(RobotTestingFramework_TAG devel)
 set_tag(blockTest_TAG devel)

--- a/cmake/ProjectsTagsUnstable.cmake
+++ b/cmake/ProjectsTagsUnstable.cmake
@@ -33,3 +33,5 @@ set_tag(OsqpEigen_TAG master)
 set_tag(YARP_telemetry_TAG master)
 set_tag(gym-ignition_TAG v1.2.2)
 set_tag(walking-teleoperation_TAG devel)
+set_tag(whole-body-estimators_TAG fix_yarp36)
+

--- a/cmake/ProjectsTagsUnstable.cmake
+++ b/cmake/ProjectsTagsUnstable.cmake
@@ -33,5 +33,3 @@ set_tag(OsqpEigen_TAG master)
 set_tag(YARP_telemetry_TAG master)
 set_tag(gym-ignition_TAG v1.2.2)
 set_tag(walking-teleoperation_TAG devel)
-set_tag(whole-body-estimators_TAG fix_yarp36)
-


### PR DESCRIPTION
Revert https://github.com/robotology/robotology-superbuild/pull/961 as the issue was solved by https://github.com/robotology/gazebo-yarp-plugins/pull/599 .