### PR TITLE
Re-enable HUMAN_DYNAMICS in Unstable branches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,7 +143,7 @@ jobs:
     - name: Configure Unstable [Conda]
       if: contains(matrix.project_tags, 'Unstable')
       shell: bash -l {0}
-      run: cmake -S . -B build/ -DROBOTOLOGY_ENABLE_EVENT_DRIVEN:BOOL=OFF -DROBOTOLOGY_ENABLE_HUMAN_DYNAMICS:BOOL=OFF
+      run: cmake -S . -B build/ -DROBOTOLOGY_ENABLE_EVENT_DRIVEN:BOOL=OFF
 
     # For some reason, the Strawberry perl's pkg-config is found
     # instead of the conda's one, so let's delete the /c/Strawberry directory
@@ -248,7 +248,7 @@ jobs:
       if: contains(matrix.project_tags, 'Unstable')
       run: |
         cd build
-        cmake -DROBOTOLOGY_ENABLE_EVENT_DRIVEN:BOOL=OFF -DROBOTOLOGY_ENABLE_HUMAN_DYNAMICS:BOOL=OFF .
+        cmake -DROBOTOLOGY_ENABLE_EVENT_DRIVEN:BOOL=OFF .
 
     - name: Build  [Docker]
       run: |
@@ -441,7 +441,7 @@ jobs:
       run: |
         cd ${ROBOTOLOGY_SUPERBUILD_SOURCE_DIR}
         cd build
-        cmake -DROBOTOLOGY_ENABLE_EVENT_DRIVEN:BOOL=OFF -DROBOTOLOGY_ENABLE_HUMAN_DYNAMICS:BOOL=OFF .
+        cmake -DROBOTOLOGY_ENABLE_EVENT_DRIVEN:BOOL=OFF .
 
     - name: Build  [Ubuntu&macOS]
       if: contains(matrix.os, 'macos') || contains(matrix.os, 'ubuntu')


### PR DESCRIPTION
This PR to remove the workaround https://github.com/robotology/robotology-superbuild/pull/1143 for the HUMAN_DYNAMICS profile as https://github.com/robotology/yarp-devices-forcetorque/issues/31 has been closed.