### PR TITLE
Fix Python 3.10/Ubuntu 22.04 warning due to distutils deprecation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,7 +34,7 @@ include(RobotologySuperbuildOptions)
 # Python-related logic
 if(ROBOTOLOGY_USES_PYTHON)
   find_package(Python3 COMPONENTS Interpreter Development REQUIRED)
-  execute_process(COMMAND ${Python3_EXECUTABLE} -c "from distutils import sysconfig; print(sysconfig.get_python_lib(1,0,prefix=''))"
+  execute_process(COMMAND ${Python3_EXECUTABLE} -c "import sysconfig; print(sysconfig.get_python_lib(1,0,prefix=''))"
      OUTPUT_VARIABLE _PYTHON_INSTDIR)
   string(STRIP ${_PYTHON_INSTDIR} ROBOTOLOGY_SUPERBUILD_PYTHON_INSTALL_DIR)
   file(TO_CMAKE_PATH "${ROBOTOLOGY_SUPERBUILD_PYTHON_INSTALL_DIR}" ROBOTOLOGY_SUPERBUILD_PYTHON_INSTALL_DIR) 

--- a/cmake/RobSupPurePythonYCMEPHelper.cmake
+++ b/cmake/RobSupPurePythonYCMEPHelper.cmake
@@ -27,7 +27,7 @@ function(ROB_SUP_PURE_PYTHON_YCM_EP_HELPER _name)
   find_package(Python3 COMPONENTS Interpreter REQUIRED)
 
   execute_process(COMMAND ${Python3_EXECUTABLE}
-                  -c "from distutils import sysconfig; print(sysconfig.get_python_lib(1,0,prefix=''))"
+                  -c "import sysconfig; print(sysconfig.get_python_lib(1,0,prefix=''))"
                   OUTPUT_VARIABLE _PYTHON_INSTDIR)
   string(STRIP ${_PYTHON_INSTDIR} ROBSUB_PYTHON_INSTALL_DIR)
 


### PR DESCRIPTION
Fix https://github.com/robotology/robotology-superbuild/issues/1238 .