### PR TITLE
Switch to use matio-cpp, robometry, lie-group-controllers, unicycle-footstep-planner and bipedal-locomotion-framework conda packages from conda-forge instead of robotology channel

### DIFF
--- a/.github/workflows/generate-conda-packages.yaml
+++ b/.github/workflows/generate-conda-packages.yaml
@@ -187,17 +187,10 @@ jobs:
             # icub-main needs robotology channel as it also depends on esdcan, and local to avoid that robotology packages are used instead of local built one
             conda build -m ${CONDA_PREFIX}/conda_build_config.yaml -m ${GITHUB_WORKSPACE}/conda/conda_build_config.yml -c local -c conda-forge -c robotology icub-main
             rm -rf icub-main
-            conda mambabuild -m ${CONDA_PREFIX}/conda_build_config.yaml -m ${GITHUB_WORKSPACE}/conda/conda_build_config.yml lie-group-controllers
-            rm -rf lie-group-controllers
             conda mambabuild -m ${CONDA_PREFIX}/conda_build_config.yaml -m ${GITHUB_WORKSPACE}/conda/conda_build_config.yml yarp-matlab-bindings
             rm -rf yarp-matlab-bindings
             conda mambabuild -m ${CONDA_PREFIX}/conda_build_config.yaml -m ${GITHUB_WORKSPACE}/conda/conda_build_config.yml wb-toolbox
             rm -rf wb-toolbox
-            conda mambabuild -m ${CONDA_PREFIX}/conda_build_config.yaml -m ${GITHUB_WORKSPACE}/conda/conda_build_config.yml unicycle-footstep-planner
-            rm -rf unicycle-footstep-planner
-            # Channels specified explicitly due to https://github.com/robotology/robotology-superbuild/issues/1140
-            conda mambabuild -m ${CONDA_PREFIX}/conda_build_config.yaml -m ${GITHUB_WORKSPACE}/conda/conda_build_config.yml -c local -c conda-forge bipedal-locomotion-framework
-            rm -rf bipedal-locomotion-framework
             conda mambabuild -m ${CONDA_PREFIX}/conda_build_config.yaml -m ${GITHUB_WORKSPACE}/conda/conda_build_config.yml wearables
             rm -rf wearables
             conda mambabuild -m ${CONDA_PREFIX}/conda_build_config.yaml -m ${GITHUB_WORKSPACE}/conda/conda_build_config.yml blocktest

--- a/.github/workflows/generate-conda-packages.yaml
+++ b/.github/workflows/generate-conda-packages.yaml
@@ -178,10 +178,6 @@ jobs:
             rm -rf idyntree-matlab-bindings
             conda mambabuild -m ${CONDA_PREFIX}/conda_build_config.yaml -m ${GITHUB_WORKSPACE}/conda/conda_build_config.yml blockfactory
             rm -rf blockfactory
-            conda mambabuild -m ${CONDA_PREFIX}/conda_build_config.yaml -m ${GITHUB_WORKSPACE}/conda/conda_build_config.yml matio-cpp
-            rm -rf matio-cpp
-            conda mambabuild -m ${CONDA_PREFIX}/conda_build_config.yaml -m ${GITHUB_WORKSPACE}/conda/conda_build_config.yml robometry
-            rm -rf robometry
             conda mambabuild -m ${CONDA_PREFIX}/conda_build_config.yaml -m ${GITHUB_WORKSPACE}/conda/conda_build_config.yml icub-contrib-common
             rm -rf icub-contrib-common
             conda mambabuild -m ${CONDA_PREFIX}/conda_build_config.yaml -m ${GITHUB_WORKSPACE}/conda/conda_build_config.yml icub-firmware-shared

--- a/cmake/BuildLieGroupControllers.cmake
+++ b/cmake/BuildLieGroupControllers.cmake
@@ -8,10 +8,11 @@ find_or_build_package(manif QUIET)
 
 ycm_ep_helper(LieGroupControllers TYPE GIT
               STYLE GITHUB
-              REPOSITORY dic-iit/lie-group-controllers.git
+              REPOSITORY ami-iit/lie-group-controllers.git
               TAG master
               COMPONENT dynamics
               FOLDER src
               DEPENDS manif)
-              
-set(LieGroupControllers_CONDA_DEPENDENCIES eigen)
+
+set(LieGroupControllers_CONDA_PKG_NAME lie-group-controllers)
+set(LieGroupControllers_CONDA_PKG_CONDA_FORGE_OVERRIDE ON)

--- a/cmake/BuildUnicyclePlanner.cmake
+++ b/cmake/BuildUnicyclePlanner.cmake
@@ -14,5 +14,6 @@ ycm_ep_helper(UnicyclePlanner TYPE GIT
               COMPONENT dynamics
               FOLDER src
               DEPENDS iDynTree)
-              
-set(UnicyclePlanner_CONDA_DEPENDENCIES eigen)
+
+set(UnicyclePlanner_CONDA_PKG_NAME libunicycle-footstep-planner)
+set(UnicyclePlanner_CONDA_PKG_CONDA_FORGE_OVERRIDE ON)

--- a/cmake/Buildbipedal-locomotion-framework.cmake
+++ b/cmake/Buildbipedal-locomotion-framework.cmake
@@ -55,7 +55,7 @@ endif()
 
 ycm_ep_helper(bipedal-locomotion-framework TYPE GIT
               STYLE GITHUB
-              REPOSITORY dic-iit/bipedal-locomotion-framework.git
+              REPOSITORY ami-iit/bipedal-locomotion-framework.git
               TAG master
               COMPONENT dynamics
               FOLDER src
@@ -72,24 +72,5 @@ ycm_ep_helper(bipedal-locomotion-framework TYPE GIT
                          ${bipedal-locomotion-framework_OPTIONAL_CMAKE_ARGS}
               DEPENDS ${bipedal-locomotion-framework_DEPENDS})
 
-set(bipedal-locomotion-framework_CONDA_DEPENDENCIES eigen)
-list(APPEND bipedal-locomotion-framework_CONDA_DEPENDENCIES nlohmann_json)
-list(APPEND bipedal-locomotion-framework_CONDA_DEPENDENCIES spdlog)
-
-if(ROBOTOLOGY_USES_PCL_AND_VTK)
-  list(APPEND bipedal-locomotion-framework_CONDA_DEPENDENCIES pcl)
-endif()
-
-if(ROBOTOLOGY_ENABLE_DYNAMICS_FULL_DEPS AND NOT ROBOTOLOGY_BUILD_QHULL)
-  list(APPEND bipedal-locomotion-framework_CONDA_DEPENDENCIES qhull)
-endif()
-
-if(ROBOTOLOGY_USES_PYTHON)
-  list(APPEND bipedal-locomotion-framework_CONDA_DEPENDENCIES pybind11)
-  # https://conda-forge.org/docs/maintainer/knowledge_base.html#pybind11-abi-constraints
-  list(APPEND bipedal-locomotion-framework_CONDA_DEPENDENCIES pybind11-abi)
-  list(APPEND bipedal-locomotion-framework_CONDA_DEPENDENCIES python)
-  list(APPEND bipedal-locomotion-framework_CONDA_DEPENDENCIES numpy)
-  list(APPEND bipedal-locomotion-framework_CONDA_DEPENDENCIES manifpy)
-  list(APPEND bipedal-locomotion-framework_CONDA_RUN_DEPENDENCIES_EXPLICIT manifpy)
-endif()
+set(bipedal-locomotion-framework_CONDA_PKG_NAME bipedal-locomotion-framework)
+set(bipedal-locomotion-framework_CONDA_PKG_CONDA_FORGE_OVERRIDE ON)

--- a/cmake/BuildmatioCpp.cmake
+++ b/cmake/BuildmatioCpp.cmake
@@ -11,4 +11,5 @@ ycm_ep_helper(matioCpp TYPE GIT
               FOLDER src
               CMAKE_ARGS -DBUILD_TESTING:BOOL=OFF)
 
-set(matioCpp_CONDA_DEPENDENCIES libmatio eigen)
+set(matioCpp_CONDA_PKG_NAME libmatio-cpp)
+set(matioCpp_CONDA_PKG_CONDA_FORGE_OVERRIDE ON)

--- a/cmake/Buildrobometry.cmake
+++ b/cmake/Buildrobometry.cmake
@@ -17,4 +17,5 @@ ycm_ep_helper(robometry TYPE GIT
                       YARP
                       matioCpp)
 
-set(robometry_CONDA_DEPENDENCIES boost-cpp libmatio)
+set(robometry_CONDA_PKG_NAME librobometry)
+set(robometry_CONDA_PKG_CONDA_FORGE_OVERRIDE ON)


### PR DESCRIPTION
More work in the direction of https://github.com/robotology/robotology-superbuild/issues/752 .