### PR TITLE
Unpin CMake

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,7 +75,7 @@ jobs:
       shell: bash -l {0}
       run: |
         # Compilation related dependencies 
-        mamba install cmake=3.21 compilers make ninja pkg-config
+        mamba install cmake compilers make ninja pkg-config
         # Actual dependencies
         mamba install ace asio assimp boost eigen gazebo glew glfw graphviz gsl ipopt irrlicht libjpeg-turbo libmatio libode libxml2 nlohmann_json opencv pkg-config portaudio qt=5.12.9=*_4 sdl sdl2 sqlite tinyxml spdlog lua
         # Python 

--- a/conda/conda_build_config.yml
+++ b/conda/conda_build_config.yml
@@ -19,6 +19,4 @@ gazebo:  # [osx]
 libopencv:  # [osx]
   - '4.5.3'  # [osx] 
 
-cmake:
-  - '3.21'
 

--- a/doc/conda-forge.md
+++ b/doc/conda-forge.md
@@ -67,7 +67,7 @@ mamba install -c conda-forge -c robotology gazebo-yarp-plugins icub-models
 
 If you want to develop some C++ code on the top of these libraries, it is recommended to also install the necessary compiler and development tools directly in the same environment:
 ~~~
-mamba install -c conda-forge compilers cmake=3.21 pkg-config make ninja
+mamba install -c conda-forge compilers cmake pkg-config make ninja
 ~~~
 
 ## Source installation


### PR DESCRIPTION
Revert https://github.com/robotology/robotology-superbuild/pull/1035 as now CMake 3.22.3 has been released with the fix https://gitlab.kitware.com/cmake/cmake/-/commit/44f7238d5d542afac860be928fa215c0f3f9a8fb so we can solve https://github.com/robotology/robotology-superbuild/issues/1032 without workarounds (see https://github.com/Kitware/CMake/blob/v3.22.3/Modules/FindGLUT.cmake).