### PR TITLE
Restore latest miniforge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
     - uses: conda-incubator/setup-miniconda@v2
       with:
         miniforge-variant: Mambaforge
-        miniforge-version: 4.11.0-0 
+        miniforge-version: latest
 
     - name: Install files to enable compilation of mex files [Conda/Linux]
       if: contains(matrix.os, 'ubuntu') 


### PR DESCRIPTION
Revert https://github.com/robotology/robotology-superbuild/pull/1026 as now the latest release of miniforge seems to be working as expected.