### PR TITLE
Add support for Visual Studio 2022 in CI and Documentation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,7 +130,7 @@ jobs:
         set
         mkdir -p build
         cd build
-        cmake -G${GHA_CMAKE_GENERATOR} -C ${GITHUB_WORKSPACE}/.ci/initial-cache.gh.cmake -DYCM_EP_ADDITIONAL_CMAKE_ARGS:STRING="-DMatlab_ROOT_DIR:PATH=${GHA_Matlab_ROOT_DIR} -DMatlab_MEX_EXTENSION:STRING=${GHA_Matlab_MEX_EXTENSION}" -DROBOTOLOGY_USES_MATLAB:BOOL=ON -DNON_INTERACTIVE_BUILD:BOOL=TRUE -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}  ${{ matrix.project_tags_cmake_options }}  ..
+        cmake -G"${GHA_CMAKE_GENERATOR}" -C ${GITHUB_WORKSPACE}/.ci/initial-cache.gh.cmake -DYCM_EP_ADDITIONAL_CMAKE_ARGS:STRING="-DMatlab_ROOT_DIR:PATH=${GHA_Matlab_ROOT_DIR} -DMatlab_MEX_EXTENSION:STRING=${GHA_Matlab_MEX_EXTENSION}" -DROBOTOLOGY_USES_MATLAB:BOOL=ON -DNON_INTERACTIVE_BUILD:BOOL=TRUE -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}  ${{ matrix.project_tags_cmake_options }}  ..
         # Disable options not tested on Conda for now
         cmake -DROBOTOLOGY_USES_OCTAVE:BOOL=OFF .
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,7 +107,7 @@ jobs:
         env
 
     - name: Set CMake generator [Conda/Linux&macOs]
-      if: not(contains(matrix.os, 'windows'))
+      if: !contains(matrix.os, 'windows')
       shell: bash -l {0}
       run: |
         echo "GHA_CMAKE_GENERATOR=Ninja" >> $GITHUB_ENV

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
       fail-fast: false
       matrix:
         build_type: [Release]
-        os: [ubuntu-latest, macos-10.15, windows-2022]
+        os: [ubuntu-latest, macos-10.15, windows-2019, windows-2022]
         project_tags:
           - Default
           - Unstable
@@ -112,14 +112,14 @@ jobs:
       run: |
         echo "GHA_CMAKE_GENERATOR=Ninja" >> $GITHUB_ENV
 
-    - name: Set CMake generator [Conda/Windows Stable]
-      if: contains(matrix.os, 'windows') && contains(matrix.project_tags, 'Default')
+    - name: Set CMake generator [Conda/Windows 2022]
+      if: contains(matrix.os, 'windows-2022')
       shell: bash -l {0}
       run: |
         echo "GHA_CMAKE_GENERATOR=Visual Studio 17 2022" >> $GITHUB_ENV
 
-    - name: Set CMake generator [Conda/Windows Unstable]
-      if: contains(matrix.os, 'windows') && contains(matrix.project_tags, 'Unstable')
+    - name: Set CMake generator [Conda/Windows 2019]
+      if: contains(matrix.os, 'windows-2019')
       shell: bash -l {0}
       run: |
         echo "GHA_CMAKE_GENERATOR=Visual Studio 16 2019" >> $GITHUB_ENV

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,7 +107,7 @@ jobs:
         env
 
     - name: Set CMake generator [Conda/Linux and macOs]
-      if: !contains(matrix.os, 'windows')
+      if: ! contains(matrix.os, 'windows')
       shell: bash -l {0}
       run: |
         echo "GHA_CMAKE_GENERATOR=Ninja" >> $GITHUB_ENV

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,6 @@ jobs:
       fail-fast: false
       matrix:
         build_type: [Release]
-        # Windows is disabled due to the missing ipopt package
         os: [ubuntu-latest, macos-10.15, windows-2019]
         project_tags:
           - Default
@@ -98,8 +97,8 @@ jobs:
       if: contains(matrix.os, 'windows') 
       shell: bash -l {0}
       run: |
-        # Additional dependencies only useful on Linux
-        mamba install -c conda-forge -c robotology esdcan
+        # Additional dependencies only useful on Windows
+        mamba install -c conda-forge -c robotology esdcan freeglut
 
     - name: Print used environment [Conda]
       shell: bash -l {0}
@@ -107,34 +106,38 @@ jobs:
         mamba list
         env
 
-    - name: Configure [Conda/Linux&macOS]
-      if: contains(matrix.os, 'macos') || contains(matrix.os, 'ubuntu')
+    - name: Set CMake generator [Conda/Linux&macOs]
+      if: not(contains(matrix.os, 'windows'))
       shell: bash -l {0}
       run: |
+        echo "GHA_CMAKE_GENERATOR=Ninja" >> $GITHUB_ENV
+
+    - name: Set CMake generator [Conda/Windows Stable]
+      if: contains(matrix.os, 'windows') and contains(matrix.project_tags, 'Default')
+      shell: bash -l {0}
+      run: |
+        echo "GHA_CMAKE_GENERATOR=Visual Studio 17 2022" >> $GITHUB_ENV
+
+    - name: Set CMake generator [Conda/Windows Unstable]
+      if: contains(matrix.os, 'windows') and contains(matrix.project_tags, 'Unstable')
+      shell: bash -l {0}
+      run: |
+        echo "GHA_CMAKE_GENERATOR=Visual Studio 16 2019" >> $GITHUB_ENV
+
+    - name: Configure [Conda]
+      shell: bash -l {0}
+      run: |
+        set
         mkdir -p build
         cd build
-        cmake -GNinja -C ${GITHUB_WORKSPACE}/.ci/initial-cache.gh.cmake -DYCM_EP_ADDITIONAL_CMAKE_ARGS:STRING="-DMatlab_ROOT_DIR:PATH=${GHA_Matlab_ROOT_DIR} -DMatlab_MEX_EXTENSION:STRING=${GHA_Matlab_MEX_EXTENSION}" -DROBOTOLOGY_USES_MATLAB:BOOL=ON -DNON_INTERACTIVE_BUILD:BOOL=TRUE -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}  ${{ matrix.project_tags_cmake_options }}  ..
+        cmake -G${GHA_CMAKE_GENERATOR} -C ${GITHUB_WORKSPACE}/.ci/initial-cache.gh.cmake -DYCM_EP_ADDITIONAL_CMAKE_ARGS:STRING="-DMatlab_ROOT_DIR:PATH=${GHA_Matlab_ROOT_DIR} -DMatlab_MEX_EXTENSION:STRING=${GHA_Matlab_MEX_EXTENSION}" -DROBOTOLOGY_USES_MATLAB:BOOL=ON -DNON_INTERACTIVE_BUILD:BOOL=TRUE -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}  ${{ matrix.project_tags_cmake_options }}  ..
         # Disable options not tested on Conda for now
-        # Reference issue: https://github.com/robotology/robotology-superbuild/issues/563
         cmake -DROBOTOLOGY_USES_OCTAVE:BOOL=OFF .
 
     - name: Configure Extra [Conda/Linux]
       if: contains(matrix.os, 'ubuntu')
       shell: bash -l {0}
       run: cmake -S . -B build/ -DROBOTOLOGY_USES_IGNITION:BOOL=ON
-
-    - name: Configure [Conda/Windows]
-      if: contains(matrix.os, 'windows')
-      # ROBOTOLOGY_ENABLE_ICUB_HEAD is disabled due to https://github.com/robotology/icub-main/issues/685
-      shell: bash -l {0}
-      run: |
-        # Windows-only dependencies
-        mamba install freeglut
-        mkdir -p build
-        cd build
-        cmake -G"Visual Studio 16 2019" -C ${GITHUB_WORKSPACE}/.ci/initial-cache.gh.cmake -DYCM_EP_ADDITIONAL_CMAKE_ARGS:STRING="-DMatlab_ROOT_DIR:PATH=${GHA_Matlab_ROOT_DIR} -DMatlab_MEX_EXTENSION:STRING=${GHA_Matlab_MEX_EXTENSION}" -DROBOTOLOGY_USES_MATLAB:BOOL=ON  -DNON_INTERACTIVE_BUILD:BOOL=TRUE -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}  ${{ matrix.project_tags_cmake_options }}  ..
-        # Disable options not tested on Conda for now
-        cmake -DROBOTOLOGY_USES_OCTAVE:BOOL=OFF .
 
     # For some reason, the Strawberry perl's pkg-config is found
     # instead of the conda's one, so let's delete the /c/Strawberry directory

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,13 +113,13 @@ jobs:
         echo "GHA_CMAKE_GENERATOR=Ninja" >> $GITHUB_ENV
 
     - name: Set CMake generator [Conda/Windows Stable]
-      if: contains(matrix.os, 'windows') and contains(matrix.project_tags, 'Default')
+      if: contains(matrix.os, 'windows') && contains(matrix.project_tags, 'Default')
       shell: bash -l {0}
       run: |
         echo "GHA_CMAKE_GENERATOR=Visual Studio 17 2022" >> $GITHUB_ENV
 
     - name: Set CMake generator [Conda/Windows Unstable]
-      if: contains(matrix.os, 'windows') and contains(matrix.project_tags, 'Unstable')
+      if: contains(matrix.os, 'windows') && contains(matrix.project_tags, 'Unstable')
       shell: bash -l {0}
       run: |
         echo "GHA_CMAKE_GENERATOR=Visual Studio 16 2019" >> $GITHUB_ENV

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,7 +106,7 @@ jobs:
         mamba list
         env
 
-    - name: Set CMake generator [Conda/Linux&macOs]
+    - name: Set CMake generator [Conda/Linux and macOs]
       if: !contains(matrix.os, 'windows')
       shell: bash -l {0}
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
       fail-fast: false
       matrix:
         build_type: [Release]
-        os: [ubuntu-latest, macos-10.15, windows-2019]
+        os: [ubuntu-latest, macos-10.15, windows-2022]
         project_tags:
           - Default
           - Unstable

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,7 +107,7 @@ jobs:
         env
 
     - name: Set CMake generator [Conda/Linux and macOs]
-      if: ! contains(matrix.os, 'windows')
+      if: contains(matrix.os, 'ubuntu') || contains(matrix.os, 'macos')
       shell: bash -l {0}
       run: |
         echo "GHA_CMAKE_GENERATOR=Ninja" >> $GITHUB_ENV

--- a/doc/conda-forge.md
+++ b/doc/conda-forge.md
@@ -150,6 +150,9 @@ cmake -G"Visual Studio 16 2019" ..
 cmake --build . --config Release 
 ~~~
 
+**IMPORTANT: If you use Visual Studio 2022, the fourth command needs to be changed in `cmake -G"Visual Studio 17 2022" ..`. Visual Studio 2017 or earlier are not supported.**
+
+
 **IMPORTANT: conda-forge does not provide Debug version of its libraries, so in Windows you can't compile in Debug mode if you are using conda-forge.**
 
 ### Run software installed


### PR DESCRIPTION
To avoid duplicate the number of jobs, on Windows we compile against Visual Studio 2022 for Stable branches, and against Visual Studio 2019 for Unstable branches.