### PR TITLE
BuildYARP: Set ENABLE_yarpcar_mjpeg to ON on Apple if we are using Unstable branches

### DIFF
--- a/cmake/BuildYARP.cmake
+++ b/cmake/BuildYARP.cmake
@@ -31,7 +31,8 @@ else()
 endif()
 
 # Workaround for https://github.com/robotology/yarp/issues/2353
-if(APPLE AND NOT ${ROBOTOLOGY_CONFIGURING_UNDER_CONDA})
+# To be removed once a new minor release of YARP (3.7?) is released
+if(APPLE AND NOT ("${ROBOTOLOGY_PROJECT_TAGS}" STREQUAL "Unstable"))
   set(ENABLE_yarpcar_mjpeg OFF)
 else()
   set(ENABLE_yarpcar_mjpeg ON)

--- a/cmake/BuildYARP.cmake
+++ b/cmake/BuildYARP.cmake
@@ -31,7 +31,7 @@ else()
 endif()
 
 # Workaround for https://github.com/robotology/yarp/issues/2353
-if(APPLE)
+if(APPLE AND NOT ${ROBOTOLOGY_CONFIGURING_UNDER_CONDA})
   set(ENABLE_yarpcar_mjpeg OFF)
 else()
   set(ENABLE_yarpcar_mjpeg ON)


### PR DESCRIPTION
As the unstable branches contain the fix  https://github.com/robotology/yarp/pull/2810 .

FYI @S-Dafarra 