### PR TITLE
[DO NOT MERGE] Check compilation failures induced by https://github.com/robotology/yarp/pull/2833

### DIFF
--- a/cmake/ProjectsTagsUnstable.cmake
+++ b/cmake/ProjectsTagsUnstable.cmake
@@ -13,7 +13,8 @@ set_tag(CppAD_TAG 20220000.2)
 set_tag(casadi 3.5.5.3)
 
 # Robotology projects
-set_tag(YARP_TAG master)
+set_tag(YARP_REPOSITORY randaz81/yarp.git)
+set_tag(YARP_TAG removed_deprecated_interfaces)
 set_tag(ICUB_TAG devel)
 set_tag(RobotTestingFramework_TAG devel)
 set_tag(blockTest_TAG devel)

--- a/cmake/ProjectsTagsUnstable.cmake
+++ b/cmake/ProjectsTagsUnstable.cmake
@@ -14,7 +14,7 @@ set_tag(casadi 3.5.5.3)
 
 # Robotology projects
 set_tag(YARP_REPOSITORY randaz81/yarp.git)
-set_tag(YARP_TAG removed_deprecated_interfaces)
+set_tag(YARP_TAG deprecation_cleanup)
 set_tag(ICUB_TAG devel)
 set_tag(RobotTestingFramework_TAG devel)
 set_tag(blockTest_TAG devel)


### PR DESCRIPTION
https://github.com/robotology/yarp/pull/2833 will remove some methods that have been deprecated for a long time. This PR tries to compile the superbuild with that change before the PR is merged to early detect repos that still needs to be fixed.