### PR TITLE
Bump manif fork to 0.0.4.2

### DIFF
--- a/cmake/ProjectsTagsStable.cmake
+++ b/cmake/ProjectsTagsStable.cmake
@@ -7,7 +7,7 @@ endmacro()
 # External projects
 set_tag(osqp_TAG v0.6.2)
 set_tag(manif_REPOSITORY robotology-dependencies/manif.git)
-set_tag(manif_TAG 0.0.4.1)
+set_tag(manif_TAG 0.0.4.2)
 set_tag(qhull_TAG 2020.2)
 set_tag(CppAD_TAG 20220000.4)
 set_tag(casadi 3.5.5.3)

--- a/cmake/ProjectsTagsUnstable.cmake
+++ b/cmake/ProjectsTagsUnstable.cmake
@@ -7,7 +7,7 @@ endmacro()
 # External projects
 set_tag(osqp_TAG v0.6.2)
 set_tag(manif_REPOSITORY robotology-dependencies/manif.git)
-set_tag(manif_TAG 0.0.4.1)
+set_tag(manif_TAG 0.0.4.2)
 set_tag(qhull_TAG 2020.2)
 set_tag(CppAD_TAG 20220000.4)
 set_tag(casadi 3.5.5.3)

--- a/releases/latest.releases.yaml
+++ b/releases/latest.releases.yaml
@@ -10,7 +10,7 @@ repositories:
   manif:
     type: git
     url: https://github.com/robotology-dependencies/manif.git
-    version: 0.0.4.1
+    version: 0.0.4.2
   qhull:
     type: git
     url: https://github.com/qhull/qhull.git


### PR DESCRIPTION
Fix https://github.com/robotology/robotology-superbuild/issues/1271 . 

The problem occured in https://github.com/robotology/robotology-superbuild/issues/1271 is due to a missing header that was solved upstream in https://github.com/artivis/manif/pull/248 , however there was no release since then, and for the superbuild from source we still rely on our manif fork at https://github.com/robotology-dependencies/manif. For this reason, I backported https://github.com/artivis/manif/pull/248 on our fork, and release 0.0.4.2 release. This PR just bumps the manif version used to 0.0.4.2 , solving https://github.com/robotology/robotology-superbuild/issues/1271 .