### PR TITLE
Testing Debian Sid instead of Debian Testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -185,7 +185,7 @@ jobs:
     - uses: actions/checkout@master
 
     - name: Upgrade apt packages Debian Testing and Sid [Debian Testing and Sid]
-      if: (matrix.docker_image == 'debian:testing' || matrix.docker_image == 'debian:sid'
+      if: (matrix.docker_image == 'debian:testing' || matrix.docker_image == 'debian:sid')
       run: |
         # The Debian Testing and Sid docker image are generated only
         # once a month, so to actually test with the latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -167,7 +167,7 @@ jobs:
           - "ubuntu:bionic"
           - "ubuntu:focal"
           - "debian:buster-backports"
-          - "debian:testing"
+          - "debian:sid"
 
         project_tags:
           - Default
@@ -184,10 +184,10 @@ jobs:
     steps:
     - uses: actions/checkout@master
 
-    - name: Upgrade apt packages Debian Testing [Debian Testing]
-      if: matrix.docker_image == 'debian:testing'
+    - name: Upgrade apt packages Debian Testing and Sid [Debian Testing and Sid]
+      if: (matrix.docker_image == 'debian:testing' || matrix.docker_image == 'debian:sid'
       run: |
-        # The Debian testing docker image is generated only
+        # The Debian Testing and Sid docker image are generated only
         # once a month, so to actually test with the latest
         # packages we need to manually upgrade the packages
         apt-get -y upgrade
@@ -223,8 +223,8 @@ jobs:
         # Gazebo is disabled due to the errors reported in https://github.com/robotology/robotology-superbuild/pull/593
         cmake -DROBOTOLOGY_USES_OCTAVE:BOOL=OFF -DROBOTOLOGY_USES_PYTHON:BOOL=OFF -DROBOTOLOGY_USES_GAZEBO:BOOL=OFF .
 
-    - name: Disable profiles that are not supported in docker for now [Docker debian-testing and debian-buster]
-      if: (matrix.docker_image == 'debian:testing' || matrix.docker_image == 'debian:buster-backports' || matrix.docker_image == 'ubuntu:bionic')
+    - name: Disable profiles that are not supported in docker for now [Docker debian-testing, debian-sid and debian-buster]
+      if: (matrix.docker_image == 'debian:testing' || matrix.docker_image == 'debian:sid' || matrix.docker_image == 'debian:buster-backports' || matrix.docker_image == 'ubuntu:bionic')
       run: |
        cd build
        cmake -DROBOTOLOGY_ENABLE_DYNAMICS_FULL_DEPS:BOOL=OFF -DROBOTOLOGY_ENABLE_ROBOT_TESTING:BOOL=OFF -DROBOTOLOGY_USES_PYTHON:BOOL=OFF .
@@ -236,8 +236,8 @@ jobs:
        cmake -DROBOTOLOGY_ENABLE_DYNAMICS_FULL_DEPS:BOOL=OFF -DROBOTOLOGY_ENABLE_ROBOT_TESTING:BOOL=OFF -DROBOTOLOGY_USES_PYTHON:BOOL=OFF .
 
     # See https://github.com/robotology/robotology-superbuild/issues/944
-    - name: Disable profiles that are not supported in Debian Testing [Docker ubuntu:testing]
-      if: (matrix.docker_image == 'debian:testing')
+    - name: Disable profiles that are not supported in Debian Testing and Sid [Docker debian:testing, debian:sid]
+      if: (matrix.docker_image == 'debian:testing' || matrix.docker_image == 'debian:sid')
       run: |
        cd build
        cmake -DROBOTOLOGY_USES_GAZEBO:BOOL=OFF .


### PR DESCRIPTION
Not meant to be merged, but useful to debugging the issue from https://github.com/robotology/robotology-superbuild/issues/974 to see if it is still present in Debian sid that as of 2021/12/23 has assimp 5.1.4 while Testing has 5.1.3 .