### PR TITLE
Bump YCM to 0.14

### DIFF
--- a/cmake/ProjectsTagsStable.cmake
+++ b/cmake/ProjectsTagsStable.cmake
@@ -13,7 +13,7 @@ set_tag(CppAD_TAG 20220000.2)
 set_tag(casadi 3.5.5.3)
 
 # Robotology projects
-set_tag(YCM_TAG ycm-0.13)
+set_tag(YCM_TAG ycm-0.14)
 set_tag(YARP_TAG yarp-3.6)
 set_tag(yarp-matlab-bindings_TAG yarp-3.6)
 set_tag(gym-ignition_TAG v1.2.2)

--- a/releases/latest.releases.yaml
+++ b/releases/latest.releases.yaml
@@ -26,7 +26,7 @@ repositories:
   YCM:
     type: git
     url: https://github.com/robotology/ycm.git
-    version: v0.13.2
+    version: v0.14.0
   YARP:
     type: git
     url: https://github.com/robotology/yarp.git


### PR DESCRIPTION
After the recent release https://github.com/robotology/ycm/releases/tag/v0.14.0 .