### PR TITLE
BuildYARP: Enable compilation of usbCamera YARP device even if ROBOTOLOGY_ENABLE_ICUB_HEAD is OFF

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format of this document is based on [Keep a Changelog](https://keepachangelo
 
 ### Changed
 - On Windows the option `ROBOTOLOGY_USES_ESDCAN` is now enabled when generating conda packages (https://github.com/robotology/robotology-superbuild/pull/935).
+- For the YARP package, the compilation of the `usbCamera` device on Linux is enabled regardless of the value of `ROBOTOLOGY_ENABLE_ICUB_HEAD` (https://github.com/robotology/robotology-superbuild/pull/989).
 
 ## [2021.11.1] - 2022-01-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ The format of this document is based on [Keep a Changelog](https://keepachangelo
 
 ### Changed
 - On Windows the option `ROBOTOLOGY_USES_ESDCAN` is now enabled when generating conda packages (https://github.com/robotology/robotology-superbuild/pull/935).
-- For the YARP package, the compilation of the `usbCamera` device on Linux is enabled regardless of the value of `ROBOTOLOGY_ENABLE_ICUB_HEAD` (https://github.com/robotology/robotology-superbuild/pull/989).
+- For the YARP package, the compilation of the `usbCamera` device on Linux is enabled even if `ROBOTOLOGY_ENABLE_ICUB_HEAD` is `OFF` (https://github.com/robotology/robotology-superbuild/pull/989).
 
 ## [2021.11.1] - 2022-01-05
 

--- a/cmake/BuildYARP.cmake
+++ b/cmake/BuildYARP.cmake
@@ -27,7 +27,7 @@ endif()
 if (APPLE OR WIN32)
   set(ENABLE_USBCAMERA OFF)
 else()
-  set(ENABLE_USBCAMERA ${ROBOTOLOGY_ENABLE_ICUB_HEAD})
+  set(ENABLE_USBCAMERA ON)
 endif()
 
 # Workaround for https://github.com/robotology/yarp/issues/2353


### PR DESCRIPTION
The `usbCamera` device is a useful YARP device even for developers on their laptops that want to stream the output of their webcam on a YARP port. For this reason, it make sense to enable its compilation even if `ROBOTOLOGY_ENABLE_ICUB_HEAD` is OFF. 