### PR TITLE
Add support for <pkgName>_CONDA_ENTRY_POINTS to specify build/entry_points option in conda meta.yaml file

### DIFF
--- a/cmake/Buildrobot-log-visualizer.cmake
+++ b/cmake/Buildrobot-log-visualizer.cmake
@@ -19,3 +19,4 @@ rob_sup_pure_python_ycm_ep_helper(robot-log-visualizer
                                   FOLDER src)
 
 set(robot-log-visualizer_CONDA_DEPENDENCIES numpy pyqt matplotlib h5py)
+set(robot-log-visualizer_CONDA_ENTRY_POINTS "robot-log-visualizer = robot_log_visualizer.__main__:main")

--- a/conda/cmake/RobotologySuperbuildGenerateCondaRecipes.cmake
+++ b/conda/cmake/RobotologySuperbuildGenerateCondaRecipes.cmake
@@ -175,6 +175,13 @@ macro(generate_metametadata_file)
       endforeach()
     endif()
     
+    if(NOT "${${_cmake_pkg}_CONDA_ENTRY_POINTS}" STREQUAL "")
+      string(APPEND metametadata_file_contents "    entry_points:\n")
+      foreach(_entry_point IN LISTS ${_cmake_pkg}_CONDA_ENTRY_POINTS)
+        string(APPEND metametadata_file_contents "      - ${_entry_point}\n")
+      endforeach()
+    endif()
+    
     # By default we rely on properly set run_exports configurations in conda recipes
     # to avoid to manually set run dependencies. However, in some cases (cmake-only 
     # libraries, header-only libraries) run_exports is not used, so it is necessary 

--- a/conda/pure_python_recipe_template/meta.yaml
+++ b/conda/pure_python_recipe_template/meta.yaml
@@ -13,6 +13,9 @@ build:
   skip: True  # [py<38]
   number: {{ conda_build_number }}
 {% raw %}  script: {{ PYTHON }} -m pip install . --no-deps -vv {% endraw %}
+  entry_points:
+{% for entry_point in entry_points %}    - {{ entry_point }}
+{% endfor %}
 
 requirements:
   build:

--- a/doc/developers-faqs.md
+++ b/doc/developers-faqs.md
@@ -92,6 +92,7 @@ This action will automatically perform the following steps:
 | `<pkg>_CONDA_PKG_NAME`  | The name that will be used for the conda package name. The convention is to use lowercase names separated by dashes. | The name of the github repo of the package. | 
 | `<pkg>_CONDA_DEPENDENCIES` | The list of conda-forge dependencies required by this package. Note that dependencies managed by the robotology-superbuild should not be listed, as those are handled automatically. | The default value is empty. |
 | `<pkg>_CONDA_VERSION` | The version that will be used for the conda package, by default it is not set as the value from the tag will be extracted. | The default value is to use the value of the tag, removing any occurence of the `v` letter. |
+| `<pkg>_CONDA_ENTRY_POINTS` | This option permits to specify explicitly the entry_points used by a pure_python package (see https://github.com/robotology/robotology-superbuild/issues/1105). | Empty. |
 
 For any doubt, double check the existing `Build<pkg>.cmake` files for inspiration.
 * If your package needs to set or modify some environment variables to work correctly, it should provide a pair of [multisheller](https://github.com/wolfv/multisheller) scripts named `<condaPkgName>_activate.msh` and `<condaPkgName>_deactivate.msh` in the `conda/multisheller` directory to describe how the environment should be modified. Refer to the existing scripts for more details.


### PR DESCRIPTION
This should permit to correctly support executables created by `entry_points` in Python packages.
Furthermore, add the `robot-log-visualizer = robot_log_visualizer.__main__:main` entry_point for `robot-log-visualizer`. 

Fix https://github.com/robotology/robotology-superbuild/issues/1105.