### PR TITLE
Document installation of libi2c in Linux with apt and conda

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,7 +88,7 @@ jobs:
       run: |
         # Additional dependencies only useful on Linux
         # See https://github.com/robotology/robotology-superbuild/issues/477
-        mamba install bash-completion expat-cos7-x86_64 freeglut libdc1394 libselinux-cos7-x86_64 libxau-cos7-x86_64 libxcb-cos7-x86_64 libxdamage-cos7-x86_64 libxext-cos7-x86_64 libxfixes-cos7-x86_64 libxxf86vm-cos7-x86_64 mesa-libgl-cos7-x86_64 mesa-libgl-devel-cos7-x86_64 libxshmfence-cos7-x86_64 libxshmfence-devel-cos7-x86_64 
+        mamba install bash-completion expat-cos7-x86_64 freeglut libdc1394 libi2c libselinux-cos7-x86_64 libxau-cos7-x86_64 libxcb-cos7-x86_64 libxdamage-cos7-x86_64 libxext-cos7-x86_64 libxfixes-cos7-x86_64 libxxf86vm-cos7-x86_64 mesa-libgl-cos7-x86_64 mesa-libgl-devel-cos7-x86_64 libxshmfence-cos7-x86_64 libxshmfence-devel-cos7-x86_64 
         # Ignition Gazebo
         mamba install libignition-gazebo4
 

--- a/apt.txt
+++ b/apt.txt
@@ -13,6 +13,7 @@ libboost-thread-dev
 libedit-dev
 libeigen3-dev
 libgsl0-dev
+libi2c-dev
 libjpeg-dev
 liblua5.2-dev
 lua5.2

--- a/cmake/BuildYARP.cmake
+++ b/cmake/BuildYARP.cmake
@@ -116,3 +116,7 @@ endif()
 if(NOT WIN32)
   list(APPEND YARP_CONDA_DEPENDENCIES bash-completion)
 endif()
+
+if(${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
+  list(APPEND YARP_CONDA_DEPENDENCIES libi2c)
+endif()

--- a/cmake/BuildYARP.cmake
+++ b/cmake/BuildYARP.cmake
@@ -37,6 +37,13 @@ else()
   set(ENABLE_yarpcar_mjpeg ON)
 endif()
 
+# I2C is only enabled on Linux
+if(${CMAKE_SYSTEM_NAME} STREQUAL "Linux" AND ${ROBOTOLOGY_ENABLE_ICUB_HEAD})
+  set(YARP_USE_I2C ON)
+else()
+  set(YARP_USE_I2C OFF)
+endif()
+
 # For what regards Python installation, the options changes depending
 # on whether we are installing YARP from source, or generating a
 # conda package on Windows as in that case the installation location
@@ -98,7 +105,7 @@ ycm_ep_helper(YARP TYPE GIT
                               -DYARP_COMPILE_EXPERIMENTAL_WRAPPERS:BOOL=ON
                               -DYARP_COMPILE_RobotTestingFramework_ADDONS:BOOL=${ROBOTOLOGY_ENABLE_ROBOT_TESTING}
                               -DYARP_COMPILE_BINDINGS:BOOL=${YARP_COMPILE_BINDINGS}
-                              -DYARP_USE_I2C:BOOL=${ROBOTOLOGY_ENABLE_ICUB_HEAD}
+                              -DYARP_USE_I2C:BOOL=${YARP_USE_I2C}
                               -DYARP_USE_SDL:BOOL=ON
                               -DCREATE_PYTHON:BOOL=${ROBOTOLOGY_USES_PYTHON}
                               -DCREATE_LUA:BOOL=${ROBOTOLOGY_USES_LUA}
@@ -117,6 +124,6 @@ if(NOT WIN32)
   list(APPEND YARP_CONDA_DEPENDENCIES bash-completion)
 endif()
 
-if(${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
+if(YARP_USE_I2C)
   list(APPEND YARP_CONDA_DEPENDENCIES libi2c)
 endif()

--- a/doc/conda-forge.md
+++ b/doc/conda-forge.md
@@ -117,7 +117,7 @@ mamba install -c conda-forge ace asio assimp boost eigen gazebo glew glfw graphv
 
 If you are on **Linux**, you also need to install also the following packages:
 ~~~
-mamba install -c conda-forge bash-completion expat-cos7-x86_64 freeglut libdc1394 libselinux-cos7-x86_64 libxau-cos7-x86_64 libxcb-cos7-x86_64 libxdamage-cos7-x86_64 libxext-cos7-x86_64 libxfixes-cos7-x86_64 libxxf86vm-cos7-x86_64 mesa-libgl-cos7-x86_64 mesa-libgl-devel-cos7-x86_64 libxshmfence-cos7-x86_64 libxshmfence-devel-cos7-x86_64 
+mamba install -c conda-forge bash-completion freeglut libdc1394 libi2c expat-cos7-x86_64 libselinux-cos7-x86_64 libxau-cos7-x86_64 libxcb-cos7-x86_64 libxdamage-cos7-x86_64 libxext-cos7-x86_64 libxfixes-cos7-x86_64 libxxf86vm-cos7-x86_64 mesa-libgl-cos7-x86_64 mesa-libgl-devel-cos7-x86_64 libxshmfence-cos7-x86_64 libxshmfence-devel-cos7-x86_64 
 ~~~
 
 If you are on **Windows**, you also need to install also the following packages:


### PR DESCRIPTION
Since a long time, we enabled the `YARP_USES_I2C` option on YARP. The option is automatically disabled if I2C is not found (and this is convenient for us on macOS and Windows), but the problem is that we never installed the required dependency. This PR fixes the problem by installing `libi2c-dev` from apt and `libi2c` from conda-forge.

Fix https://github.com/robotology/robotology-superbuild/issues/999 .
Fix https://github.com/robotology/robotology-superbuild/issues/1002 .