### PR TITLE
Switch MATLAB one-line install to mamba (take two)

### DIFF
--- a/scripts/install_robotology_packages.m
+++ b/scripts/install_robotology_packages.m
@@ -58,14 +58,14 @@ function install_robotology_packages(varargin)
     fprintf('Installing mambaforge\n');
     if ispc
         system(sprintf('start /wait "" %s /InstallationType=JustMe /RegisterPython=0 /S /D=%s', mambaforge_installer_name, install_prefix));
-        conda_full_path = fullfile(install_prefix, 'condabin', 'conda.bat');
+        conda_full_path = fullfile(install_prefix, 'condabin', 'mamba.bat');
         % On Windows, the files in conda are installed in the Library
         % subdirectory of the prefix
         robotology_install_prefix = fullfile(install_prefix, 'Library');
     elseif isunix
         system(sprintf('sh %s -b -p "%s"', mambaforge_installer_name, install_prefix));
         assert(length(['#!',install_prefix,'/bin python'])<=127,'install_prefix path is too long! Shebangs cannot be longer than 127 characters (see https://github.com/robotology/robotology-superbuild/pull/1145)')        
-        conda_full_path = fullfile(install_prefix, 'bin', 'conda');
+        conda_full_path = fullfile(install_prefix, 'condabin', 'mamba');
         robotology_install_prefix = install_prefix;
     end
     fprintf('Installation of mambaforge completed\n');


### PR DESCRIPTION
Now that mamba is more stable, it should ensure a faster installation of packages.