### PR TITLE
Specify version of YCM_TAG that works fine with CMake 3.23

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,6 +44,8 @@ endif()
 set(YCM_FOLDER src)
 set(YCM_COMPONENT core)
 set(YCM_MINIMUM_VERSION 0.11.1)
+# Workaround for https://github.com/robotology/robotology-superbuild/issues/1074
+set(YCM_TAG fixcmake323)
 
 # Include logic for generating Conda recipes (by default it is disabled) and exit
 if(ROBOTOLOGY_GENERATE_CONDA_RECIPES)


### PR DESCRIPTION
Do not merge, this PR is just used to test https://github.com/robotology/ycm/pull/393 . If that works, the PR will be merged and a new release of YCM will be done.