### PR TITLE
Pin miniforge version to avoid mamba regression

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
     - uses: conda-incubator/setup-miniconda@v2
       with:
         miniforge-variant: Mambaforge
-        miniforge-version: latest
+        miniforge-version: 4.11.0-0 
 
     - name: Install files to enable compilation of mex files [Conda/Linux]
       if: contains(matrix.os, 'ubuntu') 


### PR DESCRIPTION
The issue described in https://github.com/robotology/robotology-superbuild/issues/1020 is taking some time to be fixed upstream, so for the time being let's just use a old `Mambaforge` that is known to work.