### PR TITLE
Pin  event-driven to v1.6 to fix macOS CI

### DIFF
--- a/cmake/ProjectsTagsStable.cmake
+++ b/cmake/ProjectsTagsStable.cmake
@@ -17,3 +17,5 @@ set_tag(YCM_TAG ycm-0.13)
 set_tag(YARP_TAG yarp-3.6)
 set_tag(yarp-matlab-bindings_TAG yarp-3.6)
 set_tag(gym-ignition_TAG v1.2.2)
+# Workaround for https://github.com/robotology/robotology-superbuild/issues/1033
+set_tag(event-driven_TAG v1.2.2)

--- a/cmake/ProjectsTagsStable.cmake
+++ b/cmake/ProjectsTagsStable.cmake
@@ -18,4 +18,4 @@ set_tag(YARP_TAG yarp-3.6)
 set_tag(yarp-matlab-bindings_TAG yarp-3.6)
 set_tag(gym-ignition_TAG v1.2.2)
 # Workaround for https://github.com/robotology/robotology-superbuild/issues/1033
-set_tag(event-driven_TAG v1.2.2)
+set_tag(event-driven_TAG v1.6)

--- a/cmake/ProjectsTagsUnstable.cmake
+++ b/cmake/ProjectsTagsUnstable.cmake
@@ -33,3 +33,5 @@ set_tag(OsqpEigen_TAG master)
 set_tag(YARP_telemetry_TAG master)
 set_tag(gym-ignition_TAG v1.2.2)
 set_tag(walking-teleoperation_TAG devel)
+# Workaround for https://github.com/robotology/robotology-superbuild/issues/1033
+set_tag(event-driven_TAG v1.6)


### PR DESCRIPTION
Workaround for https://github.com/robotology/robotology-superbuild/issues/1033 . This can be reverted once https://github.com/robotology/event-driven/pull/153 is merged.