### PR TITLE
Update `icub-main` to `v1.26.1`

### DIFF
--- a/releases/2022.05.2.yaml
+++ b/releases/2022.05.2.yaml
@@ -34,7 +34,7 @@ repositories:
   ICUB:
     type: git
     url: https://github.com/robotology/icub-main.git
-    version: v1.26.0
+    version: v1.26.1
   ICUBcontrib:
     type: git
     url: https://github.com/robotology/icub-contrib-common.git


### PR DESCRIPTION
As per the title.

<sub>I mistakenly called the branch referring to v1.16.1</sub>