### PR TITLE
Add generation of conda metapackages robotology-distro and robotology-distro-all for each new distro release

### DIFF
--- a/.github/workflows/generate-conda-packages.yaml
+++ b/.github/workflows/generate-conda-packages.yaml
@@ -114,9 +114,6 @@ jobs:
           if: contains(matrix.os, 'macos') || contains(matrix.os, 'ubuntu')
           shell: bash -l {0}
           run: |
-            echo "==============="
-            echo ${{needs.get-conda-build-number.outputs.conda_build_number}}
-            echo "==============="
             mkdir build
             cd build
             cmake -GNinja -C ${GITHUB_WORKSPACE}/.ci/initial-cache.gh.cmake -DYCM_EP_ADDITIONAL_CMAKE_ARGS:STRING="-DMatlab_ROOT_DIR:PATH=${GHA_Matlab_ROOT_DIR} -DMatlab_MEX_EXTENSION:STRING=${GHA_Matlab_MEX_EXTENSION}" -DROBOTOLOGY_USES_MATLAB:BOOL=ON -DROBOTOLOGY_PROJECT_TAGS=LatestRelease -DROBOTOLOGY_GENERATE_CONDA_RECIPES:BOOL=ON -DCONDA_BUILD_NUMBER=${{needs.get-conda-build-number.outputs.conda_build_number}} ..
@@ -125,9 +122,6 @@ jobs:
           if: contains(matrix.os, 'windows')
           shell: bash -l {0}
           run: |
-            echo "==============="
-            echo ${{needs.get-conda-build-number.outputs.conda_build_number}}
-            echo "==============="
             mkdir build
             cd build
             cmake -G"Visual Studio 16 2019" -C ${GITHUB_WORKSPACE}/.ci/initial-cache.gh.cmake  -DYCM_EP_ADDITIONAL_CMAKE_ARGS:STRING="-DMatlab_ROOT_DIR:PATH=${GHA_Matlab_ROOT_DIR} -DMatlab_MEX_EXTENSION:STRING=${GHA_Matlab_MEX_EXTENSION}" -DROBOTOLOGY_USES_MATLAB:BOOL=ON -DROBOTOLOGY_PROJECT_TAGS=LatestRelease -DROBOTOLOGY_GENERATE_CONDA_RECIPES:BOOL=ON -DCONDA_BUILD_NUMBER=${{needs.get-conda-build-number.outputs.conda_build_number}}  ..

--- a/.github/workflows/generate-conda-packages.yaml
+++ b/.github/workflows/generate-conda-packages.yaml
@@ -12,11 +12,39 @@ on:
   schedule:
   # Run the job once a week
   - cron: '0 0 * * 2'
+  release:
+    types: [published]
 
 jobs:
+    # Regardless of the branch on which this action is trigged, 
+    # the CONDA_BUILD_NUMBER CMake option needs to be read from the 
+    # master branch, to avoid that a conda package generation from the 
+    # master branch and one from a releases/YYYY.MM branch use the same
+    # CONDA_BUILD_NUMBER
+    get-conda-build-number:
+        name: "Read Conda Build number from master branch"
+        runs-on: ubuntu-latest
+        # Define outputs (see https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#example-defining-outputs-for-a-job)
+        outputs:
+          conda_build_number: ${{ steps.step1.outputs.conda_build_number }}
+
+        steps:
+        - uses: actions/checkout@v2
+          with:
+            ref: 'master'
+        
+        - id: step1
+          name: Get CONDA_BUILD_NUMBER and set it as output
+          shell: bash
+          run: |
+            # Get CONDA_BUILD_NUMBER via grep and set it to an environment variable 
+            export CONDA_BUILD_NUMBER=`grep "CONDA_BUILD_NUMBER" ./conda/cmake/CondaGenerationOptions.cmake | grep -oe '\([0-9.]*\)'` 
+            echo "::set-output name=conda_build_number::${CONDA_BUILD_NUMBER}"
+
     generate-conda-packages:
         name: "Generate conda packages @${{ matrix.os }}"
         runs-on:  ${{ matrix.os }}
+        needs: get-conda-build-number
         strategy:
             fail-fast: false
             matrix:
@@ -86,17 +114,30 @@ jobs:
           if: contains(matrix.os, 'macos') || contains(matrix.os, 'ubuntu')
           shell: bash -l {0}
           run: |
+            echo "==============="
+            echo ${{needs.get-conda-build-number.outputs.conda_build_number}}
+            echo "==============="
             mkdir build
             cd build
-            cmake -GNinja -C ${GITHUB_WORKSPACE}/.ci/initial-cache.gh.cmake -DYCM_EP_ADDITIONAL_CMAKE_ARGS:STRING="-DMatlab_ROOT_DIR:PATH=${GHA_Matlab_ROOT_DIR} -DMatlab_MEX_EXTENSION:STRING=${GHA_Matlab_MEX_EXTENSION}" -DROBOTOLOGY_USES_MATLAB:BOOL=ON -DROBOTOLOGY_PROJECT_TAGS=LatestRelease -DROBOTOLOGY_GENERATE_CONDA_RECIPES:BOOL=ON ..
+            cmake -GNinja -C ${GITHUB_WORKSPACE}/.ci/initial-cache.gh.cmake -DYCM_EP_ADDITIONAL_CMAKE_ARGS:STRING="-DMatlab_ROOT_DIR:PATH=${GHA_Matlab_ROOT_DIR} -DMatlab_MEX_EXTENSION:STRING=${GHA_Matlab_MEX_EXTENSION}" -DROBOTOLOGY_USES_MATLAB:BOOL=ON -DROBOTOLOGY_PROJECT_TAGS=LatestRelease -DROBOTOLOGY_GENERATE_CONDA_RECIPES:BOOL=ON -DCONDA_BUILD_NUMBER=${{needs.get-conda-build-number.outputs.conda_build_number}} ..
 
         - name: Generate recipes [Windows]
           if: contains(matrix.os, 'windows')
           shell: bash -l {0}
           run: |
+            echo "==============="
+            echo ${{needs.get-conda-build-number.outputs.conda_build_number}}
+            echo "==============="
             mkdir build
             cd build
-            cmake -G"Visual Studio 16 2019" -C ${GITHUB_WORKSPACE}/.ci/initial-cache.gh.cmake -DYCM_EP_ADDITIONAL_CMAKE_ARGS:STRING="-DMatlab_ROOT_DIR:PATH=${GHA_Matlab_ROOT_DIR} -DMatlab_MEX_EXTENSION:STRING=${GHA_Matlab_MEX_EXTENSION}" -DROBOTOLOGY_USES_MATLAB:BOOL=ON -DROBOTOLOGY_PROJECT_TAGS=LatestRelease -DROBOTOLOGY_GENERATE_CONDA_RECIPES:BOOL=ON ..
+            cmake -G"Visual Studio 16 2019" -C ${GITHUB_WORKSPACE}/.ci/initial-cache.gh.cmake  -DYCM_EP_ADDITIONAL_CMAKE_ARGS:STRING="-DMatlab_ROOT_DIR:PATH=${GHA_Matlab_ROOT_DIR} -DMatlab_MEX_EXTENSION:STRING=${GHA_Matlab_MEX_EXTENSION}" -DROBOTOLOGY_USES_MATLAB:BOOL=ON -DROBOTOLOGY_PROJECT_TAGS=LatestRelease -DROBOTOLOGY_GENERATE_CONDA_RECIPES:BOOL=ON -DCONDA_BUILD_NUMBER=${{needs.get-conda-build-number.outputs.conda_build_number}}  ..
+
+        - name: Specify additional option if we are in a release and we need to generate robotology-distro metapackages
+          if: github.event_name == 'release'
+          shell: bash -l {0}
+          run: |
+            cd build
+            cmake -DCONDA_GENERATE_ROBOTOLOGY_METAPACKAGES:BOOL=ON .
 
         - name: Build conda packages
           shell: bash -l {0}
@@ -155,12 +196,22 @@ jobs:
             rm -rf blocktest
             conda mambabuild -m ${CONDA_PREFIX}/conda_build_config.yaml -m ${GITHUB_WORKSPACE}/conda/conda_build_config.yml human-dynamics-estimation
             rm -rf human-dynamics-estimation
-            conda mambabuild -m ${CONDA_PREFIX}/conda_build_config.yaml -m ${GITHUB_WORKSPACE}/conda/conda_build_config.yml . 
+            conda build -m ${CONDA_PREFIX}/conda_build_config.yaml -m ${GITHUB_WORKSPACE}/conda/conda_build_config.yml . 
+
+        - name: Build conda metapackages (if necessary
+          if: github.event_name == 'release'
+          shell: bash -l {0}
+          run: |
+            cd build/conda/generated_recipes_metapackages
+             # Debug generated recipes
+            cat */meta.yaml
+            conda mambabuild -m ${CONDA_PREFIX}/conda_build_config.yaml -m ${GITHUB_WORKSPACE}/conda/conda_build_config.yml -c local -c conda-forge -c robotology robotology-distro
+            conda mambabuild -m ${CONDA_PREFIX}/conda_build_config.yaml -m ${GITHUB_WORKSPACE}/conda/conda_build_config.yml -c local -c conda-forge -c robotology robotology-distro-all
 
         - name: Upload conda packages
           shell: bash -l {0}
           # Upload by default on schedule events, and on workflow dispatch only if input upload_conda_binaries is 'true'
-          if: github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && github.event.inputs.upload_conda_binaries == 'true')
+          if: github.event_name == 'schedule' || github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && github.event.inputs.upload_conda_binaries == 'true')
           env:
             ANACONDA_API_TOKEN: ${{ secrets.ANACONDA_API_TOKEN }}
           run: |
@@ -170,22 +221,26 @@ jobs:
 
     # If the  generate-conda-packages completed correctly and binaries are uploaded,
     # bump automatically the CONDA_BUILD_NUMBER in conda/cmake/CondaGenerationOptions.cmake
-    # for future builds
+    # of master branch for future builds
+    # the master branch is always used in case the action is triggered by a release on 
+    # a release/vYYYY.MM branch
     bump-conda-build-number:
         name: "Bump Conda Build number for future builds"
         runs-on: ubuntu-latest
         needs: generate-conda-packages
-        if: github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && github.event.inputs.upload_conda_binaries == 'true')
+        if: github.event_name == 'schedule' || github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && github.event.inputs.upload_conda_binaries == 'true')
 
         steps:
         - uses: actions/checkout@v2
+          with:
+            ref: 'master'
         
         - name: Bump Conda Build number for future builds
           shell: bash
           run: |
             sh ./scripts/robotologyBumpCondaBuildNumber.sh 
       
-        - uses: EndBug/add-and-commit@v7.0.0
+        - uses: EndBug/add-and-commit@v8.0.1
           with:
             default_author: github_actions
             message: 'Bump CONDA_BUILD_NUMBER after successful Conda packages build and upload'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,6 +40,9 @@ jobs:
         sed -i -e 's/set(INSTALLER_VERSION "")/set(INSTALLER_VERSION ${{ github.event.inputs.superbuild_year_month_prefix }}.0)/g' ./packaging/windows/CMakeLists.txt
         git add .
         git commit -m "Updating packaging/windows/CMakeLists.txt"
+        sed -i -e 's/set(CONDA_ROBOTOLOGY_SUPERBUILD_VERSION "")/set(CONDA_ROBOTOLOGY_SUPERBUILD_VERSION ${{ github.event.inputs.superbuild_year_month_prefix }}.0)/g' ./conda/cmake/CondaGenerationOptions.cmake
+        git add .
+        git commit -m "Updating conda/cmake/CondaGenerationOptions.cmake"
         git push --set-upstream origin releases/${{ github.event.inputs.superbuild_year_month_prefix }}
 
     - name: Create and push the ${{ github.event.inputs.superbuild_year_month_prefix }}.0 tag

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format of this document is based on [Keep a Changelog](https://keepachangelo
 
 ### Added
 - Added dependency on `graphviz` to compile `yarpviz` YARP tool (https://github.com/robotology/robotology-superbuild/pull/988).
+- Added generation of `robotology-distro` and `robotology-distro-all` conda metapackages on releases (https://github.com/robotology/robotology-superbuild/pull/1030). 
  
 ### Changed
 - On Windows the option `ROBOTOLOGY_USES_ESDCAN` is now enabled when generating conda packages (https://github.com/robotology/robotology-superbuild/pull/935).

--- a/cmake/Buildcasadi.cmake
+++ b/cmake/Buildcasadi.cmake
@@ -35,3 +35,9 @@ ycm_ep_helper(casadi TYPE GIT
 
 set(casadi_CONDA_PKG_NAME casadi)
 set(casadi_CONDA_PKG_CONDA_FORGE_OVERRIDE ON)
+# This is a small hack. To avoid incompatibilities between the version tagged in the ami-iit fork
+# (something like 3.5.5.x) and the version available in conda-forge when generating conda metapackages
+# such as robotology-distro and robotology-distro-all, we override the conda package version of casadi
+# here. This needs to be removed as soon as we stop use our fork in the superbuild 
+set(casadi_CONDA_VERSION 3.5.5)
+

--- a/cmake/Buildmanif.cmake
+++ b/cmake/Buildmanif.cmake
@@ -21,3 +21,8 @@ ycm_ep_helper(manif TYPE GIT
 
 set(manif_CONDA_PKG_NAME manif)
 set(manif_CONDA_PKG_CONDA_FORGE_OVERRIDE ON)
+# This is a small hack. To avoid incompatibilities between the version tagged in the ami-iit fork
+# (something like 0.0.4.x) and the version available in conda-forge when generating conda metapackages
+# such as robotology-distro and robotology-distro-all, we override the conda package version of manif
+# here. This needs to be removed as soon as we stop using our fork in the superbuild 
+set(manif_CONDA_VERSION 0.0.4)

--- a/conda/cmake/CondaGenerationOptions.cmake
+++ b/conda/cmake/CondaGenerationOptions.cmake
@@ -1,7 +1,18 @@
 # This number needs to be increased at each full rebuild,
 # to ensure that binaries belonging to different rebuilds
 # can be distinguished even if the version number is the same
-set(CONDA_BUILD_NUMBER 42)
+if(NOT CONDA_BUILD_NUMBER)
+  set(CONDA_BUILD_NUMBER 46)
+endif()
+
+# This option is enabled only when the metapackages robotology-distro and robotology-distro-all are
+# generated, so only in case a robotology-superbuild distro is released
+option(CONDA_GENERATE_ROBOTOLOGY_METAPACKAGES "If on, generate recipes for robotology-distro and robotology-distro-all conda metapackages." OFF)
+
+# This variable is automatically set to contain the robotology-superbuild version in case of releases
+if(NOT CONDA_ROBOTOLOGY_SUPERBUILD_VERSION)
+  set(CONDA_ROBOTOLOGY_SUPERBUILD_VERSION "")
+endif()
 
 # For more conda generation options, check the specific project Build<CMakeProject>.cmake
 # file for variables that start with `<CMakeProject>_CONDA`

--- a/conda/cmake/CondaGenerationOptions.cmake
+++ b/conda/cmake/CondaGenerationOptions.cmake
@@ -2,7 +2,7 @@
 # to ensure that binaries belonging to different rebuilds
 # can be distinguished even if the version number is the same
 if(NOT CONDA_BUILD_NUMBER)
-  set(CONDA_BUILD_NUMBER 46)
+  set(CONDA_BUILD_NUMBER 42)
 endif()
 
 # This option is enabled only when the metapackages robotology-distro and robotology-distro-all are

--- a/conda/metapackages_recipes_template/robotology-distro-all.yaml
+++ b/conda/metapackages_recipes_template/robotology-distro-all.yaml
@@ -1,0 +1,16 @@
+package:
+  name: robotology-distro-all
+  version: {{ robotology_superbuild_version }}
+
+build:
+  number: {{ conda_build_number }}
+
+requirements:
+  # We use run as installing robotology-distro-all should install all robotology packages
+  run: {# List all packages and the version dependency. #}
+{% for pkg in robotology_all_packages %}    - {{ pkg.name }}={{ pkg.version.replace("v","") }}
+{% endfor %}
+
+about:
+  home: https://github.com/robotology/robotology-superbuild
+

--- a/conda/metapackages_recipes_template/robotology-distro.yaml
+++ b/conda/metapackages_recipes_template/robotology-distro.yaml
@@ -1,0 +1,18 @@
+package:
+  name: robotology-distro
+  version: {{ robotology_superbuild_version }}
+
+build:
+  number: {{ conda_build_number }}
+
+requirements:
+  # We used run_constrained to ensure that a specific version of 
+  # the specified package is used if the package is installed, but
+  # we do not depend explicitly on the packages
+  run_constrained: {# List all packages and the version dependency. #}
+{% for pkg in robotology_all_packages %}    - {{ pkg.name }}={{ pkg.version.replace("v","") }}
+{% endfor %}
+
+about:
+  home: https://github.com/robotology/robotology-superbuild
+

--- a/scripts/robotologyBumpCondaBuildNumber.sh
+++ b/scripts/robotologyBumpCondaBuildNumber.sh
@@ -11,4 +11,4 @@
 
 # Inspired from https://superuser.com/questions/198143/increment-one-value-in-a-text-line-using-script
 cp ./conda/cmake/CondaGenerationOptions.cmake /tmp/CondaGenerationOptions.cmake
-awk '{if ($1 == "set(CONDA_BUILD_NUMBER") printf("%s %d)\n", $1, $2 + 1); else print $0;}' /tmp/CondaGenerationOptions.cmake > ./conda/cmake/CondaGenerationOptions.cmake
+awk '{if ($1 == "set(CONDA_BUILD_NUMBER") printf("  %s %d)\n", $1, $2 + 1); else print $0;}' /tmp/CondaGenerationOptions.cmake > ./conda/cmake/CondaGenerationOptions.cmake


### PR DESCRIPTION
This PR adds the logic to generate the `robotology-distro` and `robotology-distro-all` conda metapackages for each new robotology-superbuild. 

This would permit user to run:
~~~
mamba install -c conda-forge -c robotology robotology-distro=2022.0 yarp icub-main idyntree
~~~

And the solver will automatically compute the correct version of `yarp`, `icub-main` and `idyntree` to install. Note that `robotology-distro` will just constrain the version of packages that are installed by the user, so installing just that package will not install anything else. On the other hand, this PR also adds the `robotology-distro-all` metapackage, that will install all the packages contained in the robotology-superbuild corresponding to a given release.

No documentation is currently added as I prefer to actually have the first metapackages generated and present on the `robotology` channel before document this. 

In details, this PR:
* Also generate conda packages on releases and not only on weekly jobs on master branch, to make sure that the versions references by the metapackages actually exists
* Read and write `CONDA_BUILD_NUMBER` always on `master` branch, even when the conda packages are generated on a branch (that is tipically is a `release/YYYY.MM`
* On releases, also generate the robotology-distro and robotology-distro-all metapackages . This is done by appropriate modifications to the conda packages generation logic, that is described in https://github.com/robotology/robotology-superbuild/blob/master/doc/conda-recipe-generation.md#internals


Fix https://github.com/robotology/robotology-superbuild/issues/727 .