### PR TITLE
Document that ROBOTOLOGY_USES_GAZEBO is not supported on macOS with Homebrew dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -367,8 +367,6 @@ jobs:
         brew install libmatio irrlicht spdlog
         # ROBOTOLOGY_ENABLE_DYNAMICS_FULL_DEPS (qhull and cppad are installed  with brew)
         brew install cppad qhull
-        # ROBOTOLOGY_USES_GAZEBO dependencies
-        brew install osrf/simulation/gazebo11
         # CI-specific dependencies
         brew install ninja
         cmake --version
@@ -405,16 +403,7 @@ jobs:
         cd ${ROBOTOLOGY_SUPERBUILD_SOURCE_DIR}
         cd build
         # Disable ROBOTOLOGY_USES_PYTHON in macOS
-        cmake -DROBOTOLOGY_USES_OCTAVE:BOOL=OFF -DROBOTOLOGY_USES_PYTHON:BOOL=OFF .
-       
-    # Workaround for https://github.com/robotology/robotology-superbuild/issues/753
-    # taken from https://github.com/osrf/homebrew-simulation/issues/1486#issuecomment-850218440
-    - name: Add Gazebo-specific Homebrew workaround
-      if: contains(matrix.os, 'macos')
-      run: |
-           echo "CMAKE_PREFIX_PATH=${CMAKE_PREFIX_PATH}:/usr/local/opt/tbb@2020_u3" >> $GITHUB_ENV
-           echo "CPATH=${CPATH}:/usr/local/opt/tbb@2020_u3/include" >> $GITHUB_ENV
-           echo "LIBRARY_PATH=${CMAKE_PREFIX_PATH}:${LIBRARY_PATH}:/usr/local/opt/tbb@2020_u3/lib" >> $GITHUB_ENV
+        cmake -DROBOTOLOGY_USES_OCTAVE:BOOL=OFF -DROBOTOLOGY_USES_PYTHON:BOOL=OFF -DROBOTOLOGY_USES_GAZEBO:BOOL=OFF .
 
     - name: Disable options unsupported on Ubuntu 18.04
       if: contains(matrix.os, '18.04')
@@ -429,7 +418,6 @@ jobs:
         cd ${ROBOTOLOGY_SUPERBUILD_SOURCE_DIR}
         cd build
         cmake -DROBOTOLOGY_ENABLE_DYNAMICS_FULL_DEPS:BOOL=OFF -DROBOTOLOGY_ENABLE_ROBOT_TESTING:BOOL=OFF -DROBOTOLOGY_USES_PYTHON:BOOL=OFF .
-
 
     - name: Configure [Windows]
       if: contains(matrix.os, 'windows')

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format of this document is based on [Keep a Changelog](https://keepachangelo
 - On Windows the option `ROBOTOLOGY_USES_ESDCAN` is now enabled when generating conda packages (https://github.com/robotology/robotology-superbuild/pull/935).
 - For the YARP package, the compilation of the `usbCamera` device on Linux is enabled even if `ROBOTOLOGY_ENABLE_ICUB_HEAD` is `OFF` (https://github.com/robotology/robotology-superbuild/pull/989).
 - `walking-controllers` now depends on `bipedal-locomotion-framework`, so it is now compiled if `ROBOTOLOGY_ENABLE_DYNAMICS_FULL_DEPS` option is enabled (https://github.com/robotology/robotology-superbuild/pull/1013).
+- The `ROBOTOLOGY_USES_GAZEBO` is now unsupported on macOS with Homebrew dependencies (https://github.com/robotology/robotology-superbuild/pull/1028).
 
 ## [2021.11.1] - 2022-01-05
 

--- a/doc/cmake-options.md
+++ b/doc/cmake-options.md
@@ -87,7 +87,7 @@ Not all options are supported on all platforms. The following table provides a r
 | `ROBOTOLOGY_ENABLE_TELEOPERATION`  | ✔️   |        ✔️                     |             ❌                |                 ✔️              |              ✔️                |                 ❌              |
 | `ROBOTOLOGY_ENABLE_HUMAN_DYNAMICS`  | ✔️   |        ✔️                     |             ✔️                |                 ✔️              |              ✔️                |                 ✔️              |
 | `ROBOTOLOGY_ENABLE_EVENT_DRIVEN`  | ✔️   |        ✔️                     |             ❌                |                 ✔️              |              ✔️                |                 ❌              |
-| `ROBOTOLOGY_USES_GAZEBO` |  ✔️           |        ✔️                     |             ✔️                |                 ✔️              |              ✔️                |                 ✔️              |
+| `ROBOTOLOGY_USES_GAZEBO` |  ✔️           |        ❌                     |             ✔️                |                 ✔️              |              ✔️                |                 ✔️              |
 | `ROBOTOLOGY_USES_IGNITION` |  ❌           |        ❌                     |             ❌                |                 ✔️              |              ❌                |                 ❌              |
 | `ROBOTOLOGY_USES_MATLAB` |  ✔️           |        ✔️                     |             ❌                |                 ✔️              |              ✔️                |                 ✔️              |
 | `ROBOTOLOGY_USES_OCTAVE` |  ✔️           |        ✔️                     |              ❌                |                  ❌              |               ❌                |                  ❌              |
@@ -230,23 +230,15 @@ Support for this dependency is enabled by the `ROBOTOLOGY_USES_GAZEBO` CMake opt
 This option is still set to `OFF` on Windows as it is still experimental.
 
 ### System Dependencies
-On Linux or macOS, install Gazebo following the instructions available at http://gazebosim.org/tutorials?cat=install .
+On Linux with apt dependencies install Gazebo following the instructions available at http://gazebosim.org/tutorials?cat=install .
 Make sure to install also the development files, i.e. `libgazebo*-dev` on Debian/Ubuntu.
 
-On Windows, make sure that you install the Windows dependencies using the `vcpkg-robotology-with-gazebo.zip` archive and you set
+If you install your dependencies with `conda`, just make sure to install the `gazebo` package.
+
+On Windows with vcpkg dependencies, make sure that you install the Windows dependencies using the `vcpkg-robotology-with-gazebo.zip` archive and you set
 the correct enviroment variables as documented in [`robotology-superbuild-dependencies-vcpkg` documentation](https://github.com/robotology/robotology-superbuild-dependencies-vcpkg).
 
-#### macOS with Homebrew workaround
-
-On macOS with Homebrew dependencies, due to an incompatibility of Gazebo with the latest version of tbb (https://github.com/osrf/gazebo/issues/2867), to correctly compiled `robotology-superbuild` with the `ROBOTOLOGY_USES_GAZEBO` option enabled,
-it is necessary to define the following environment variables:
-~~~
-export CMAKE_PREFIX_PATH=${CMAKE_PREFIX_PATH}:/usr/local/opt/tbb@2020_u3
-export CPATH=${CPATH}:/usr/local/opt/tbb@2020_u3/include
-export LIBRARY_PATH=${LIBRARY_PATH}:/usr/local/opt/tbb@2020_u3/lib
-~~~
-See https://github.com/osrf/homebrew-simulation/issues/1486 for more info.
-
+This option is not supported when using Homebrew to install your dependencies.
 
 ### Check the installation
 Follow the steps in https://github.com/robotology/icub-gazebo#usage and/or https://github.com/robotology/icub-models#use-the-models-with-gazebo to check if the Gazebo-based iCub simulation works fine.

--- a/doc/deprecated-installation-methods.md
+++ b/doc/deprecated-installation-methods.md
@@ -83,7 +83,7 @@ Since Qt5 is not symlinked in `/usr/local` by default in the homebrew formula, `
 export Qt5_DIR=/usr/local/opt/qt5/lib/cmake/Qt5
 ```
 
-If you want to enable a [profile](cmake-options.md#profile-cmake-options) or a [dependency](cmake-options.md#dependencies-cmake-options) specific CMake option, you may need to install additional system dependencies following the dependency-specific documentation (in particular, the `ROBOTOLOGY_USES_GAZEBO` option is enabled by default, so you should install Gazebo unless you plan to disable this option):
+If you want to enable a [profile](cmake-options.md#profile-cmake-options) or a [dependency](cmake-options.md#dependencies-cmake-options) specific CMake option, you may need to install additional system dependencies following the dependency-specific documentation (in particular, the `ROBOTOLOGY_USES_GAZEBO` option is enabled by default, so you should disable it as it is not supported on macOS with Homebrew dependencies):
 * [`ROBOTOLOGY_USES_GAZEBO`](cmake-options.md#gazebo)
 
 ### Superbuild


### PR DESCRIPTION
See https://github.com/robotology/robotology-superbuild/issues/1017#issuecomment-1038960278 for a rationale on this choice.
Fix https://github.com/robotology/robotology-superbuild/issues/1017 .