### PR TITLE
Add libqt5multimedia5-plugins to apt-python.txt (2022.05 backport)

### DIFF
--- a/apt-python.txt
+++ b/apt-python.txt
@@ -13,3 +13,4 @@ python3-u-msgpack
 python3-tornado
 python3-zmq
 python3-ipython
+libqt5multimedia5-plugins


### PR DESCRIPTION
Backport of https://github.com/robotology/robotology-superbuild/pull/1164 for 2022.05.2 release.