### PR TITLE
Make ROBOTOLOGY_PROJECT_TAGS and ROBOTOLOGY_PROJECT_TAGS_CUSTOM_FILE non advanced CMake options and update docs

### DIFF
--- a/cmake/RobotologySuperbuildOptions.cmake
+++ b/cmake/RobotologySuperbuildOptions.cmake
@@ -68,9 +68,7 @@ if(NOT CMAKE_CONFIGURATION_TYPES)
 endif()
 
 set(ROBOTOLOGY_PROJECT_TAGS "Stable" CACHE STRING "The tags to be used for the robotology projects: Stable, Unstable, LatestRelease or Custom. This can be changed only before the first configuration.")
-mark_as_advanced(ROBOTOLOGY_PROJECT_TAGS)
 set(ROBOTOLOGY_PROJECT_TAGS_CUSTOM_FILE CACHE FILEPATH "If ROBOTOLOGY_PROJECT_TAGS is custom, this file will be loaded to specify the tags of the projects to use.")
-mark_as_advanced(ROBOTOLOGY_PROJECT_TAGS_CUSTOM_FILE)
 set_property(CACHE ROBOTOLOGY_PROJECT_TAGS PROPERTY STRINGS "Stable" "Unstable" "LatestRelease" "Custom")
 
 if(ROBOTOLOGY_PROJECT_TAGS STREQUAL "Stable")

--- a/doc/change-project-tags.md
+++ b/doc/change-project-tags.md
@@ -12,7 +12,7 @@ It can take one of four possible values:
 * `Unstable` : by selecting this option, you will use the tags or branches specified in [`cmake/ProjectsTagsUnstable.cmake`](../cmake/ProjectsTagsUnstable.cmake), 
                that are the "unstable" active development branches for the robotology projects. This is reccomended just for users that work at the IIT labs in Genoa,
                as it can break compilation or runtime behaviour without any notice.
-* `LatestReleases` : by selecting this option, you will use the tags specified in [`releases/latest.releases.yaml`](../releases/latest.releases.yaml), 
+* `LatestRelease` : by selecting this option, you will use the tags specified in [`releases/latest.releases.yaml`](../releases/latest.releases.yaml), 
                that are the latest releases for the robotology projects. 
 * `Custom` : by selecting this option, you need to manually specify the tags or branches that you want to use by specifying a custom project tags file in the 
              `ROBOTOLOGY_PROJECT_TAGS_CUSTOM_FILE` CMake option. It is necessary to specify the absolute location of the file.  This is useful when  you want to use a fixed version of the software built by the superbuild. The specified file is included in the project via the [`include` CMake command](https://cmake.org/cmake/help/v3.15/command/include.html), or if it ends with `.yaml` or `.repos` it is assumed to be a YAML file that is loaded by the [`ycm_load_vcs_yaml_info`](../cmake/YCMLoadVcsYamlInfo.cmake) CMake function.

--- a/doc/change-project-tags.md
+++ b/doc/change-project-tags.md
@@ -6,13 +6,14 @@ branch, tag or commit used for each specific CMake package can be manually speci
 CMake variables. By default, the `robotology-superbuild` uses the latest "stable" branches of the robotology repositories, but in some cases it may be necessary to use the "unstable" active development branches, 
 or use some fixed tags. These advanced use cases are supported by the `ROBOTOLOGY_PROJECT_TAGS` CMake variable. 
 
-`ROBOTOLOGY_PROJECT_TAGS` is an advanced CMake option, so it is visible from the CMake GUI only after enabling the visualization of advanced variables.
-It can take one of three possible values: 
+It can take one of four possible values: 
 * `Stable` :  this is the default value, that will use the tags or branches specified in [`cmake/ProjectsTagsStable.cmake`](../cmake/ProjectsTagsStable.cmake) 
               that are the stables branches for the robotology projects.
 * `Unstable` : by selecting this option, you will use the tags or branches specified in [`cmake/ProjectsTagsUnstable.cmake`](../cmake/ProjectsTagsUnstable.cmake), 
                that are the "unstable" active development branches for the robotology projects. This is reccomended just for users that work at the IIT labs in Genoa,
                as it can break compilation or runtime behaviour without any notice.
+* `LatestReleases` : by selecting this option, you will use the tags specified in [`releases/latest.releases.yaml`](../releases/latest.releases.yaml), 
+               that are the latest releases for the robotology projects. 
 * `Custom` : by selecting this option, you need to manually specify the tags or branches that you want to use by specifying a custom project tags file in the 
              `ROBOTOLOGY_PROJECT_TAGS_CUSTOM_FILE` CMake option. It is necessary to specify the absolute location of the file.  This is useful when  you want to use a fixed version of the software built by the superbuild. The specified file is included in the project via the [`include` CMake command](https://cmake.org/cmake/help/v3.15/command/include.html), or if it ends with `.yaml` or `.repos` it is assumed to be a YAML file that is loaded by the [`ycm_load_vcs_yaml_info`](../cmake/YCMLoadVcsYamlInfo.cmake) CMake function.
 


### PR DESCRIPTION
Fix https://github.com/robotology/robotology-superbuild/issues/1226 .

cc @marcoaccame @mfussi66 @valegagge @davidetome @triccyx 