### PR TITLE
Conda: Specify explicitly requirement of qt=5.12.9=*_4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,7 +77,7 @@ jobs:
         # Compilation related dependencies 
         mamba install cmake compilers make ninja pkg-config
         # Actual dependencies
-        mamba install ace asio assimp boost eigen gazebo glew glfw graphviz gsl ipopt irrlicht libjpeg-turbo libmatio libode libxml2 nlohmann_json opencv pkg-config portaudio qt sdl sdl2 sqlite tinyxml spdlog lua
+        mamba install ace asio assimp boost eigen gazebo glew glfw graphviz gsl ipopt irrlicht libjpeg-turbo libmatio libode libxml2 nlohmann_json opencv pkg-config portaudio qt=5.12.9=*_4 sdl sdl2 sqlite tinyxml spdlog lua
         # Python 
         mamba install numpy swig pybind11
 

--- a/conda/conda_build_config.yml
+++ b/conda/conda_build_config.yml
@@ -10,5 +10,5 @@ pin_run_as_build:
     max_pin: x.x
 
 # Workaround for https://github.com/conda-forge/gazebo-feedstock/issues/119
-icu:
-  - '68'
+qt:
+  - "5.12.9=*_4"

--- a/doc/conda-forge.md
+++ b/doc/conda-forge.md
@@ -112,7 +112,7 @@ of the robotology-superbuild.**
 Once you activated it, you can install packages in it. In particular the dependencies for the robotology-superbuild can be installed as:
 ~~~
 mamba install -c conda-forge cmake compilers make ninja pkg-config
-mamba install -c conda-forge ace asio assimp boost eigen gazebo glew glfw graphviz gsl ipopt irrlicht libjpeg-turbo libmatio libode libxml2 nlohmann_json opencv pkg-config portaudio qt sdl sdl2 sqlite tinyxml spdlog lua icu=68
+mamba install -c conda-forge ace asio assimp boost eigen gazebo glew glfw graphviz gsl ipopt irrlicht libjpeg-turbo libmatio libode libxml2 nlohmann_json opencv pkg-config portaudio qt=5.12.9=*_4 sdl sdl2 sqlite tinyxml spdlog lua
 ~~~
 
 If you are on **Linux**, you also need to install also the following packages:


### PR DESCRIPTION
It is a workaround for https://github.com/conda-forge/gazebo-feedstock/issues/119 like https://github.com/robotology/robotology-superbuild/pull/1022, but I like it more because it is more explicit. Furthermore, I also adding it in the CI that I forgot in https://github.com/robotology/robotology-superbuild/pull/1022 .