### PR TITLE
Add python3-pip apt package dependency

### DIFF
--- a/apt-python.txt
+++ b/apt-python.txt
@@ -1,6 +1,7 @@
 python3-dev
 python3-numpy
 python3-pybind11
+python3-pip
 pybind11-dev
 python3-pyqt5
 python3-pyqt5.qtmultimedia


### PR DESCRIPTION
After https://github.com/robotology/robotology-superbuild/pull/1069 the CI was failing on some configurations with error (https://pipelines.actions.githubusercontent.com/serviceHosts/b3e4f43b-711e-4c4a-9229-829950399fe6/_apis/pipelines/1/runs/3570/signedlogcontent/11?urlExpires=2022-04-27T06%3A48%3A33.9360011Z&urlSigningMethod=HMACV1&urlSignature=7DvePC4jZNepFYPr7u0BjV3Xw%2BIr8xd8mznaRQcwy9I%3D):
~~~
2022-04-27T02:48:24.1609768Z [91/368] Performing install step for 'meshcat-python'
2022-04-27T02:48:24.1610645Z FAILED: src/meshcat-python/CMakeFiles/YCMStamp/meshcat-python-install 
2022-04-27T02:48:24.1612294Z cd /__w/robotology-superbuild/robotology-superbuild/build/src/meshcat-python && /usr/bin/python3.9 -m pip install --upgrade --no-deps --target=/__w/robotology-superbuild/robotology-superbuild/build/install/lib/python3/dist-packages -VV /__w/robotology-superbuild/robotology-superbuild/src/meshcat-python && /usr/bin/cmake -E touch /__w/robotology-superbuild/robotology-superbuild/build/src/meshcat-python/CMakeFiles/YCMStamp/meshcat-python-install
2022-04-27T02:48:24.1613748Z /usr/bin/python3.9: No module named pip
~~~

Apparently we were not installing pip, this PR fixes that.