### PR TITLE
Switch PROJECT_TAGS Stable to use YARP 3.7

### DIFF
--- a/cmake/ProjectsTagsStable.cmake
+++ b/cmake/ProjectsTagsStable.cmake
@@ -14,8 +14,8 @@ set_tag(casadi 3.5.5.3)
 
 # Robotology projects
 set_tag(YCM_TAG ycm-0.14)
-set_tag(YARP_TAG yarp-3.6)
-set_tag(yarp-matlab-bindings_TAG yarp-3.6)
+set_tag(YARP_TAG yarp-3.7)
+set_tag(yarp-matlab-bindings_TAG yarp-3.7)
 set_tag(gym-ignition_TAG v1.2.2)
 set_tag(YARP_telemetry_TAG v0.5.1)
 set_tag(robometry_TAG v1.0.0)

--- a/releases/latest.releases.yaml
+++ b/releases/latest.releases.yaml
@@ -30,7 +30,7 @@ repositories:
   YARP:
     type: git
     url: https://github.com/robotology/yarp.git
-    version: v3.6.0
+    version: v3.7.0
   ICUB:
     type: git
     url: https://github.com/robotology/icub-main.git
@@ -54,7 +54,7 @@ repositories:
   yarp-matlab-bindings:
     type: git
     url: https://github.com/robotology/yarp-matlab-bindings.git
-    version: v3.6.1
+    version: v3.7.0
   RobotTestingFramework:
     type: git
     url: https://github.com/robotology/robot-testing-framework.git


### PR DESCRIPTION
YARP 3.7.0 was released recently: https://github.com/robotology/community/discussions/579 .