### PR TITLE
BuildYARP: Enable YARP_DISABLE_MACOS_BUNDLES option to restore compatibility with CMake 3.23.1 on macOS

### DIFF
--- a/cmake/BuildYARP.cmake
+++ b/cmake/BuildYARP.cmake
@@ -66,6 +66,8 @@ ycm_ep_helper(YARP TYPE GIT
                               -DYARP_USE_SYSTEM_SQLite:BOOL=ON
                               -DYARP_COMPILE_libYARP_math:BOOL=ON
                               -DYARP_COMPILE_CARRIER_PLUGINS:BOOL=ON
+                              # Workaround for https://github.com/robotology/robotology-superbuild/issues/1091
+                              -DYARP_DISABLE_MACOS_BUNDLES:BOOL=ON
                               -DENABLE_yarpcar_bayer:BOOL=ON
                               -DENABLE_yarpcar_tcpros:BOOL=ON
                               -DENABLE_yarpcar_xmlrpc:BOOL=ON


### PR DESCRIPTION
Workaround for fixing https://github.com/robotology/robotology-superbuild/issues/1090 until https://github.com/robotology/yarp/pull/2822 is fixed and released.