### PR TITLE
Disable CI tests on ubuntu:jammy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -165,7 +165,8 @@ jobs:
         docker_image:
           - "ubuntu:bionic"
           - "ubuntu:focal"
-          - "ubuntu:jammy"
+          # Disabled as workaround for https://github.com/robotology/robotology-superbuild/issues/1029
+          # - "ubuntu:jammy"
           - "debian:buster-backports"
           - "debian:testing"
 


### PR DESCRIPTION
Workaround for https://github.com/robotology/robotology-superbuild/issues/1029, as the problem is in Ubuntu Jammy and not on our side.