### PR TITLE
Update package versions in 2021.11.1 release

### DIFF
--- a/releases/2021.11.1.yaml
+++ b/releases/2021.11.1.yaml
@@ -42,7 +42,7 @@ repositories:
   robots-configuration:
     type: git
     url: https://github.com/robotology/robots-configuration.git
-    version: v1.22.1
+    version: v1.22.2
   GazeboYARPPlugins:
     type: git
     url: https://github.com/robotology/gazebo-yarp-plugins.git

--- a/releases/2021.11.1.yaml
+++ b/releases/2021.11.1.yaml
@@ -106,7 +106,7 @@ repositories:
   whole-body-estimators:
     type: git
     url: https://github.com/robotology/whole-body-estimators.git
-    version: v0.6.0
+    version: v0.6.1
   walking-teleoperation:
     type: git
     url: https://github.com/robotology/walking-teleoperation.git

--- a/releases/2021.11.1.yaml
+++ b/releases/2021.11.1.yaml
@@ -162,7 +162,7 @@ repositories:
   funny-things:
     type: git
     url: https://github.com/robotology/funny-things.git
-    version: v1.1.0
+    version: v2.0.0
   bipedal-locomotion-framework:
     type: git
     url: https://github.com/ami-iit/bipedal-locomotion-framework.git

--- a/releases/2021.11.1.yaml
+++ b/releases/2021.11.1.yaml
@@ -138,7 +138,7 @@ repositories:
   icub-firmware-build:
     type: git
     url: https://github.com/robotology/icub-firmware-build.git
-    version: v1.22.0
+    version: v1.23.0
   icub-firmware-models:
     type: git
     url: https://github.com/robotology/icub-firmware-models.git

--- a/releases/2021.11.1.yaml
+++ b/releases/2021.11.1.yaml
@@ -54,7 +54,7 @@ repositories:
   yarp-matlab-bindings:
     type: git
     url: https://github.com/robotology/yarp-matlab-bindings.git
-    version: v3.5.0
+    version: v3.6.0
   RobotTestingFramework:
     type: git
     url: https://github.com/robotology/robot-testing-framework.git

--- a/releases/2021.11.1.yaml
+++ b/releases/2021.11.1.yaml
@@ -30,11 +30,11 @@ repositories:
   YARP:
     type: git
     url: https://github.com/robotology/yarp.git
-    version: v3.5.1
+    version: v3.6.0
   ICUB:
     type: git
     url: https://github.com/robotology/icub-main.git
-    version: v1.22.0
+    version: v1.23.1
   ICUBcontrib:
     type: git
     url: https://github.com/robotology/icub-contrib-common.git
@@ -42,11 +42,11 @@ repositories:
   robots-configuration:
     type: git
     url: https://github.com/robotology/robots-configuration.git
-    version: v1.22.0
+    version: v1.22.1
   GazeboYARPPlugins:
     type: git
     url: https://github.com/robotology/gazebo-yarp-plugins.git
-    version: v4.0.0
+    version: v4.1.0
   icub-models:
     type: git
     url: https://github.com/robotology/icub-models.git


### PR DESCRIPTION
CI will probably fail as https://github.com/robotology/whole-body-estimators/pull/135 still needs to be merged and released, but better to open this PR so we can check if we are missing some release.