### PR TITLE
Bump CppAD to 20220000.2 and let CppAD be updated by automatic update

### DIFF
--- a/releases/latest.releases.yaml
+++ b/releases/latest.releases.yaml
@@ -18,7 +18,7 @@ repositories:
   CppAD:
     type: git
     url: https://github.com/coin-or/CppAD.git
-    version: 20220000.1
+    version: 20220000.2
   casadi:
     type: git
     url: https://github.com/ami-iit/casadi.git

--- a/scripts/robotologyUpdateLatestReleases.sh
+++ b/scripts/robotologyUpdateLatestReleases.sh
@@ -17,7 +17,7 @@
 # to get the last one
 # External repos are in the list as we updated them manually
 # event-driven does not have a recent release
-projects_to_skip=("ICUBcontrib" "qhull" "CppAD" "casadi" "manif" "osqp" "event-driven")
+projects_to_skip=("ICUBcontrib" "qhull" "casadi" "manif" "osqp")
 
 getParentDir () {
     SOURCE="${1}"


### PR DESCRIPTION
This matches the latest available version on conda-forge: https://anaconda.org/conda-forge/cppad .
Furthermore, I remove `CppAD` to the list of repos that we do not automatically update: as it is important that we track the same version that it used in conda-forge (and there the latest version is tipically adopted quite quickly as the process is automatic, see https://github.com/conda-forge/cppad-feedstock/pull/13) then it is better to update the version as soon as it is available.

Furthermore, I also removed `event-driven` from the list of repos that we do not update as a recent release is now available for it, and I just noticed this when I removed CppAD.