### PR TITLE
Specify that recipes built from pure_python_recipe_template are noarch

### DIFF
--- a/conda/pure_python_recipe_template/meta.yaml
+++ b/conda/pure_python_recipe_template/meta.yaml
@@ -9,6 +9,7 @@ source:
   git_rev: {{ github_tag }}
 
 build:
+  noarch: python
   # Due to robot-log-visualizer, drop when conda-forge does not uses Python 3.7 anymore
   skip: True  # [py<38]
   number: {{ conda_build_number }}


### PR DESCRIPTION
I noticed that in https://github.com/robotology/robotology-superbuild/runs/8082454197 a lot of time is spent to build multiple versions of `robot-log-visualizer`, even if a single version is sufficient to work fine on all python versions. This can be force with `noarch: python`, see https://docs.conda.io/projects/conda-build/en/latest/resources/define-metadata.html#architecture-independent-packages .