### PR TITLE
2022.05.2 : Bump `yarp@v3.7.1`, `icub-firmware-shared@v1.25.1`

### DIFF
--- a/releases/2022.05.2.yaml
+++ b/releases/2022.05.2.yaml
@@ -30,7 +30,7 @@ repositories:
   YARP:
     type: git
     url: https://github.com/robotology/yarp.git
-    version: v3.7.0
+    version: v3.7.1
   ICUB:
     type: git
     url: https://github.com/robotology/icub-main.git

--- a/releases/2022.05.2.yaml
+++ b/releases/2022.05.2.yaml
@@ -130,7 +130,7 @@ repositories:
   icub_firmware_shared:
     type: git
     url: https://github.com/robotology/icub-firmware-shared.git
-    version: v1.25.0
+    version: v1.25.1
   icub-firmware:
     type: git
     url: https://github.com/robotology/icub-firmware.git


### PR DESCRIPTION
This should fix the failure reported in https://github.com/robotology/robotology-superbuild/pull/1180#issuecomment-1162274510 .