### PR TITLE
Add setuptools-scm dependency in pure python conda template and pyqtwebengine to robot-log-visualizer conda dependencies

### DIFF
--- a/cmake/Buildrobot-log-visualizer.cmake
+++ b/cmake/Buildrobot-log-visualizer.cmake
@@ -18,5 +18,5 @@ rob_sup_pure_python_ycm_ep_helper(robot-log-visualizer
                                   COMPONENT dynamics
                                   FOLDER src)
 
-set(robot-log-visualizer_CONDA_DEPENDENCIES numpy pyqt matplotlib h5py)
+set(robot-log-visualizer_CONDA_DEPENDENCIES numpy pyqt pyqtwebengine matplotlib h5py)
 set(robot-log-visualizer_CONDA_ENTRY_POINTS "robot-log-visualizer = robot_log_visualizer.__main__:main")

--- a/conda/pure_python_recipe_template/meta.yaml
+++ b/conda/pure_python_recipe_template/meta.yaml
@@ -23,6 +23,7 @@ requirements:
   host:
     - python
     - pip
+    - setuptools-scm
 {% for dep in dependencies %}    - {{ dep }}
 {% endfor %}
   run:


### PR DESCRIPTION
Fix https://github.com/robotology/robotology-superbuild/issues/1122 .