### PR TITLE
Bump YARP and yarp-matlab-bindings in Stable branches to yarp-3.6

### DIFF
--- a/cmake/ProjectsTagsStable.cmake
+++ b/cmake/ProjectsTagsStable.cmake
@@ -14,8 +14,7 @@ set_tag(casadi 3.5.5.3)
 
 # Robotology projects
 set_tag(YCM_TAG ycm-0.13)
-set_tag(YARP_TAG yarp-3.5)
-# Workaround for https://github.com/robotology/robotology-superbuild/issues/978
+set_tag(YARP_TAG yarp-3.6)
 set_tag(ICUB_TAG v1.22.0)
-set_tag(yarp-matlab-bindings_TAG yarp-3.5)
+set_tag(yarp-matlab-bindings_TAG yarp-3.6)
 set_tag(gym-ignition_TAG v1.2.2)


### PR DESCRIPTION
As `yarp` and `yarp-matlab-bindings` use a different branch for each minor release, we need to update manually them to ensure that Stable branches use YARP 3.6 .
As now we bump to yarp-3.6, I also removed the workaround added in https://github.com/robotology/robotology-superbuild/pull/979 .