### PR TITLE
macOS conda package generation: Pin gazebo and opencv and do not generate metapackages

### DIFF
--- a/.github/workflows/generate-conda-packages.yaml
+++ b/.github/workflows/generate-conda-packages.yaml
@@ -192,8 +192,8 @@ jobs:
             rm -rf human-dynamics-estimation
             conda build -m ${CONDA_PREFIX}/conda_build_config.yaml -m ${GITHUB_WORKSPACE}/conda/conda_build_config.yml . 
 
-        - name: Build conda metapackages (if necessary
-          if: github.event_name == 'release'
+        - name: Build conda metapackages (if necessary)
+          if: github.event_name == 'release' && !contains(matrix.os, 'macos')
           shell: bash -l {0}
           run: |
             cd build/conda/generated_recipes_metapackages

--- a/conda/cmake/CondaGenerationOptions.cmake
+++ b/conda/cmake/CondaGenerationOptions.cmake
@@ -2,7 +2,7 @@
 # to ensure that binaries belonging to different rebuilds
 # can be distinguished even if the version number is the same
 if(NOT CONDA_BUILD_NUMBER)
-  set(CONDA_BUILD_NUMBER 43)
+  set(CONDA_BUILD_NUMBER 44)
 endif()
 
 # This option is enabled only when the metapackages robotology-distro and robotology-distro-all are

--- a/conda/conda_build_config.yml
+++ b/conda/conda_build_config.yml
@@ -10,9 +10,14 @@ pin_run_as_build:
     max_pin: x.x
 
 # Workaround for https://github.com/conda-forge/gazebo-feedstock/issues/119
-# On macOS do not apply this constraint to avoid https://github.com/robotology/robotology-superbuild/issues/1041
-qt:  # [not osx]
-  - "5.12.9=*_4"  # [not osx]
+qt:
+  - "5.12.9=*_4"
+
+gazebo:  # [osx]
+  - '11.9' # [osx] 
+
+libopencv:  # [osx]
+  - '4.5.3'  # [osx] 
 
 cmake:
   - '3.21'

--- a/conda/conda_build_config.yml
+++ b/conda/conda_build_config.yml
@@ -10,8 +10,9 @@ pin_run_as_build:
     max_pin: x.x
 
 # Workaround for https://github.com/conda-forge/gazebo-feedstock/issues/119
-qt:
-  - "5.12.9=*_4"
+# On macOS do not apply this constraint to avoid https://github.com/robotology/robotology-superbuild/issues/1041
+qt:  # [not osx]
+  - "5.12.9=*_4"  # [not osx]
 
 cmake:
   - '3.21'


### PR DESCRIPTION
The pin was added in https://github.com/robotology/robotology-superbuild/pull/1025 to avoid any problem related to https://github.com/conda-forge/gazebo-feedstock/issues/119 . Anyhow, this is creating problems in macOS, so add two further pins and disable the metapackage generation.