### PR TITLE
ci: Ensure that gazebo is not searched in ubuntu:jammy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -215,7 +215,7 @@ jobs:
       run: |
         mkdir -p build
         cd build
-        cmake -C ${GITHUB_WORKSPACE}/.ci/initial-cache.gh.cmake  -G"${{ matrix.cmake_generator }}"  -DROBOTOLOGY_USES_GAZEBO:BOOL=OFF -DNON_INTERACTIVE_BUILD:BOOL=TRUE -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}  ${{ matrix.project_tags_cmake_options }}  ..
+        cmake -DROBOTOLOGY_USES_GAZEBO:BOOL=OFF -C ${GITHUB_WORKSPACE}/.ci/initial-cache.gh.cmake  -G"${{ matrix.cmake_generator }}"  -DROBOTOLOGY_USES_GAZEBO:BOOL=OFF -DNON_INTERACTIVE_BUILD:BOOL=TRUE -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}  ${{ matrix.project_tags_cmake_options }}  ..
         # Octave is disabled as a workaround for https://github.com/robotology/robotology-superbuild/issues/384
         # Python is disabled as a workaround for https://github.com/robotology/robotology-superbuild/issues/494
         # Gazebo is disabled due to the errors reported in https://github.com/robotology/robotology-superbuild/pull/593

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -215,11 +215,11 @@ jobs:
       run: |
         mkdir -p build
         cd build
-        cmake -C ${GITHUB_WORKSPACE}/.ci/initial-cache.gh.cmake  -G"${{ matrix.cmake_generator }}" -DNON_INTERACTIVE_BUILD:BOOL=TRUE -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}  ${{ matrix.project_tags_cmake_options }}  ..
+        cmake -C ${GITHUB_WORKSPACE}/.ci/initial-cache.gh.cmake  -G"${{ matrix.cmake_generator }}"  -DROBOTOLOGY_USES_GAZEBO:BOOL=OFF -DNON_INTERACTIVE_BUILD:BOOL=TRUE -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}  ${{ matrix.project_tags_cmake_options }}  ..
         # Octave is disabled as a workaround for https://github.com/robotology/robotology-superbuild/issues/384
         # Python is disabled as a workaround for https://github.com/robotology/robotology-superbuild/issues/494
         # Gazebo is disabled due to the errors reported in https://github.com/robotology/robotology-superbuild/pull/593
-        cmake -DROBOTOLOGY_USES_OCTAVE:BOOL=OFF -DROBOTOLOGY_USES_PYTHON:BOOL=OFF -DROBOTOLOGY_USES_GAZEBO:BOOL=OFF -DCMAKE_DISABLE_FIND_PACKAGE_gazebo:BOOL=ON .
+        cmake -DROBOTOLOGY_USES_OCTAVE:BOOL=OFF -DROBOTOLOGY_USES_PYTHON:BOOL=OFF .
 
     - name: Disable profiles that are not supported in docker for now [Docker debian-testing and debian-buster]
       if: (matrix.docker_image == 'debian:testing' || matrix.docker_image == 'debian:buster-backports' || matrix.docker_image == 'ubuntu:bionic')

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -242,6 +242,13 @@ jobs:
        cd build
        cmake -DROBOTOLOGY_USES_GAZEBO:BOOL=OFF .
 
+    # See https://github.com/robotology/robotology-superbuild/issues/1029
+    - name: Disable profiles that are not supported in Ubuntu Jammy [Docker ubuntu:jammy]
+      if: (matrix.docker_image == 'ubuntu:jammy')
+      run: |
+       cd build
+       cmake -DROBOTOLOGY_USES_GAZEBO:BOOL=OFF .
+
     - name: Build  [Docker]
       run: |
         cd build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -215,10 +215,11 @@ jobs:
       run: |
         mkdir -p build
         cd build
-        cmake -DROBOTOLOGY_USES_GAZEBO:BOOL=OFF -C ${GITHUB_WORKSPACE}/.ci/initial-cache.gh.cmake  -G"${{ matrix.cmake_generator }}"  -DROBOTOLOGY_USES_GAZEBO:BOOL=OFF -DNON_INTERACTIVE_BUILD:BOOL=TRUE -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}  ${{ matrix.project_tags_cmake_options }}  ..
+        cmake  -G"${{ matrix.cmake_generator }}"  -DROBOTOLOGY_ENABLE_ROBOT_TESTING:BOOL=ON -DROBOTOLOGY_ENABLE_DYNAMICS:BOOL=ON -DROBOTOLOGY_ENABLE_HUMAN_DYNAMICS:BOOL=ON  -DROBOTOLOGY_ENABLE_DYNAMICS_FULL_DEPS:BOOL=ON  -DROBOTOLOGY_ENABLE_ICUB_HEAD:BOOL=ON -DROBOTOLOGY_ENABLE_ICUB_BASIC_DEMOS:BOOL=ON  -DROBOTOLOGY_ENABLE_TELEOPERATION:BOOL=ON  -DROBOTOLOGY_ENABLE_EVENT_DRIVEN:BOOL=ON -DROBOTOLOGY_USES_GAZEBO:BOOL=OFF -DNON_INTERACTIVE_BUILD:BOOL=TRUE -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}  ${{ matrix.project_tags_cmake_options }}  ..
         # Octave is disabled as a workaround for https://github.com/robotology/robotology-superbuild/issues/384
         # Python is disabled as a workaround for https://github.com/robotology/robotology-superbuild/issues/494
         # Gazebo is disabled due to the errors reported in https://github.com/robotology/robotology-superbuild/pull/593
+        # initial-cache.cmake is not used for https://github.com/robotology/robotology-superbuild/issues/1029
         cmake -DROBOTOLOGY_USES_OCTAVE:BOOL=OFF -DROBOTOLOGY_USES_PYTHON:BOOL=OFF .
 
     - name: Disable profiles that are not supported in docker for now [Docker debian-testing and debian-buster]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -211,8 +211,6 @@ jobs:
         apt-get -y update
         apt-get -y upgrade
 
-
-
     - name: Configure [Docker]
       run: |
         mkdir -p build
@@ -221,7 +219,7 @@ jobs:
         # Octave is disabled as a workaround for https://github.com/robotology/robotology-superbuild/issues/384
         # Python is disabled as a workaround for https://github.com/robotology/robotology-superbuild/issues/494
         # Gazebo is disabled due to the errors reported in https://github.com/robotology/robotology-superbuild/pull/593
-        cmake -DROBOTOLOGY_USES_OCTAVE:BOOL=OFF -DROBOTOLOGY_USES_PYTHON:BOOL=OFF -DROBOTOLOGY_USES_GAZEBO:BOOL=OFF .
+        cmake -DROBOTOLOGY_USES_OCTAVE:BOOL=OFF -DROBOTOLOGY_USES_PYTHON:BOOL=OFF -DROBOTOLOGY_USES_GAZEBO:BOOL=OFF -DCMAKE_DISABLE_FIND_PACKAGE_gazebo:BOOL=ON .
 
     - name: Disable profiles that are not supported in docker for now [Docker debian-testing and debian-buster]
       if: (matrix.docker_image == 'debian:testing' || matrix.docker_image == 'debian:buster-backports' || matrix.docker_image == 'ubuntu:bionic')
@@ -238,13 +236,6 @@ jobs:
     # See https://github.com/robotology/robotology-superbuild/issues/944
     - name: Disable profiles that are not supported in Debian Testing [Docker ubuntu:testing]
       if: (matrix.docker_image == 'debian:testing')
-      run: |
-       cd build
-       cmake -DROBOTOLOGY_USES_GAZEBO:BOOL=OFF .
-
-    # See https://github.com/robotology/robotology-superbuild/issues/1029
-    - name: Disable profiles that are not supported in Ubuntu Jammy [Docker ubuntu:jammy]
-      if: (matrix.docker_image == 'ubuntu:jammy')
       run: |
        cd build
        cmake -DROBOTOLOGY_USES_GAZEBO:BOOL=OFF .


### PR DESCRIPTION
Workaround for https://github.com/robotology/robotology-superbuild/issues/1029 . As we need to set `ROBOTOLOGY_USES_GAZEBO` is set to `OFF` since the beginning, I had to remove the use of `${GITHUB_WORKSPACE}/.ci/initial-cache.gh.cmake` and listed all the options manually.