### PR TITLE
Bump qhull and CppAD to latest versions

### DIFF
--- a/cmake/ProjectsTagsStable.cmake
+++ b/cmake/ProjectsTagsStable.cmake
@@ -8,8 +8,8 @@ endmacro()
 set_tag(osqp_TAG v0.6.2)
 set_tag(manif_REPOSITORY robotology-dependencies/manif.git)
 set_tag(manif_TAG 0.0.4.1)
-set_tag(qhull_TAG v8.0.2)
-set_tag(CppAD_TAG 20210000.8)
+set_tag(qhull_TAG 2020.2)
+set_tag(CppAD_TAG 20220000.1)
 set_tag(casadi 3.5.5.3)
 
 # Robotology projects

--- a/cmake/ProjectsTagsUnstable.cmake
+++ b/cmake/ProjectsTagsUnstable.cmake
@@ -8,8 +8,8 @@ endmacro()
 set_tag(osqp_TAG v0.6.2)
 set_tag(manif_REPOSITORY robotology-dependencies/manif.git)
 set_tag(manif_TAG 0.0.4.1)
-set_tag(qhull_TAG v8.0.2)
-set_tag(CppAD_TAG 20210000.8)
+set_tag(qhull_TAG 2020.2)
+set_tag(CppAD_TAG 20220000.1)
 set_tag(casadi 3.5.5.3)
 
 # Robotology projects

--- a/releases/latest.releases.yaml
+++ b/releases/latest.releases.yaml
@@ -14,11 +14,11 @@ repositories:
   qhull:
     type: git
     url: https://github.com/qhull/qhull.git
-    version: v8.0.2
+    version: 2020.2
   CppAD:
     type: git
     url: https://github.com/coin-or/CppAD.git
-    version: 20210000.8
+    version: 20220000.1
   casadi:
     type: git
     url: https://github.com/ami-iit/casadi.git


### PR DESCRIPTION
This is part of the work on branch https://github.com/traversaro/robotology-superbuild/tree/fix727 that was done to solve https://github.com/robotology/robotology-superbuild/issues/727 . However, this part can be contributed on its own PR.

This PR bumps the qhull and CppAD version to track the latest version. In particular, this ensures that the versions used in the superbuild are compatible with the latest versions used in conda-forge:
* https://github.com/conda-forge/qhull-feedstock
* https://github.com/conda-forge/cppad-feedstock

Note that qhull has a bit of a complex versioning scheme, as it has releases like `8.0.2`  and `2020.2` . We switch to the `2020.2`-style tags for compatibility with most linux distros (see https://repology.org/project/qhull/versions) and with conda-forge.

As this are external packages, they are fixed to releases in `LatestReleases` and also for Stable and Unstable branches.