### PR TITLE
Create 2022.02.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ The format of this document is based on [Keep a Changelog](https://keepachangelo
 
 ## [Unreleased]
 
+## [2022.02.1] - 2022-04-01
+
+### Fixed
+- Fix compatibility with CMake 3.23 by bumping YCM version to 0.13.1 .
+
 ## [2022.02.0] - 2022-03-01
 
 ### Added

--- a/cmake/RobotologySuperbuildOptions.cmake
+++ b/cmake/RobotologySuperbuildOptions.cmake
@@ -69,7 +69,7 @@ endif()
 
 set(ROBOTOLOGY_PROJECT_TAGS "Custom" CACHE STRING "The tags to be used for the robotology projects: Stable, Unstable, LatestRelease or Custom. This can be changed only before the first configuration.")
 mark_as_advanced(ROBOTOLOGY_PROJECT_TAGS)
-set(ROBOTOLOGY_PROJECT_TAGS_CUSTOM_FILE "${CMAKE_CURRENT_SOURCE_DIR}/releases/2022.02.0.yaml" CACHE FILEPATH "If ROBOTOLOGY_PROJECT_TAGS is custom, this file will be loaded to specify the tags of the projects to use.")
+set(ROBOTOLOGY_PROJECT_TAGS_CUSTOM_FILE "${CMAKE_CURRENT_SOURCE_DIR}/releases/2022.02.1.yaml" CACHE FILEPATH "If ROBOTOLOGY_PROJECT_TAGS is custom, this file will be loaded to specify the tags of the projects to use.")
 mark_as_advanced(ROBOTOLOGY_PROJECT_TAGS_CUSTOM_FILE)
 set_property(CACHE ROBOTOLOGY_PROJECT_TAGS PROPERTY STRINGS "Stable" "Unstable" "LatestRelease" "Custom")
 

--- a/conda/cmake/CondaGenerationOptions.cmake
+++ b/conda/cmake/CondaGenerationOptions.cmake
@@ -11,7 +11,7 @@ option(CONDA_GENERATE_ROBOTOLOGY_METAPACKAGES "If on, generate recipes for robot
 
 # This variable is automatically set to contain the robotology-superbuild version in case of releases
 if(NOT CONDA_ROBOTOLOGY_SUPERBUILD_VERSION)
-  set(CONDA_ROBOTOLOGY_SUPERBUILD_VERSION 2022.02.0)
+  set(CONDA_ROBOTOLOGY_SUPERBUILD_VERSION 2022.02.1)
 endif()
 
 # For more conda generation options, check the specific project Build<CMakeProject>.cmake

--- a/packaging/windows/CMakeLists.txt
+++ b/packaging/windows/CMakeLists.txt
@@ -6,7 +6,7 @@
 
 cmake_minimum_required(VERSION 3.12)
 
-set(INSTALLER_VERSION 2022.02.0)
+set(INSTALLER_VERSION 2022.02.1)
 option(RI_INCLUDE_GAZEBO "If ON include the Gazebo simulator binaries." ON)
 option(RI_BUILD_FULL_INSTALLER "If ON build the full installer, otherwise the dependencies one." ON)
 

--- a/releases/2022.02.1.yaml
+++ b/releases/2022.02.1.yaml
@@ -1,0 +1,209 @@
+repositories:
+  qpOASES:
+    type: git
+    url: https://github.com/robotology-dependencies/qpOASES.git
+    version: v3.2.0.1
+  osqp:
+    type: git
+    url: https://github.com/oxfordcontrol/osqp.git
+    version: v0.6.2
+  manif:
+    type: git
+    url: https://github.com/robotology-dependencies/manif.git
+    version: 0.0.4.1
+  qhull:
+    type: git
+    url: https://github.com/qhull/qhull.git
+    version: 2020.2
+  CppAD:
+    type: git
+    url: https://github.com/coin-or/CppAD.git
+    version: 20220000.2
+  casadi:
+    type: git
+    url: https://github.com/ami-iit/casadi.git
+    version: 3.5.5.3
+  YCM:
+    type: git
+    url: https://github.com/robotology/ycm.git
+    version: v0.13.1
+  YARP:
+    type: git
+    url: https://github.com/robotology/yarp.git
+    version: v3.6.0
+  ICUB:
+    type: git
+    url: https://github.com/robotology/icub-main.git
+    version: v1.24.0
+  ICUBcontrib:
+    type: git
+    url: https://github.com/robotology/icub-contrib-common.git
+    version: v1.19.0
+  robots-configuration:
+    type: git
+    url: https://github.com/robotology/robots-configuration.git
+    version: v1.23.0
+  GazeboYARPPlugins:
+    type: git
+    url: https://github.com/robotology/gazebo-yarp-plugins.git
+    version: v4.2.0
+  icub-models:
+    type: git
+    url: https://github.com/robotology/icub-models.git
+    version: v1.23.0
+  yarp-matlab-bindings:
+    type: git
+    url: https://github.com/robotology/yarp-matlab-bindings.git
+    version: v3.6.1
+  RobotTestingFramework:
+    type: git
+    url: https://github.com/robotology/robot-testing-framework.git
+    version: v2.0.1
+  icub-tests:
+    type: git
+    url: https://github.com/robotology/icub-tests.git
+    version: v1.22.0
+  blocktestcore:
+    type: git
+    url: https://github.com/robotology/blocktest.git
+    version: v2.3.4
+  blocktest-yarp-plugins:
+    type: git
+    url: https://github.com/robotology/blocktest-yarp-plugins.git
+    version: v1.1.2
+  iDynTree:
+    type: git
+    url: https://github.com/robotology/idyntree.git
+    version: v5.1.0
+  BlockFactory:
+    type: git
+    url: https://github.com/robotology/blockfactory.git
+    version: v0.8.3
+  WBToolbox:
+    type: git
+    url: https://github.com/robotology/wb-toolbox.git
+    version: v5.5.0
+  OsqpEigen:
+    type: git
+    url: https://github.com/robotology/osqp-eigen.git
+    version: v0.7.0
+  UnicyclePlanner:
+    type: git
+    url: https://github.com/robotology/unicycle-footstep-planner.git
+    version: v0.4.1
+  walking-controllers:
+    type: git
+    url: https://github.com/robotology/walking-controllers.git
+    version: v0.5.0
+  icub-gazebo-wholebody:
+    type: git
+    url: https://github.com/robotology/icub-gazebo-wholebody.git
+    version: v0.1.0
+  whole-body-controllers:
+    type: git
+    url: https://github.com/robotology/whole-body-controllers.git
+    version: v2.5.6
+  whole-body-estimators:
+    type: git
+    url: https://github.com/robotology/whole-body-estimators.git
+    version: v0.6.1
+  walking-teleoperation:
+    type: git
+    url: https://github.com/robotology/walking-teleoperation.git
+    version: v1.2.0
+  forcetorque-yarp-devices:
+    type: git
+    url: https://github.com/robotology/forcetorque-yarp-devices.git
+    version: v0.2.0
+  wearables:
+    type: git
+    url: https://github.com/robotology/wearables.git
+    version: v1.3.0
+  HumanDynamicsEstimation:
+    type: git
+    url: https://github.com/robotology/human-dynamics-estimation.git
+    version: v2.4.1
+  human-gazebo:
+    type: git
+    url: https://github.com/robotology/human-gazebo.git
+    version: v1.0
+  icub_firmware_shared:
+    type: git
+    url: https://github.com/robotology/icub-firmware-shared.git
+    version: v1.24.0
+  icub-firmware:
+    type: git
+    url: https://github.com/robotology/icub-firmware.git
+    version: v1.24.0
+  icub-firmware-build:
+    type: git
+    url: https://github.com/robotology/icub-firmware-build.git
+    version: v1.24.0
+  icub-firmware-models:
+    type: git
+    url: https://github.com/robotology/icub-firmware-models.git
+    version: v1.20.0
+  yarp-device-xsensmt:
+    type: git
+    url: https://github.com/robotology/yarp-device-xsensmt.git
+    version: v0.1.1
+  yarp-device-ovrheadset:
+    type: git
+    url: https://github.com/robotology/yarp-device-ovrheadset.git
+    version: v1.0.0
+  speech:
+    type: git
+    url: https://github.com/robotology/speech.git
+    version: v1.1.0
+  icub-basic-demos:
+    type: git
+    url: https://github.com/robotology/icub-basic-demos.git
+    version: v1.21.0
+  funny-things:
+    type: git
+    url: https://github.com/robotology/funny-things.git
+    version: v2.0.0
+  bipedal-locomotion-framework:
+    type: git
+    url: https://github.com/ami-iit/bipedal-locomotion-framework.git
+    version: v0.6.0
+  LieGroupControllers:
+    type: git
+    url: https://github.com/ami-iit/lie-group-controllers.git
+    version: v0.1.1
+  event-driven:
+    type: git
+    url: https://github.com/robotology/event-driven.git
+    version: v1.6
+  matioCpp:
+    type: git
+    url: https://github.com/ami-iit/matio-cpp.git
+    version: v0.1.1
+  diagnosticdaemon:
+    type: git
+    url: https://github.com/robotology/diagnostic-daemon.git
+    version: v1.0.0
+  osqp-matlab:
+    type: git
+    url: https://github.com/ami-iit/osqp-matlab-cmake-buildsystem.git
+    version: v0.6.2.1
+  YARP_telemetry:
+    type: git
+    url: https://github.com/robotology/yarp-telemetry.git
+    version: v0.4.0
+  gym-ignition:
+    type: git
+    url: https://github.com/robotology/gym-ignition.git
+    version: v1.2.1
+  matlab-whole-body-simulator:
+    type: git
+    url: https://github.com/ami-iit/matlab-whole-body-simulator.git
+    version: v2.0.0
+  casadi-matlab-bindings:
+    type: git
+    url: https://github.com/ami-iit/casadi-matlab-bindings.git
+    version: v3.5.5.2
+  idyntree-yarp-tools:
+    type: git
+    url: https://github.com/robotology/idyntree-yarp-tools.git
+    version: v0.0.4


### PR DESCRIPTION
Fix https://github.com/robotology/robotology-superbuild/issues/1079 . Bump YCM to 0.13.1 to fix CMake 3.23 compatibility. 