### PR TITLE
Switch to ubuntu-22.04 for workaround of matlab one line install job

### DIFF
--- a/.github/workflows/matlab-one-line-install-test.yml
+++ b/.github/workflows/matlab-one-line-install-test.yml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-22.04, macos-latest, windows-latest]
         matlab_version: [R2020b, R2021a, R2021b, latest]
         exclude:
           # R2020* is not supported on Windows on GitHub Actions


### PR DESCRIPTION
Workaround for https://github.com/robotology/robotology-superbuild/issues/1159 .