### PR TITLE
Switch to graphviz 2.50 to avoid compilation problems

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,7 +77,7 @@ jobs:
         # Compilation related dependencies 
         mamba install cmake compilers make ninja pkg-config
         # Actual dependencies
-        mamba install ace asio assimp boost eigen freetype gazebo glew glfw glm graphviz=2.50 gsl ipopt irrlicht libjpeg-turbo libmatio libode libxml2 nlohmann_json opencv pkg-config portaudio qt-main sdl sdl2 sqlite tinyxml spdlog lua soxr
+        mamba install ace asio assimp boost eigen freetype gazebo glew glfw glm graphviz gsl ipopt irrlicht libjpeg-turbo libmatio libode libxml2 nlohmann_json opencv pkg-config portaudio qt-main sdl sdl2 sqlite tinyxml spdlog lua soxr
         # Python 
         mamba install python numpy swig pybind11 pyqt matplotlib h5py tornado u-msgpack-python pyzmq ipython
 
@@ -98,7 +98,7 @@ jobs:
       shell: bash -l {0}
       run: |
         # Additional dependencies only useful on Windows
-        mamba install -c conda-forge -c robotology esdcan freeglut
+        mamba install -c conda-forge -c robotology esdcan freeglut graphviz=2.50
 
     - name: Print used environment [Conda]
       shell: bash -l {0}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,7 +77,7 @@ jobs:
         # Compilation related dependencies 
         mamba install cmake compilers make ninja pkg-config
         # Actual dependencies
-        mamba install ace asio assimp boost eigen freetype gazebo glew glfw glm graphviz gsl ipopt irrlicht libjpeg-turbo libmatio libode libxml2 nlohmann_json opencv pkg-config portaudio qt-main sdl sdl2 sqlite tinyxml spdlog lua soxr
+        mamba install ace asio assimp boost eigen freetype gazebo glew glfw glm graphviz=3 gsl ipopt irrlicht libjpeg-turbo libmatio libode libxml2 nlohmann_json opencv pkg-config portaudio qt-main sdl sdl2 sqlite tinyxml spdlog lua soxr
         # Python 
         mamba install python numpy swig pybind11 pyqt matplotlib h5py tornado u-msgpack-python pyzmq ipython
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,7 +77,7 @@ jobs:
         # Compilation related dependencies 
         mamba install cmake compilers make ninja pkg-config
         # Actual dependencies
-        mamba install ace asio assimp boost eigen freetype gazebo glew glfw glm graphviz=3 gsl ipopt irrlicht libjpeg-turbo libmatio libode libxml2 nlohmann_json opencv pkg-config portaudio qt-main sdl sdl2 sqlite tinyxml spdlog lua soxr
+        mamba install ace asio assimp boost eigen freetype gazebo glew glfw glm graphviz=2.50 gsl ipopt irrlicht libjpeg-turbo libmatio libode libxml2 nlohmann_json opencv pkg-config portaudio qt-main sdl sdl2 sqlite tinyxml spdlog lua soxr
         # Python 
         mamba install python numpy swig pybind11 pyqt matplotlib h5py tornado u-msgpack-python pyzmq ipython
 

--- a/doc/conda-forge.md
+++ b/doc/conda-forge.md
@@ -112,7 +112,7 @@ of the robotology-superbuild.**
 Once you activated it, you can install packages in it. In particular the dependencies for the robotology-superbuild can be installed as:
 ~~~
 mamba install -c conda-forge cmake compilers make ninja pkg-config
-mamba install -c conda-forge ace asio assimp boost eigen freetype gazebo glew glfw glm graphviz gsl ipopt irrlicht libjpeg-turbo libmatio libode libxml2 nlohmann_json opencv pkg-config portaudio qt-main sdl sdl2 sqlite tinyxml spdlog lua soxr
+mamba install -c conda-forge ace asio assimp boost eigen freetype gazebo glew glfw glm graphviz=3 gsl ipopt irrlicht libjpeg-turbo libmatio libode libxml2 nlohmann_json opencv pkg-config portaudio qt-main sdl sdl2 sqlite tinyxml spdlog lua soxr
 ~~~
 
 If you are on **Linux**, you also need to install also the following packages:

--- a/doc/conda-forge.md
+++ b/doc/conda-forge.md
@@ -112,7 +112,7 @@ of the robotology-superbuild.**
 Once you activated it, you can install packages in it. In particular the dependencies for the robotology-superbuild can be installed as:
 ~~~
 mamba install -c conda-forge cmake compilers make ninja pkg-config
-mamba install -c conda-forge ace asio assimp boost eigen freetype gazebo glew glfw glm graphviz=2.50 gsl ipopt irrlicht libjpeg-turbo libmatio libode libxml2 nlohmann_json opencv pkg-config portaudio qt-main sdl sdl2 sqlite tinyxml spdlog lua soxr
+mamba install -c conda-forge ace asio assimp boost eigen freetype gazebo glew glfw glm graphviz gsl ipopt irrlicht libjpeg-turbo libmatio libode libxml2 nlohmann_json opencv pkg-config portaudio qt-main sdl sdl2 sqlite tinyxml spdlog lua soxr
 ~~~
 
 If you are on **Linux**, you also need to install also the following packages:
@@ -122,7 +122,7 @@ mamba install -c conda-forge bash-completion freeglut libdc1394 libi2c expat-cos
 
 If you are on **Windows**, you also need to install also the following packages:
 ~~~
-mamba install -c conda-forge freeglut
+mamba install -c conda-forge freeglut graphviz=2.50
 ~~~
 
 ### Clone the repo

--- a/doc/conda-forge.md
+++ b/doc/conda-forge.md
@@ -112,7 +112,7 @@ of the robotology-superbuild.**
 Once you activated it, you can install packages in it. In particular the dependencies for the robotology-superbuild can be installed as:
 ~~~
 mamba install -c conda-forge cmake compilers make ninja pkg-config
-mamba install -c conda-forge ace asio assimp boost eigen freetype gazebo glew glfw glm graphviz=3 gsl ipopt irrlicht libjpeg-turbo libmatio libode libxml2 nlohmann_json opencv pkg-config portaudio qt-main sdl sdl2 sqlite tinyxml spdlog lua soxr
+mamba install -c conda-forge ace asio assimp boost eigen freetype gazebo glew glfw glm graphviz=2.50 gsl ipopt irrlicht libjpeg-turbo libmatio libode libxml2 nlohmann_json opencv pkg-config portaudio qt-main sdl sdl2 sqlite tinyxml spdlog lua soxr
 ~~~
 
 If you are on **Linux**, you also need to install also the following packages:


### PR DESCRIPTION
graphviz 4 have a breaking change that will be reverted in a following release (see https://github.com/robotology/robotology-superbuild/issues/1152), so it does not make sense to try to be compatible with graphviz 4 at this moment.