### PR TITLE
CI: Enable Gazebo in all apt jobs and enable Ubuntu Jammy 22.04 and Debian Bullseye 11 Job

### DIFF
--- a/.ci/install_debian.sh
+++ b/.ci/install_debian.sh
@@ -26,9 +26,9 @@ lsb_dist="$(. /etc/os-release && echo "$ID")"
 dist_version="$(lsb_release -c | cut -d: -f2 | sed s/'^\t'//)"
 echo "lsb_dist: ${lsb_dist}"
 echo "dist_version: ${dist_version}"
-# bullseye is not supported by OpenRobotics' repo, but it has already 
-# the right version of Gazebo in its repo, so we just skip everything
-if [[ ("sid" != "$dist_version" && "bullseye" != "$dist_version" && "bookworm" != "$dist_version" && "trixie" != "$dist_version" && "jammy" != "$dist_version") ]]; then
+# Just a limited amount of distros are supported by OSRF repos, for all the other we use the 
+# gazebo packages in regular repos
+if [[ ("bionic" == "$dist_version" || "focal" == "$dist_version") ]]; then
     mkdir -p /etc/apt/sources.list.d
     echo deb http://packages.osrfoundation.org/gazebo/$lsb_dist\-stable $dist_version main > /etc/apt/sources.list.d/gazebo-stable.list
     apt-key adv --keyserver keyserver.ubuntu.com --recv-keys D2486D2DD83DB69272AFE98867170598AF249743
@@ -38,7 +38,3 @@ else
     apt-get install -y libgazebo-dev
 fi
 
-# Workaround for https://github.com/robotology/robotology-superbuild/pull/998#issuecomment-1015415833
-if [[ ("jammy" == "$dist_version") ]]; then
-    apt-get install -y libsdformat9-dev
-fi

--- a/.ci/install_debian.sh
+++ b/.ci/install_debian.sh
@@ -34,8 +34,7 @@ if [[ ("sid" != "$dist_version" && "bullseye" != "$dist_version" && "bookworm" !
     apt-key adv --keyserver keyserver.ubuntu.com --recv-keys D2486D2DD83DB69272AFE98867170598AF249743
     apt-get update
     apt-get install -y libgazebo11-dev
-# See https://github.com/robotology/robotology-superbuild/issues/944
-elif [[ ("bookworm" != "$dist_version") ]]; then
+else
     apt-get install -y libgazebo-dev
 fi
 

--- a/.ci/install_debian.sh
+++ b/.ci/install_debian.sh
@@ -28,7 +28,7 @@ echo "lsb_dist: ${lsb_dist}"
 echo "dist_version: ${dist_version}"
 # Just a limited amount of distros are supported by OSRF repos, for all the other we use the 
 # gazebo packages in regular repos
-if [[ ("bionic" == "$dist_version" || "focal" == "$dist_version") ]]; then
+if [[ ("bionic" == "$dist_version" || "focal" == "$dist_version" || "buster" == "$dist_version") ]]; then
     mkdir -p /etc/apt/sources.list.d
     echo deb http://packages.osrfoundation.org/gazebo/$lsb_dist\-stable $dist_version main > /etc/apt/sources.list.d/gazebo-stable.list
     apt-key adv --keyserver keyserver.ubuntu.com --recv-keys D2486D2DD83DB69272AFE98867170598AF249743

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -167,6 +167,7 @@ jobs:
           - "ubuntu:focal"
           - "ubuntu:jammy"
           - "debian:buster-backports"
+          - "debian:bullseye"
 
         project_tags:
           - Default

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -221,8 +221,7 @@ jobs:
         cmake -C ${GITHUB_WORKSPACE}/.ci/initial-cache.gh.cmake  -G"${{ matrix.cmake_generator }}" -DNON_INTERACTIVE_BUILD:BOOL=TRUE -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}  ${{ matrix.project_tags_cmake_options }}  ..
         # Octave is disabled as a workaround for https://github.com/robotology/robotology-superbuild/issues/384
         # Python is disabled as a workaround for https://github.com/robotology/robotology-superbuild/issues/494
-        # Gazebo is disabled due to the errors reported in https://github.com/robotology/robotology-superbuild/pull/593
-        cmake -DROBOTOLOGY_USES_OCTAVE:BOOL=OFF -DROBOTOLOGY_USES_PYTHON:BOOL=OFF -DROBOTOLOGY_USES_GAZEBO:BOOL=OFF .
+        cmake -DROBOTOLOGY_USES_OCTAVE:BOOL=OFF -DROBOTOLOGY_USES_PYTHON:BOOL=OFF .
 
     - name: Disable profiles that are not supported in docker for now [Docker debian-testing and debian-buster]
       if: (matrix.docker_image == 'debian:testing' || matrix.docker_image == 'debian:buster-backports' || matrix.docker_image == 'ubuntu:bionic')
@@ -235,13 +234,6 @@ jobs:
       run: |
        cd build
        cmake -DROBOTOLOGY_ENABLE_DYNAMICS_FULL_DEPS:BOOL=OFF -DROBOTOLOGY_ENABLE_ROBOT_TESTING:BOOL=OFF -DROBOTOLOGY_USES_PYTHON:BOOL=OFF .
-
-    # See https://github.com/robotology/robotology-superbuild/issues/944
-    - name: Disable profiles that are not supported in Debian Testing [Docker ubuntu:testing]
-      if: (matrix.docker_image == 'debian:testing')
-      run: |
-       cd build
-       cmake -DROBOTOLOGY_USES_GAZEBO:BOOL=OFF .
 
     - name: Build  [Docker]
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -217,9 +217,6 @@ jobs:
         mkdir -p build
         cd build
         cmake -C ${GITHUB_WORKSPACE}/.ci/initial-cache.gh.cmake  -G"${{ matrix.cmake_generator }}" -DNON_INTERACTIVE_BUILD:BOOL=TRUE -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}  ${{ matrix.project_tags_cmake_options }}  ..
-        # Octave is disabled as a workaround for https://github.com/robotology/robotology-superbuild/issues/384
-        # Python is disabled as a workaround for https://github.com/robotology/robotology-superbuild/issues/494
-        cmake -DROBOTOLOGY_USES_OCTAVE:BOOL=OFF -DROBOTOLOGY_USES_PYTHON:BOOL=OFF .
 
     - name: Disable profiles that are not supported in docker for now [Docker debian-testing and debian-buster]
       if: (matrix.docker_image == 'debian:testing' || matrix.docker_image == 'debian:buster-backports' || matrix.docker_image == 'ubuntu:bionic')

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -165,10 +165,8 @@ jobs:
         docker_image:
           - "ubuntu:bionic"
           - "ubuntu:focal"
-          # Disabled as workaround for https://github.com/robotology/robotology-superbuild/issues/1029
-          # - "ubuntu:jammy"
+          - "ubuntu:jammy"
           - "debian:buster-backports"
-          - "debian:testing"
 
         project_tags:
           - Default

--- a/doc/cmake-options.md
+++ b/doc/cmake-options.md
@@ -226,22 +226,35 @@ Dependencies-specific documentation
 ===================================
 
 ## Gazebo
-Support for this dependency is enabled by the `ROBOTOLOGY_USES_GAZEBO` CMake option.
+Support for this dependency is enabled by the `ROBOTOLOGY_USES_GAZEBO` CMake option, that enables the software that depends on "Classic Gazebo". 
 This option is still set to `OFF` on Windows as it is still experimental.
 
 ### System Dependencies
-On Linux with apt dependencies install Gazebo following the instructions available at http://gazebosim.org/tutorials?cat=install .
-Make sure to install also the development files, i.e. `libgazebo*-dev` on Debian/Ubuntu.
 
+#### Linux with apt
+On Linux with apt dependencies install Gazebo, if you are on:
+* Ubuntu 20.04
+* Buster 10
+
+follow the instructions available at https://gazebosim.org/tutorials?tut=install_ubuntu . Make sure to install also the development files, i.e. `libgazebo*-dev` on Debian/Ubuntu.
+
+Otherwise, if you are on other supported Debian/Ubuntu systems, just install the system provided gazebo package with:
+~~~~
+sudo apt install libgazebo-dev
+~~~~
+
+#### Linux/macOS/Windows with conda
 If you install your dependencies with `conda`, just make sure to install the `gazebo` package.
 
+#### Windows with vcpkg
 On Windows with vcpkg dependencies, make sure that you install the Windows dependencies using the `vcpkg-robotology-with-gazebo.zip` archive and you set
 the correct enviroment variables as documented in [`robotology-superbuild-dependencies-vcpkg` documentation](https://github.com/robotology/robotology-superbuild-dependencies-vcpkg).
 
+#### macOS with Homebrew
 This option is not supported when using Homebrew to install your dependencies.
 
 ### Check the installation
-Follow the steps in https://github.com/robotology/icub-gazebo#usage and/or https://github.com/robotology/icub-models#use-the-models-with-gazebo to check if the Gazebo-based iCub simulation works fine.
+Follow the steps in  https://github.com/robotology/icub-models#use-the-models-with-gazebo to check if the Gazebo-based iCub simulation works fine.
 
 ## Ignition
 Support for this dependency is enabled by the `ROBOTOLOGY_USES_IGNITION` CMake option.


### PR DESCRIPTION
The problems described in https://github.com/robotology/robotology-superbuild/issues/944 should now be solved. 
This is also related to https://github.com/robotology/robotology-superbuild/issues/1095 .

Also do a general cleanup of CI in view of Ubuntu 22.04 release, and close or remove workaround due:
* https://github.com/robotology/robotology-superbuild/issues/494
* https://github.com/robotology/robotology-superbuild/pull/998
* https://github.com/robotology/robotology-superbuild/pull/593
* https://github.com/robotology/robotology-superbuild/issues/384
* https://github.com/robotology/robotology-superbuild/pull/593

This PR also completes the documentation for Ubuntu 22.04 by updating the docs to address https://github.com/robotology/robotology-superbuild/issues/1095 and adding a workaround for https://github.com/osrf/gazebo/issues/3203 .