### PR TITLE
Add missing Ubuntu 20.04 apt dependencies

### DIFF
--- a/apt.txt
+++ b/apt.txt
@@ -3,6 +3,7 @@ build-essential
 cmake
 cmake-curses-gui
 coinor-libipopt-dev
+gfortran
 freeglut3-dev
 git
 libace-dev

--- a/apt.txt
+++ b/apt.txt
@@ -35,6 +35,7 @@ qml-module-qtquick2
 qtbase5-dev
 qtdeclarative5-dev
 qtmultimedia5-dev
+libqt5opengl5-dev
 swig
 libmatio-dev
 libirrlicht-dev


### PR DESCRIPTION
I'm trying to build the `v2021.11.0` tag of the superbuild in a clean docker image with the following command:

```dockerfile

RUN git clone -b ${SUPERBUILD_TAG} https://github.com/robotology/robotology-superbuild &&\
    cd robotology-superbuild &&\
    sudo bash ./scripts/install_apt_dependencies.sh &&\
    sudo rm -rf /var/lib/apt/lists/*

RUN cd robotology-superbuild &&\
    cmake -S . -B build \
        -GNinja \
        -DNON_INTERACTIVE_BUILD:BOOL=ON \
        -DYCM_DISABLE_SYSTEM_PACKAGES:BOOL=ON \
        -DROBOTOLOGY_USES_GAZEBO:BOOL=ON \
        -DROBOTOLOGY_USES_MATLAB:BOOL=ON \
        -DROBOTOLOGY_USES_PYTHON:BOOL=ON \
        -DROBOTOLOGY_ENABLE_DYNAMICS:BOOL=ON \
        -DROBOTOLOGY_ENABLE_HUMAN_DYNAMICS:BOOL=ON \
        -DROBOTOLOGY_ENABLE_DYNAMICS_FULL_DEPS:BOOL=ON \
    &&\
    cmake --build build/ &&\
    find build/src/ -type f -not -name 'CMakeCache.txt' -delete
```

## Error compiling `yarpmanager`

```
[595/1154] Building CXX object src/yarpmanager/CMakeFiles/yarpmanager.dir/yarpmanager_autogen/mocs_compilation.cpp.o
FAILED: src/yarpmanager/CMakeFiles/yarpmanager.dir/yarpmanager_autogen/mocs_compilation.cpp.o 
/usr/bin/c++  -DBUILDING_YARP -DQT_CORE_LIB -DQT_GUI_LIB -DQT_NO_DEBUG -DQT_WIDGETS_LIB -Isrc/yarpmanager/yarpmanager_autogen/include -I/home/matlab/isaac/robotology-superbuild/src/YARP/src/yarpmanager/src-builder -I/home/matlab/isaac/robotology-superbuild/src/YARP/src/yarpmanager/src-manager -Isrc/yarpmanager -I/home/matlab/isaac/robotology-superbuild/src/YARP/src/libYARP_os/src -I/home/matlab/isaac/robotology-superbuild/src/YARP/src/libYARP_conf/src -Isrc/libYARP_conf/src -I/home/matlab/isaac/robotology-superbuild/src/YARP/src/libYARP_manager/src -I/home/matlab/isaac/robotology-superbuild/src/YARP/src/libYARP_profiler/src -isystem /usr/include/x86_64-linux-gnu/qt5 -isystem /usr/include/x86_64-linux-gnu/qt5/QtWidgets -isystem /usr/include/x86_64-linux-gnu/qt5/QtGui -isystem /usr/include/x86_64-linux-gnu/qt5/QtCore -isystem /usr/lib/x86_64-linux-gnu/qt5/mkspecs/linux-g++ -Wall -Wextra -Wsign-compare -Wpointer-arith -Winit-self -Wnon-virtual-dtor -Wcast-align -Wunused -Wunused-but-set-variable -Wvla -Wmissing-include-dirs -Wlogical-op -Wreorder -Wsizeof-pointer-memaccess -Woverloaded-virtual -Wundef -Wredundant-decls -Wunknown-pragmas -Wunused-result -Wc++17-compat -Wignored-attributes -Wdangling-else -Wmisleading-indentation -Wtautological-compare -Wsuggest-override -Wmaybe-uninitialized  -Wno-unused-parameter  -Wdeprecated-declarations  -O3 -DNDEBUG -fPIE -fvisibility=hidden -fvisibility-inlines-hidden   -fPIC -std=c++14 -MD -MT src/yarpmanager/CMakeFiles/yarpmanager.dir/yarpmanager_autogen/mocs_compilation.cpp.o -MF src/yarpmanager/CMakeFiles/yarpmanager.dir/yarpmanager_autogen/mocs_compilation.cpp.o.d -o src/yarpmanager/CMakeFiles/yarpmanager.dir/yarpmanager_autogen/mocs_compilation.cpp.o -c src/yarpmanager/yarpmanager_autogen/mocs_compilation.cpp
In file included from src/yarpmanager/yarpmanager_autogen/2BYEQ6JWEJ/moc_builderwindow.cpp:9,
                 from src/yarpmanager/yarpmanager_autogen/mocs_compilation.cpp:3:
/home/matlab/isaac/robotology-superbuild/src/YARP/src/yarpmanager/src-builder/builderwindow.h:16:10: fatal error: QtOpenGL/QGLWidget: No such file or directory
   16 | #include <QtOpenGL/QGLWidget>
      |          ^~~~~~~~~~~~~~~~~~~~
compilation terminated.
```

It seems that the `libqt5opengl5-dev` package required by `yarpmanager` is missing from the dependency list.

## Error compiling the ipopt plugin of `casadi`

```
[9/46] Linking CXX shared library lib/libcasadi_nlpsol_ipopt.so.3.6
FAILED: lib/libcasadi_nlpsol_ipopt.so.3.6 
: && /usr/bin/c++ -fPIC -fPIC -fvisibility=hidden -fvisibility-inlines-hidden  -O3 -DNDEBUG   -shared -Wl,-soname,libcasadi_nlpsol_ipopt.so.3.6 -o lib/libcasadi_nlpsol_ipopt.so.3.6 casadi/interfaces/ipopt/CMakeFiles/casadi_nlpsol_ipopt.dir/ipopt_interface.cpp.o casadi/interfaces/ipopt/CMakeFiles/casadi_nlpsol_ipopt.dir/ipopt_nlp.cpp.o casadi/interfaces/ipopt/CMakeFiles/casadi_nlpsol_ipopt.dir/ipopt_interface_meta.cpp.o -L/usr/lib/gcc/lib -Wl,-rpath,/usr/lib/gcc/lib:/home/matlab/isaac/robotology-superbuild/build/src/casadi/lib:  lib/libcasadi.so.3.6  -lipopt  -ldmumps_seq  -lblas  -llapack  -lblas  -ldmumps_seq  -ldl  -lgfortran  -lm  -lquadmath  -lblas  -lm  -ldl  -ldmumps_seq  -llapack  -lgfortran  -lquadmath  -ldl && :
/usr/bin/ld: cannot find -lgfortran
collect2: error: ld returned 1 exit status
```

Having the following dependencies installed from the previous steps of the docker image:

```
matlab@4d251a1ccceb:~$ dpkg -l | grep gfortran
ii  gfortran-8                               8.4.0-3ubuntu2                    amd64        GNU Fortran compiler
ii  libgfortran-8-dev:amd64                  8.4.0-3ubuntu2                    amd64        Runtime library for GNU Fortran applications (development files)
ii  libgfortran5:amd64                       10.3.0-1ubuntu1~20.04             amd64        Runtime library for GNU Fortran applications
```

the error is solved by installing `gfortran` metapackage that installs `gfortran-9 libgfortran-9-dev`. 