### PR TITLE
Fix Linux bug when XDG_DATA_DIRS is not defined

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format of this document is based on [Keep a Changelog](https://keepachangelo
 
 ## [Unreleased]
 
+### Fixed
+- Fixed problem that occured when robotology-superbuild's `setup.sh` was sourced on Linux system in which `XDG_DATA_DIRS` was not defined ().
+
 ## [2022.08.0] - 2022-09-02
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format of this document is based on [Keep a Changelog](https://keepachangelo
 ## [Unreleased]
 
 ### Fixed
-- Fixed problem that occured when robotology-superbuild's `setup.sh` was sourced on Linux system in which `XDG_DATA_DIRS` was not defined ().
+- Fixed problem that occured when robotology-superbuild's `setup.sh` was sourced on Linux system in which `XDG_DATA_DIRS` was not defined (https://github.com/robotology/robotology-superbuild/pull/1257).
 
 ## [2022.08.0] - 2022-09-02
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -99,6 +99,15 @@ else()
   set(BLOCKFACTORY_PLUGIN_PATH_DIRECTORY "lib")
 endif()
 
+# Make sure that setting XDG_DATA_DIRS on Linux (not conda)
+# does not result in /usr/local/share and /usr/local being ignored
+# See https://github.com/robotology/robotology-superbuild/issues/1187
+if(UNIX AND NOT APPLE AND NOT ROBOTOLOGY_CONFIGURING_UNDER_CONDA)
+  set(XDG_DATA_DIRS_DEFAULT_VALUE "/usr/local/share:/usr/share:")
+else()
+  set(XDG_DATA_DIRS_DEFAULT_VALUE "")
+endif()
+
 if(WIN32)
   # On Git Bash on Windows, C: is rendered as /c
   string(REGEX MATCH "^([A-Z])" PROJECT_SOURCE_DIR_DRIVE ${PROJECT_SOURCE_DIR})

--- a/cmake/template/setup.sh.in
+++ b/cmake/template/setup.sh.in
@@ -14,7 +14,7 @@ export @SHLIB_ENV_VAR@=${@SHLIB_ENV_VAR@:+${@SHLIB_ENV_VAR@}:}${ROBOTOLOGY_SUPER
 # Setup the path of blockfactory plugins
 export BLOCKFACTORY_PLUGIN_PATH=${BLOCKFACTORY_PLUGIN_PATH:+${BLOCKFACTORY_PLUGIN_PATH}:}$ROBOTOLOGY_SUPERBUILD_INSTALL_PREFIX/@BLOCKFACTORY_PLUGIN_PATH_DIRECTORY@/blockfactory
 # Extend path for bash completion (see https://github.com/robotology/robotology-superbuild/issues/622#issuecomment-847586406)
-export XDG_DATA_DIRS=${XDG_DATA_DIRS:+${XDG_DATA_DIRS}:}$ROBOTOLOGY_SUPERBUILD_INSTALL_PREFIX/share
+export XDG_DATA_DIRS=${XDG_DATA_DIRS:-"/usr/local/share:/usr/share"}:$ROBOTOLOGY_SUPERBUILD_INSTALL_PREFIX/share
 
 @cmakeif ROBOTOLOGY_USES_GAZEBO
 # ROBOTOLOGY_USES_GAZEBO-specific lines

--- a/doc/environment-variables-configuration.md
+++ b/doc/environment-variables-configuration.md
@@ -31,7 +31,7 @@ while on macOS you need to append `$ROBOTOLOGY_SUPERBUILD_INSTALL_PREFIX/lib` to
 For what regards correctly loading resources in URDF files, you need to append `$ROBOTOLOGY_SUPERBUILD_INSTALL_PREFIX\share` to the
 [`ROS_PACKAGE_PATH`](http://wiki.ros.org/ROS/EnvironmentVariables#ROS_PACKAGE_PATH) environment variable for [ROS1](https://www.ros.org/), and `$ROBOTOLOGY_SUPERBUILD_INSTALL_PREFIX` to [`AMENT_PREFIX_PATH`](http://design.ros2.org/articles/ament.html) for [ROS2](https://index.ros.org/doc/ros2/)
 
-To enable bash autocompletion, you need to add `$ROBOTOLOGY_SUPERBUILD_INSTALL_PREFIX\share` to `XDG_DATA_DIRS` environment variable.
+To enable bash autocompletion, you need to add `$ROBOTOLOGY_SUPERBUILD_INSTALL_PREFIX\share` to `XDG_DATA_DIRS` environment variable. If you are on Linux and not using conda and `XDG_DATA_DIRS` is empty, before adding `$ROBOTOLOGY_SUPERBUILD_INSTALL_PREFIX\share` also append to it the value `/usr/local/share/:/usr/share/`.
 
 ## Profile-specific configuration steps
 


### PR DESCRIPTION
`XDG_DATA_DIRS` default value (at least on Linux system) when the variable is not set is `/usr/local/share/:/usr/share/`, see https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html . This means that the behaviour of the Linux application when `XDG_DATA_DIRS` is not set or when it is set to an empty string is not the same, as in the latter case the directories `/usr/local/share/:/usr/share/`, where most configuration files of system installed software are installed are ignored, resulting in software not working properly (see https://github.com/robotology/robotology-superbuild/issues/1187 for some examples).

On most system this issue was not appearing as some other system installed software was already properly defining `XDG_DATA_DIRS` with `/usr/local/share/:/usr/share/` in it, but on some system (such as barebones Docker images) that was not the case.

This PR fixes this problem by putting `/usr/local/share/:/usr/share/` in `XDG_DATA_DIRS` if `XDG_DATA_DIRS` was not defined, before appending any value to it. This logic is only applied on Linux and if conda is not used.

Fix https://github.com/robotology/robotology-superbuild/issues/1187 .