### PR TITLE
When compiling conda packages compile as shared library on Windows

### DIFF
--- a/conda/cmake_recipe_template/bld.bat
+++ b/conda/cmake_recipe_template/bld.bat
@@ -6,13 +6,13 @@ mkdir build
 cd build
 
 :: Hardcoding Visual Studio 2019 as GitHub Actions does not have VS2019
-:: -DBUILD_SHARED_LIBS=ON for now disabled as a workaround for https://github.com/robotology/icub-main/issues/717 
 cmake ^
     -G"Visual Studio 16 2019" ^
     -DCMAKE_INSTALL_PREFIX=%LIBRARY_PREFIX% ^
     -DCMAKE_PREFIX_PATH=%LIBRARY_PREFIX% ^
     -DCMAKE_BUILD_TYPE=Release ^
     -DCMAKE_VERBOSE_MAKEFILE=OFF ^
+    -DBUILD_SHARED_LIBS=ON ^
     -DCMAKE_INSTALL_LIBDIR=lib ^
 {% for cmake_arg in cmake_args %}    {{ cmake_arg }} ^
 {% endfor %}    ..


### PR DESCRIPTION
This was not done due to https://github.com/robotology/icub-main/issues/717, but https://github.com/robotology/icub-main/issues/717 was solved a long time ago.

`generate-conda-packages` test run: https://github.com/robotology/robotology-superbuild/actions/runs/2533920743 .