### PR TITLE
Pin Stable builds to v1.22.0 to workaround lack of YARP 3.6 release

### DIFF
--- a/cmake/ProjectsTagsStable.cmake
+++ b/cmake/ProjectsTagsStable.cmake
@@ -15,5 +15,7 @@ set_tag(casadi 3.5.5.3)
 # Robotology projects
 set_tag(YCM_TAG ycm-0.13)
 set_tag(YARP_TAG yarp-3.5)
+# Workaround for https://github.com/robotology/robotology-superbuild/issues/978
+set_tag(ICUB_TAG v1.22.0)
 set_tag(yarp-matlab-bindings_TAG yarp-3.5)
 set_tag(gym-ignition_TAG v1.2.2)


### PR DESCRIPTION
Fix https://github.com/robotology/robotology-superbuild/issues/978 .