### PR TITLE
Fix wrong name of qpOASES_CONDA_VERSION variable and remove hardcoding step of qpoases build useless since we switch to use qpOASES binary from conda-forge

### DIFF
--- a/.github/workflows/generate-conda-packages.yaml
+++ b/.github/workflows/generate-conda-packages.yaml
@@ -172,8 +172,6 @@ jobs:
             rm -rf icub-main
             conda mambabuild -m ${CONDA_PREFIX}/conda_build_config.yaml -m ${GITHUB_WORKSPACE}/conda/conda_build_config.yml lie-group-controllers
             rm -rf lie-group-controllers
-            conda mambabuild -m ${CONDA_PREFIX}/conda_build_config.yaml -m ${GITHUB_WORKSPACE}/conda/conda_build_config.yml qpoases
-            rm -rf qpoases
             conda mambabuild -m ${CONDA_PREFIX}/conda_build_config.yaml -m ${GITHUB_WORKSPACE}/conda/conda_build_config.yml yarp-matlab-bindings
             rm -rf yarp-matlab-bindings
             conda mambabuild -m ${CONDA_PREFIX}/conda_build_config.yaml -m ${GITHUB_WORKSPACE}/conda/conda_build_config.yml wb-toolbox

--- a/cmake/BuildqpOASES.cmake
+++ b/cmake/BuildqpOASES.cmake
@@ -35,4 +35,4 @@ set(qpOASES_CONDA_PKG_CONDA_FORGE_OVERRIDE ON)
 # (something like 3.2.0.1) and the version available in conda-forge when generating conda metapackages
 # such as robotology-distro and robotology-distro-all, we override the conda package version of qpOASES
 # here. This needs to be removed as soon as we stop use our fork in the superbuild 
-set(casadi_CONDA_VERSION 3.2.1)
+set(qpOASES_CONDA_VERSION 3.2.1)


### PR DESCRIPTION
https://github.com/robotology/robotology-superbuild/pull/1064 had a clear error, but it was merged without a review so this error was not noticed. This error eventually lead to https://github.com/robotology/robotology-superbuild/issues/1084 . 

Let's fix this and wait for a review. : ) 

Fix https://github.com/robotology/robotology-superbuild/issues/1084 .