### PR TITLE
GitHub Actions: Cleanup CMake conda configuration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,7 +117,6 @@ jobs:
         # Disable options not tested on Conda for now
         # Reference issue: https://github.com/robotology/robotology-superbuild/issues/563
         cmake -DROBOTOLOGY_USES_OCTAVE:BOOL=OFF .
-        cat ./install/share/robotology-superbuild/setup.sh
 
     - name: Configure Extra [Conda/Linux]
       if: contains(matrix.os, 'ubuntu')
@@ -135,10 +134,7 @@ jobs:
         cd build
         cmake -G"Visual Studio 16 2019" -C ${GITHUB_WORKSPACE}/.ci/initial-cache.gh.cmake -DYCM_EP_ADDITIONAL_CMAKE_ARGS:STRING="-DMatlab_ROOT_DIR:PATH=${GHA_Matlab_ROOT_DIR} -DMatlab_MEX_EXTENSION:STRING=${GHA_Matlab_MEX_EXTENSION}" -DROBOTOLOGY_USES_MATLAB:BOOL=ON  -DNON_INTERACTIVE_BUILD:BOOL=TRUE -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}  ${{ matrix.project_tags_cmake_options }}  ..
         # Disable options not tested on Conda for now
-        # Reference issue: https://github.com/robotology/robotology-superbuild/issues/563
-        cmake -DROBOTOLOGY_USES_OCTAVE:BOOL=OFF  -DROBOTOLOGY_USES_PYTHON:BOOL=ON .
-        cat ./install/share/robotology-superbuild/setup.sh
-        cat ./install/share/robotology-superbuild/setup.bat
+        cmake -DROBOTOLOGY_USES_OCTAVE:BOOL=OFF .
 
     # For some reason, the Strawberry perl's pkg-config is found
     # instead of the conda's one, so let's delete the /c/Strawberry directory


### PR DESCRIPTION
For some reason `ROBOTOLOGY_USES_PYTHON` was still disabled on Windows/Conda. Furthemore, there was a reference to https://github.com/robotology/robotology-superbuild/issues/563, but `ROBOTOLOGY_ENABLE_DYNAMICS_FULL_DEPS` was enabled in CI since a long time. So I cleanup up a bit this part of the CI scripts, eliminating also some debug `cat` commands