### PR TITLE
Pin cmake to 3.21 to workaround FindGLUT regression

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,7 +75,7 @@ jobs:
       shell: bash -l {0}
       run: |
         # Compilation related dependencies 
-        mamba install cmake compilers make ninja pkg-config
+        mamba install cmake=3.21 compilers make ninja pkg-config
         # Actual dependencies
         mamba install ace asio assimp boost eigen gazebo glew glfw graphviz gsl ipopt irrlicht libjpeg-turbo libmatio libode libxml2 nlohmann_json opencv pkg-config portaudio qt sdl sdl2 sqlite tinyxml spdlog lua
         # Python 

--- a/conda/conda_build_config.yml
+++ b/conda/conda_build_config.yml
@@ -12,3 +12,6 @@ pin_run_as_build:
 # Workaround for https://github.com/conda-forge/gazebo-feedstock/issues/119
 icu:
   - '68'
+
+cmake:
+  - '3.21'

--- a/doc/conda-forge.md
+++ b/doc/conda-forge.md
@@ -67,7 +67,7 @@ mamba install -c conda-forge -c robotology gazebo-yarp-plugins icub-models
 
 If you want to develop some C++ code on the top of these libraries, it is recommended to also install the necessary compiler and development tools directly in the same environment:
 ~~~
-mamba install -c conda-forge compilers cmake pkg-config make ninja
+mamba install -c conda-forge compilers cmake=3.21 pkg-config make ninja
 ~~~
 
 ## Source installation


### PR DESCRIPTION
Workaround for https://github.com/robotology/robotology-superbuild/issues/1032 while we wait for:
* https://gitlab.kitware.com/cmake/cmake/-/merge_requests/6985
* https://github.com/dcnieho/FreeGLUT/pull/96
* https://github.com/conda-forge/freeglut-feedstock/pull/31

To be merged and released.