### PR TITLE
Switch to use YARP conda-forge binary package when generating conda packages

### DIFF
--- a/.github/workflows/generate-conda-packages.yaml
+++ b/.github/workflows/generate-conda-packages.yaml
@@ -151,8 +151,6 @@ jobs:
             # specifically because we can't use --skip-existing as these packages are part of the robotology channel
             conda mambabuild -m ${CONDA_PREFIX}/conda_build_config.yaml -m ${GITHUB_WORKSPACE}/conda/conda_build_config.yml robot-log-visualizer
             rm -rf robot-log-visualizer
-            conda mambabuild -m ${CONDA_PREFIX}/conda_build_config.yaml -m ${GITHUB_WORKSPACE}/conda/conda_build_config.yml yarp
-            rm -rf yarp
             conda mambabuild -m ${CONDA_PREFIX}/conda_build_config.yaml -m ${GITHUB_WORKSPACE}/conda/conda_build_config.yml gazebo-yarp-plugins
             rm -rf gazebo-yarp-plugins
             conda mambabuild -m ${CONDA_PREFIX}/conda_build_config.yaml -m ${GITHUB_WORKSPACE}/conda/conda_build_config.yml idyntree-matlab-bindings

--- a/cmake/BuildYARP.cmake
+++ b/cmake/BuildYARP.cmake
@@ -119,17 +119,5 @@ ycm_ep_helper(YARP TYPE GIT
                               -DENABLE_yarpmod_usbCameraRaw:BOOL=${ENABLE_USBCAMERA}
                               ${YARP_OPTIONAL_CMAKE_ARGS})
 
-set(YARP_CONDA_DEPENDENCIES ace libopencv tinyxml qt-main eigen sdl sdl2 sqlite libjpeg-turbo)
-
-if(ROBOTOLOGY_USES_PYTHON)
-  list(APPEND YARP_CONDA_DEPENDENCIES swig)
-  list(APPEND YARP_CONDA_DEPENDENCIES python)
-endif()
-
-if(NOT WIN32)
-  list(APPEND YARP_CONDA_DEPENDENCIES bash-completion)
-endif()
-
-if(YARP_USE_I2C)
-  list(APPEND YARP_CONDA_DEPENDENCIES libi2c)
-endif()
+set(YARP_CONDA_PKG_NAME yarp-cxx)
+set(YARP_CONDA_PKG_CONDA_FORGE_OVERRIDE ON)


### PR DESCRIPTION
As https://github.com/conda-forge/staged-recipes/pull/18234 will hopefully be soon merged, we can finally fix https://github.com/robotology/robotology-superbuild/issues/752 and https://github.com/robotology/robotology-superbuild/issues/1094 .

In general, the changes are similar to https://github.com/robotology/robotology-superbuild/pull/807 but for YARP.
