### PR TITLE
Add test for MATLAB one line installer

### DIFF
--- a/.github/workflows/matlab-one-line-install-test.yml
+++ b/.github/workflows/matlab-one-line-install-test.yml
@@ -49,6 +49,12 @@ jobs:
             cd scripts
             install_robotology_packages()
             
+      # workaround for https://github.com/robotology/robotology-superbuild/issues/64
+      # and https://github.com/robotology/idyntree/issues/995
+      - name: Do not use MATLAB's stdc++ to avoid incompatibilities with other libraries
+        if: contains(matrix.os, 'ubuntu')
+        run:
+          echo "LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libstdc++.so.6" >> $GITHUB_ENV
      
       - name: Run MATLAB commands
         uses: matlab-actions/run-command@v1

--- a/.github/workflows/matlab-one-line-install-test.yml
+++ b/.github/workflows/matlab-one-line-install-test.yml
@@ -54,5 +54,6 @@ jobs:
         uses: matlab-actions/run-command@v1
         with:
           command: |
+            robotology_setup
             pos = iDynTree.Position()
             vec = yarp.Vector()

--- a/.github/workflows/matlab-one-line-install-test.yml
+++ b/.github/workflows/matlab-one-line-install-test.yml
@@ -54,6 +54,7 @@ jobs:
         uses: matlab-actions/run-command@v1
         with:
           command: |
+            cd scripts
             robotology_setup
             pos = iDynTree.Position()
             vec = yarp.Vector()

--- a/.github/workflows/matlab-one-line-install-test.yml
+++ b/.github/workflows/matlab-one-line-install-test.yml
@@ -1,13 +1,18 @@
 name: MATLAB tests
 
 on:
+  workflow_dispatch:
   push:
     branches:
-            - main
-            - CI
+      - master
+      - 'releases/**'
+    tags:
+      - v*
   pull_request:
-    branches:
-            - main
+  schedule:
+  # * is a special character in YAML so you have to quote this string
+  # Execute a "nightly" build at 2 AM UTC 
+  - cron:  '0 2 * * *'
 
 
 jobs:

--- a/.github/workflows/matlab-one-line-install-test.yml
+++ b/.github/workflows/matlab-one-line-install-test.yml
@@ -27,10 +27,6 @@ jobs:
         matlab_version: [R2020b, R2021a, R2021b, latest]
     runs-on: ${{ matrix.os }}
     
-    defaults:
-      run:
-        shell: bash -l {0}
-
     steps:
 
       - name: Check out repository

--- a/.github/workflows/matlab-one-line-install-test.yml
+++ b/.github/workflows/matlab-one-line-install-test.yml
@@ -25,6 +25,10 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         matlab_version: [R2020b, R2021a, R2021b, latest]
+        exclude:
+          # R2020* is not supported on Windows on GitHub Actions
+          - os: windows-latest
+            matlab_version: R2020b
     runs-on: ${{ matrix.os }}
     
     steps:

--- a/.github/workflows/matlab-one-line-install-test.yml
+++ b/.github/workflows/matlab-one-line-install-test.yml
@@ -1,0 +1,53 @@
+name: MATLAB tests
+
+on:
+  push:
+    branches:
+            - main
+            - CI
+  pull_request:
+    branches:
+            - main
+
+
+jobs:
+
+  run-matlab-test:
+
+    name: Install dependencies and run MATLAB tests
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        matlab_version: [R2020b, R2021a, R2021b, latest]
+    runs-on: ${{ matrix.os }}
+    
+    defaults:
+      run:
+        shell: bash -l {0}
+
+    steps:
+
+      - name: Check out repository
+        uses: actions/checkout@v2
+
+      - name: Install MATLAB
+        uses: matlab-actions/setup-matlab@v1
+        with:
+          release: ${{ matrix.matlab_version }}
+
+
+      - name: Install robotology packages
+        uses: matlab-actions/run-command@v1
+        with:
+          command: |
+            cd scripts
+            install_robotology_packages()
+            
+     
+      - name: Run MATLAB commands
+        uses: matlab-actions/run-command@v1
+        with:
+          command: |
+            pos = iDynTree.Position()
+            vec = yarp.Vector()

--- a/.github/workflows/matlab-one-line-install-test.yml
+++ b/.github/workflows/matlab-one-line-install-test.yml
@@ -1,4 +1,4 @@
-name: MATLAB tests
+name: Test One-line Installation of Robotology MATLAB/Simulink Packages
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
@FabioBergonti experiened problems in using a similar script to what describe in https://github.com/robotology/robotology-superbuild/blob/master/doc/matlab-one-line-install.md in CI, so better to test it at the source.