### PR TITLE
Do not pin multisheller, mamba and boa versions in Generate Conda Packages CI jobs

### DIFF
--- a/.github/workflows/generate-conda-packages.yaml
+++ b/.github/workflows/generate-conda-packages.yaml
@@ -102,11 +102,7 @@ jobs:
         - name: Dependencies for conda recipes generation and upload
           shell: bash -l {0}
           run: |
-            # Pin mamba and boa versions
-            # to avoid https://github.com/robotology/robotology-superbuild/issues/927#issuecomment-979765045
-            mamba install pyyaml jinja2 conda-build ninja anaconda-client conda-forge-pinning mamba=0.17 boa=0.7
-            # Use multisheller version that include the fix https://github.com/mamba-org/multisheller/pull/13
-            python -m pip install git+https://github.com/mamba-org/multisheller.git@31883c2fe325464a8d3510380afdc83e8f64c349
+            mamba install pyyaml jinja2 conda-build ninja anaconda-client conda-forge-pinning mamba boa multisheller
 
         - name: Print used environment
           shell: bash -l {0}
@@ -143,7 +139,6 @@ jobs:
           run: |
             cd build
             cmake -DCONDA_GENERATE_ROBOTOLOGY_METAPACKAGES:BOOL=ON .
-
 
         - name: Fail if both upload_conda_binaries and test_metapackages_generation are passed
           if: github.event_name == 'workflow_dispatch' && github.event.inputs.test_metapackages_generation == 'true' && github.event.inputs.upload_conda_binaries == 'true'


### PR DESCRIPTION
This versions were pinned to workaround problems with older versions, but now everything should be working fine. 

Fix https://github.com/robotology/robotology-superbuild/issues/1061 .

This PR builds on top of https://github.com/robotology/robotology-superbuild/pull/1170, so it first requires that one to be merged before.