### PR TITLE
Bump CppAD version to 20220000.4

### DIFF
--- a/cmake/ProjectsTagsStable.cmake
+++ b/cmake/ProjectsTagsStable.cmake
@@ -9,7 +9,7 @@ set_tag(osqp_TAG v0.6.2)
 set_tag(manif_REPOSITORY robotology-dependencies/manif.git)
 set_tag(manif_TAG 0.0.4.1)
 set_tag(qhull_TAG 2020.2)
-set_tag(CppAD_TAG 20220000.3)
+set_tag(CppAD_TAG 20220000.4)
 set_tag(casadi 3.5.5.3)
 
 # Robotology projects

--- a/cmake/ProjectsTagsUnstable.cmake
+++ b/cmake/ProjectsTagsUnstable.cmake
@@ -9,7 +9,7 @@ set_tag(osqp_TAG v0.6.2)
 set_tag(manif_REPOSITORY robotology-dependencies/manif.git)
 set_tag(manif_TAG 0.0.4.1)
 set_tag(qhull_TAG 2020.2)
-set_tag(CppAD_TAG 20220000.3)
+set_tag(CppAD_TAG 20220000.4)
 set_tag(casadi 3.5.5.3)
 
 # Robotology projects

--- a/releases/latest.releases.yaml
+++ b/releases/latest.releases.yaml
@@ -18,7 +18,7 @@ repositories:
   CppAD:
     type: git
     url: https://github.com/coin-or/CppAD.git
-    version: 20220000.3
+    version: 20220000.4
   casadi:
     type: git
     url: https://github.com/ami-iit/casadi.git


### PR DESCRIPTION
For consistency with conda-forge: https://github.com/conda-forge/cppad-feedstock/pull/16 .