### PR TITLE
Enable by default ROBOTOLOGY_USES_GAZEBO also on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format of this document is based on [Keep a Changelog](https://keepachangelo
 
 ## [Unreleased]
 
+### Changed
+- Enable by default ROBOTOLOGY_USES_GAZEBO also on Windows (https://github.com/robotology/robotology-superbuild/pull/1202).
+
 ## [2022.05.1] - 2022-06-09
 
 ### Fixed

--- a/cmake/RobotologySuperbuildOptions.cmake
+++ b/cmake/RobotologySuperbuildOptions.cmake
@@ -18,12 +18,7 @@ mark_as_advanced(ROBOTOLOGY_USES_LUA)
 option(ROBOTOLOGY_USES_PYTHON "Enable compilation of software that depend on Python" FALSE)
 
 ## Enable packages that depend on the Gazebo Classic simulator
-if(WIN32)
-  set(ROBOTOLOGY_USES_GAZEBO_DEFAULT FALSE)
-else()
-  set(ROBOTOLOGY_USES_GAZEBO_DEFAULT TRUE)
-endif()
-option(ROBOTOLOGY_USES_GAZEBO "Enable compilation of software that depends on Gazebo Classic" ${ROBOTOLOGY_USES_GAZEBO_DEFAULT})
+option(ROBOTOLOGY_USES_GAZEBO "Enable compilation of software that depends on Gazebo Classic" ON)
 
 ## Enable packages that depend on the Ignition Gazebo simulator
 set(ROBOTOLOGY_USES_IGNITION_DEFAULT FALSE)

--- a/doc/cmake-options.md
+++ b/doc/cmake-options.md
@@ -229,8 +229,8 @@ Dependencies-specific documentation
 ===================================
 
 ## Gazebo
+
 Support for this dependency is enabled by the `ROBOTOLOGY_USES_GAZEBO` CMake option, that enables the software that depends on "Classic Gazebo".
-This option is still set to `OFF` on Windows as it is still experimental.
 
 ### System Dependencies
 


### PR DESCRIPTION
For a long time, `ROBOTOLOGY_USES_GAZEBO` was set to `OFF` on Windows as Gazebo was either not available or experimental. As Gazebo on Windows is now quite stable, leaving the option to OFF is creating more problems than it solves.