### PR TITLE
Switch MATLAB one-line install to mamba

### DIFF
--- a/.github/workflows/matlab-one-line-install-test.yml
+++ b/.github/workflows/matlab-one-line-install-test.yml
@@ -49,6 +49,12 @@ jobs:
             cd scripts
             install_robotology_packages()
             
+      # workaround for https://github.com/robotology/robotology-superbuild/issues/64
+      # and https://github.com/robotology/idyntree/issues/995
+      - name: Do not use MATLAB's stdc++ to avoid incompatibilities with other libraries
+        if: contains(matrix.os, 'ubuntu')
+        run:
+          echo "LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libstdc++.so.6" >> $GITHUB_ENV
      
       - name: Run MATLAB commands
         uses: matlab-actions/run-command@v1

--- a/.github/workflows/matlab-one-line-install-test.yml
+++ b/.github/workflows/matlab-one-line-install-test.yml
@@ -54,5 +54,6 @@ jobs:
         uses: matlab-actions/run-command@v1
         with:
           command: |
+            robotology_setup
             pos = iDynTree.Position()
             vec = yarp.Vector()

--- a/.github/workflows/matlab-one-line-install-test.yml
+++ b/.github/workflows/matlab-one-line-install-test.yml
@@ -54,6 +54,7 @@ jobs:
         uses: matlab-actions/run-command@v1
         with:
           command: |
+            cd scripts
             robotology_setup
             pos = iDynTree.Position()
             vec = yarp.Vector()

--- a/.github/workflows/matlab-one-line-install-test.yml
+++ b/.github/workflows/matlab-one-line-install-test.yml
@@ -1,13 +1,18 @@
 name: MATLAB tests
 
 on:
+  workflow_dispatch:
   push:
     branches:
-            - main
-            - CI
+      - master
+      - 'releases/**'
+    tags:
+      - v*
   pull_request:
-    branches:
-            - main
+  schedule:
+  # * is a special character in YAML so you have to quote this string
+  # Execute a "nightly" build at 2 AM UTC 
+  - cron:  '0 2 * * *'
 
 
 jobs:

--- a/.github/workflows/matlab-one-line-install-test.yml
+++ b/.github/workflows/matlab-one-line-install-test.yml
@@ -35,6 +35,12 @@ jobs:
 
       - name: Check out repository
         uses: actions/checkout@v2
+        
+      - name: Clone Robotology in long path
+        run: |
+          git clone https://github.com/robotology/robotology-superbuild.git robotology-superbuild-with-a-long-name-really-really-really-long-not-short-long
+          cd robotology-superbuild-with-a-long-name-really-really-really-long-not-short-long
+          git checkout onelineinstallswitchtomamba
 
       - name: Install MATLAB
         uses: matlab-actions/setup-matlab@v1
@@ -46,6 +52,7 @@ jobs:
         uses: matlab-actions/run-command@v1
         with:
           command: |
+            cd robotology-superbuild-with-a-long-name-really-really-really-long-not-short-long
             cd scripts
             install_robotology_packages()
             
@@ -60,6 +67,7 @@ jobs:
         uses: matlab-actions/run-command@v1
         with:
           command: |
+            cd robotology-superbuild-with-a-long-name-really-really-really-long-not-short-long
             cd scripts
             robotology_setup
             pos = iDynTree.Position()

--- a/.github/workflows/matlab-one-line-install-test.yml
+++ b/.github/workflows/matlab-one-line-install-test.yml
@@ -27,10 +27,6 @@ jobs:
         matlab_version: [R2020b, R2021a, R2021b, latest]
     runs-on: ${{ matrix.os }}
     
-    defaults:
-      run:
-        shell: bash -l {0}
-
     steps:
 
       - name: Check out repository

--- a/.github/workflows/matlab-one-line-install-test.yml
+++ b/.github/workflows/matlab-one-line-install-test.yml
@@ -25,6 +25,10 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         matlab_version: [R2020b, R2021a, R2021b, latest]
+        exclude:
+          # R2020* is not supported on Windows on GitHub Actions
+          - os: windows-latest
+            matlab_version: R2020b
     runs-on: ${{ matrix.os }}
     
     steps:

--- a/.github/workflows/matlab-one-line-install-test.yml
+++ b/.github/workflows/matlab-one-line-install-test.yml
@@ -1,0 +1,53 @@
+name: MATLAB tests
+
+on:
+  push:
+    branches:
+            - main
+            - CI
+  pull_request:
+    branches:
+            - main
+
+
+jobs:
+
+  run-matlab-test:
+
+    name: Install dependencies and run MATLAB tests
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        matlab_version: [R2020b, R2021a, R2021b, latest]
+    runs-on: ${{ matrix.os }}
+    
+    defaults:
+      run:
+        shell: bash -l {0}
+
+    steps:
+
+      - name: Check out repository
+        uses: actions/checkout@v2
+
+      - name: Install MATLAB
+        uses: matlab-actions/setup-matlab@v1
+        with:
+          release: ${{ matrix.matlab_version }}
+
+
+      - name: Install robotology packages
+        uses: matlab-actions/run-command@v1
+        with:
+          command: |
+            cd scripts
+            install_robotology_packages()
+            
+     
+      - name: Run MATLAB commands
+        uses: matlab-actions/run-command@v1
+        with:
+          command: |
+            pos = iDynTree.Position()
+            vec = yarp.Vector()

--- a/.github/workflows/matlab-one-line-install-test.yml
+++ b/.github/workflows/matlab-one-line-install-test.yml
@@ -1,4 +1,4 @@
-name: MATLAB tests
+name: Test One-line Installation of Robotology MATLAB/Simulink Packages
 
 on:
   workflow_dispatch:

--- a/scripts/install_robotology_packages.m
+++ b/scripts/install_robotology_packages.m
@@ -58,13 +58,13 @@ function install_robotology_packages(varargin)
     fprintf('Installing mambaforge\n');
     if ispc
         system(sprintf('start /wait "" %s /InstallationType=JustMe /RegisterPython=0 /S /D=%s', mambaforge_installer_name, install_prefix));
-        conda_full_path = fullfile(install_prefix, 'condabin', 'mamba.bat');
+        conda_full_path = fullfile(install_prefix, 'condabin', 'conda.bat');
         % On Windows, the files in conda are installed in the Library
         % subdirectory of the prefix
         robotology_install_prefix = fullfile(install_prefix, 'Library');
     elseif isunix
         system(sprintf('sh %s -b -p "%s"', mambaforge_installer_name, install_prefix));
-        conda_full_path = fullfile(install_prefix, 'condabin', 'mamba');
+        conda_full_path = fullfile(install_prefix, 'condabin', 'conda');
         robotology_install_prefix = install_prefix;
     end
     fprintf('Installation of mambaforge completed\n');

--- a/scripts/install_robotology_packages.m
+++ b/scripts/install_robotology_packages.m
@@ -58,13 +58,13 @@ function install_robotology_packages(varargin)
     fprintf('Installing mambaforge\n');
     if ispc
         system(sprintf('start /wait "" %s /InstallationType=JustMe /RegisterPython=0 /S /D=%s', mambaforge_installer_name, install_prefix));
-        conda_full_path = fullfile(install_prefix, 'condabin', 'conda.bat');
+        conda_full_path = fullfile(install_prefix, 'condabin', 'mamba.bat');
         % On Windows, the files in conda are installed in the Library
         % subdirectory of the prefix
         robotology_install_prefix = fullfile(install_prefix, 'Library');
     elseif isunix
         system(sprintf('sh %s -b -p "%s"', mambaforge_installer_name, install_prefix));
-        conda_full_path = fullfile(install_prefix, 'bin', 'conda');
+        conda_full_path = fullfile(install_prefix, 'condabin', 'mamba');
         robotology_install_prefix = install_prefix;
     end
     fprintf('Installation of mambaforge completed\n');


### PR DESCRIPTION
Let's check if https://github.com/robotology/robotology-superbuild/pull/1144 is working fine or not even if we switch to mamba.