### PR TITLE
conda: Add eigen as dependency of matio-cpp

### DIFF
--- a/cmake/BuildmatioCpp.cmake
+++ b/cmake/BuildmatioCpp.cmake
@@ -5,10 +5,10 @@ include(YCMEPHelper)
 
 ycm_ep_helper(matioCpp TYPE GIT
               STYLE GITHUB
-              REPOSITORY dic-iit/matio-cpp.git
+              REPOSITORY ami-iit/matio-cpp.git
               TAG master
               COMPONENT dynamics
               FOLDER src
               CMAKE_ARGS -DBUILD_TESTING:BOOL=OFF)
 
-set(matioCpp_CONDA_DEPENDENCIES "libmatio")
+set(matioCpp_CONDA_DEPENDENCIES libmatio eigen)


### PR DESCRIPTION
Otherwise matio-cpp will be compiled without Eigen support, see https://github.com/ami-iit/matio-cpp/blob/ed9b196360b8083c3eccd3348afa7969d3a4f1fa/CMakeLists.txt#L94 .