### PR TITLE
Install old version of liblief to avoid macOS conda build crash

### DIFF
--- a/.github/workflows/generate-conda-packages.yaml
+++ b/.github/workflows/generate-conda-packages.yaml
@@ -102,7 +102,7 @@ jobs:
         - name: Dependencies for conda recipes generation and upload
           shell: bash -l {0}
           run: |
-            mamba install pyyaml jinja2 conda-build ninja anaconda-client conda-forge-pinning mamba boa multisheller
+            mamba install pyyaml jinja2 conda-build ninja anaconda-client conda-forge-pinning mamba boa multisheller liblief=0.11.5
 
         - name: Print used environment
           shell: bash -l {0}


### PR DESCRIPTION
Currently the macOS conda package generation job is failing in a non-deterministic way with a Segmentation fault, using an old version of liblief seems to work fine in avoiding this problem.

See https://github.com/conda-forge/conda-forge.github.io/issues/1823#issuecomment-1239926891 .

Workaround for https://github.com/robotology/robotology-superbuild/issues/1250 .
