### PR TITLE
Add ubuntu:jammy to docker-based CI

### DIFF
--- a/.ci/install_debian.sh
+++ b/.ci/install_debian.sh
@@ -39,3 +39,7 @@ elif [[ ("bookworm" != "$dist_version") ]]; then
     apt-get install -y libgazebo-dev
 fi
 
+# Workaround for https://github.com/robotology/robotology-superbuild/pull/998#issuecomment-1015415833
+if [[ ("jammy" == "$dist_version") ]]; then
+    apt-get install -y libsdformat9-dev
+fi

--- a/.ci/install_debian.sh
+++ b/.ci/install_debian.sh
@@ -28,7 +28,7 @@ echo "lsb_dist: ${lsb_dist}"
 echo "dist_version: ${dist_version}"
 # bullseye is not supported by OpenRobotics' repo, but it has already 
 # the right version of Gazebo in its repo, so we just skip everything
-if [[ ("sid" != "$dist_version" && "bullseye" != "$dist_version" && "bookworm" != "$dist_version" && "trixie" != "$dist_version") ]]; then
+if [[ ("sid" != "$dist_version" && "bullseye" != "$dist_version" && "bookworm" != "$dist_version" && "trixie" != "$dist_version" && "jammy" != "$dist_version") ]]; then
     mkdir -p /etc/apt/sources.list.d
     echo deb http://packages.osrfoundation.org/gazebo/$lsb_dist\-stable $dist_version main > /etc/apt/sources.list.d/gazebo-stable.list
     apt-key adv --keyserver keyserver.ubuntu.com --recv-keys D2486D2DD83DB69272AFE98867170598AF249743

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -165,6 +165,7 @@ jobs:
         docker_image:
           - "ubuntu:bionic"
           - "ubuntu:focal"
+          - "ubuntu:jammy"
           - "debian:buster-backports"
           - "debian:testing"
 


### PR DESCRIPTION
Let's add Ubuntu Jammy (22.04) to the CI to ensure that there are no problems once it is released, as it is the next Ubuntu LTS to which most users will eventually upgrade. For now a small workaround is necessary, that probably will stop being necessary once `libgazebo-dev` is updated to depend on `libsdformat9-dev`.