### PR TITLE
apt.txt: add libsqlite3-dev

### DIFF
--- a/apt.txt
+++ b/apt.txt
@@ -60,3 +60,4 @@ libglfw3-dev
 libglew-dev
 libglm-dev
 libfreetype6-dev
+libsqlite3-dev


### PR DESCRIPTION
It is a YARP dependency that was missing from `apt.txt`