### PR TITLE
Always uninstall pure Python packages every time they are installed

### DIFF
--- a/cmake/Buildmeshcat-python.cmake
+++ b/cmake/Buildmeshcat-python.cmake
@@ -7,7 +7,8 @@ rob_sup_pure_python_ycm_ep_helper(meshcat-python
                                   REPOSITORY rdeits/meshcat-python.git
                                   TAG master
                                   COMPONENT dynamics
-                                  FOLDER src)
+                                  FOLDER src
+                                  PYTHON_PACKAGE_NAME meshcat)
 
 
 set(meshcat-python_CONDA_PKG_NAME meshcat-python)

--- a/cmake/RobSupPurePythonYCMEPHelper.cmake
+++ b/cmake/RobSupPurePythonYCMEPHelper.cmake
@@ -7,6 +7,7 @@ A wrapper for ycm_ep_helper for pure Python projects in the robotology-superbuol
  rob_sup_pure_python_ycm_ep_helper(<name>
    [COMPONENT <component>] (default = "external")
    [FOLDER <folder> (default = "<component>")
+   [PYTHON_PACKAGE_NAME <python_package_name>] (default = "<name>")
    [REPOSITORY <repo>]
   #--Git and Hg only arguments-----------
    [TAG <tag>]
@@ -35,10 +36,15 @@ function(ROB_SUP_PURE_PYTHON_YCM_EP_HELPER _name)
   set(_oneValueArgs COMPONENT
                     FOLDER
                     REPOSITORY
-                    TAG)
+                    TAG
+                    PYTHON_PACKAGE_NAME)
   set(_multiValueArgs DEPENDS)
 
   cmake_parse_arguments(_PYH_${_name} "${_options}" "${_oneValueArgs}" "${_multiValueArgs}" "${ARGN}")
+
+  if(NOT _PYH_${_name}_PYTHON_PACKAGE_NAME)
+    set(_PYH_${_name}_PYTHON_PACKAGE_NAME ${_name})
+  endif()
 
   ycm_ep_helper(${_name} TYPE GIT
                          STYLE GITHUB
@@ -49,6 +55,10 @@ function(ROB_SUP_PURE_PYTHON_YCM_EP_HELPER _name)
                          FOLDER ${_PYH_${_name}_FOLDER}
                          # Workaround for https://github.com/robotology/robotology-superbuild/pull/1069#issuecomment-1099446237
                          CONFIGURE_COMMAND ${CMAKE_COMMAND} --version
-                         BUILD_COMMAND ${CMAKE_COMMAND} --version
+                         # To uninstall any existing package we call pip uninstall by passing the installation prefix to PYTHONPATH
+                         # See https://stackoverflow.com/questions/55708589/how-to-pass-an-environment-variable-to-externalproject-add-configure-command
+                         # See https://github.com/robotology/robotology-superbuild/issues/1118
+                         # To avoid the complexity of handling two commands, we just use the build step to uninstall any existing package
+                         BUILD_COMMAND ${CMAKE_COMMAND} -E env PYTHONPATH=${YCM_EP_INSTALL_DIR}/${ROBSUB_PYTHON_INSTALL_DIR} pip uninstall -y ${_PYH_${_name}_PYTHON_PACKAGE_NAME}
                          INSTALL_COMMAND ${Python3_EXECUTABLE} -m pip install --upgrade --no-deps --target=${YCM_EP_INSTALL_DIR}/${ROBSUB_PYTHON_INSTALL_DIR} -VV <SOURCE_DIR>)
 endfunction()


### PR DESCRIPTION
This should help to avoid problems such as the one described in https://github.com/robotology/robotology-superbuild/issues/1118 . The only downside is that during the first installation the packages are not installed, so the log will contain bogus warnings such as:
~~~
[ 71%] Skipping update step for 'pyqtconsole'
[ 71%] Performing configure step for 'pyqtconsole'
cmake version 3.22.1

CMake suite maintained and supported by Kitware (kitware.com/cmake).
[ 71%] Performing build step for 'pyqtconsole'
WARNING: Skipping pyqtconsole as it is not installed.
[ 71%] Performing install step for 'pyqtconsole'
Processing /home/straversaro/robotology-superbuild/src/pyqtconsole
  Preparing metadata (setup.py) ... done
Building wheels for collected packages: pyqtconsole
  Building wheel for pyqtconsole (setup.py) ... done
  Created wheel for pyqtconsole: filename=pyqtconsole-1.2.2-py2.py3-none-any.whl size=21407 sha256=82e4407fd315150975fa1b12c93b0646a6d915784be662aba13009b0719da38c
  Stored in directory: /tmp/pip-ephem-wheel-cache-_nm2mmsi/wheels/8d/d0/6b/61c471e66ae04447be88dff16646a5f1b17560fde46086d0ce
Successfully built pyqtconsole
Installing collected packages: pyqtconsole
Successfully installed pyqtconsole-1.2.2
[ 71%] Completed 'pyqtconsole'
~~~

I did not find I to suppress that output, but I think it is a minor problem w.r.t. to the problem that it solves.