### PR TITLE
Add libqt5multimedia5-plugins to apt-python.txt

### DIFF
--- a/apt-python.txt
+++ b/apt-python.txt
@@ -13,3 +13,4 @@ python3-u-msgpack
 python3-tornado
 python3-zmq
 python3-ipython
+libqt5multimedia5-plugins


### PR DESCRIPTION
As it is required by robot-log-visualizer, see https://github.com/robotology/robotology-superbuild/issues/1163 .