### PR TITLE
Do not set ICUB_TAG in ProjectsTagsStable

### DIFF
--- a/cmake/ProjectsTagsStable.cmake
+++ b/cmake/ProjectsTagsStable.cmake
@@ -15,6 +15,5 @@ set_tag(casadi 3.5.5.3)
 # Robotology projects
 set_tag(YCM_TAG ycm-0.13)
 set_tag(YARP_TAG yarp-3.6)
-set_tag(ICUB_TAG v1.22.0)
 set_tag(yarp-matlab-bindings_TAG yarp-3.6)
 set_tag(gym-ignition_TAG v1.2.2)


### PR DESCRIPTION
`ICUB_TAG` was set to 1.22.0 in https://github.com/robotology/robotology-superbuild/pull/979 for yarp-3.5 compatibility, but this is not necessary anymore since https://github.com/robotology/robotology-superbuild/pull/984 . However, in https://github.com/robotology/robotology-superbuild/pull/984 we forgot to remove the `ICUB_TAG` hardcoding.