### PR TITLE
Remove graphviz=2.5 workaround

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,7 +98,7 @@ jobs:
       shell: bash -l {0}
       run: |
         # Additional dependencies only useful on Windows
-        mamba install -c conda-forge -c robotology esdcan freeglut graphviz=2.50
+        mamba install -c conda-forge -c robotology esdcan freeglut
 
     - name: Print used environment [Conda]
       shell: bash -l {0}

--- a/doc/conda-forge.md
+++ b/doc/conda-forge.md
@@ -122,7 +122,7 @@ mamba install -c conda-forge bash-completion freeglut libdc1394 libi2c expat-cos
 
 If you are on **Windows**, you also need to install also the following packages:
 ~~~
-mamba install -c conda-forge freeglut graphviz=2.50
+mamba install -c conda-forge freeglut
 ~~~
 
 ### Clone the repo


### PR DESCRIPTION
This was added in https://github.com/robotology/robotology-superbuild/pull/1166 . Now that graphviz 5 was released and the conda-forge related migration is almost completed, I think we can remove the workaround: https://conda-forge.org/status/#graphviz5 .