### PR TITLE
Only build qhull on Linux with apt dependencies

### DIFF
--- a/cmake/Buildbipedal-locomotion-framework.cmake
+++ b/cmake/Buildbipedal-locomotion-framework.cmake
@@ -24,16 +24,19 @@ set(bipedal-locomotion-framework_USES_CppAD OFF)
 
 if (ROBOTOLOGY_ENABLE_DYNAMICS_FULL_DEPS)
   find_or_build_package(manif QUIET)
-  find_or_build_package(qhull QUIET)
   find_or_build_package(casadi QUIET)
   find_or_build_package(CppAD QUIET)
   find_or_build_package(LieGroupControllers QUIET)
 
   list(APPEND bipedal-locomotion-framework_DEPENDS manif)
-  list(APPEND bipedal-locomotion-framework_DEPENDS qhull)
   list(APPEND bipedal-locomotion-framework_DEPENDS casadi)
   list(APPEND bipedal-locomotion-framework_DEPENDS CppAD)
   list(APPEND bipedal-locomotion-framework_DEPENDS LieGroupControllers)
+
+  if (ROBOTOLOGY_BUILD_QHULL)
+    find_or_build_package(qhull QUIET)
+    list(APPEND bipedal-locomotion-framework_DEPENDS qhull)
+  endif()
 endif()
 
 # For what regards Python installation, the options changes depending
@@ -75,6 +78,10 @@ list(APPEND bipedal-locomotion-framework_CONDA_DEPENDENCIES spdlog)
 
 if(ROBOTOLOGY_USES_PCL_AND_VTK)
   list(APPEND bipedal-locomotion-framework_CONDA_DEPENDENCIES pcl)
+endif()
+
+if(ROBOTOLOGY_ENABLE_DYNAMICS_FULL_DEPS AND NOT ROBOTOLOGY_BUILD_QHULL)
+  list(APPEND bipedal-locomotion-framework_CONDA_DEPENDENCIES qhull)
 endif()
 
 if(ROBOTOLOGY_USES_PYTHON)

--- a/cmake/RobotologySuperbuildLogic.cmake
+++ b/cmake/RobotologySuperbuildLogic.cmake
@@ -8,6 +8,14 @@ else()
   set(ROBOTOLOGY_CONFIGURING_UNDER_CONDA OFF)
 endif()
 
+# We only build qhull on Linux, not on conda, Windows or macOS
+# See https://github.com/robotology/robotology-superbuild/issues/1269#issuecomment-1257811559
+if(ROBOTOLOGY_CONFIGURING_UNDER_CONDA OR APPLE OR WIN32)
+  set(ROBOTOLOGY_BUILD_QHULL OFF)
+else()
+  set(ROBOTOLOGY_BUILD_QHULL ON)
+endif()
+
 # Core
 if(ROBOTOLOGY_ENABLE_CORE)
   find_or_build_package(YARP)

--- a/doc/conda-forge.md
+++ b/doc/conda-forge.md
@@ -112,7 +112,7 @@ of the robotology-superbuild.**
 Once you activated it, you can install packages in it. In particular the dependencies for the robotology-superbuild can be installed as:
 ~~~
 mamba install -c conda-forge cmake compilers make ninja pkg-config
-mamba install -c conda-forge ace asio assimp boost eigen freetype gazebo glew glfw glm graphviz gsl ipopt irrlicht libjpeg-turbo libmatio libode libxml2 nlohmann_json pcl opencv pkg-config portaudio qt-main sdl sdl2 sqlite tinyxml spdlog lua soxr
+mamba install -c conda-forge ace asio assimp boost eigen freetype gazebo glew glfw glm graphviz gsl ipopt irrlicht libjpeg-turbo libmatio libode libxml2 nlohmann_json pcl opencv pkg-config portaudio qt-main sdl sdl2 sqlite tinyxml spdlog lua soxr qhull
 ~~~
 
 If you are on **Linux**, you also need to install also the following packages:

--- a/doc/deprecated-installation-methods.md
+++ b/doc/deprecated-installation-methods.md
@@ -75,7 +75,7 @@ All the software packages are installed using the `install` directory of the bui
 ### System Dependencies
 To install the system dependencies, it is possible to use [Homebrew](http://brew.sh/):
 ```
-brew install ace assimp bash-completion boost cmake eigen graphviz gsl ipopt jpeg libedit nlohmann-json opencv pkg-config portaudio qt@5 sqlite swig tinyxml libmatio irrlicht spdlog
+brew install ace assimp bash-completion boost cmake eigen graphviz gsl ipopt jpeg libedit nlohmann-json opencv pkg-config portaudio qt@5 sqlite swig tinyxml libmatio irrlicht spdlog qhull
 ```
 
 Since Qt5 is not symlinked in `/usr/local` by default in the homebrew formula, `Qt5_DIR` needs to be properly set to make sure that CMake-based projects are able to find Qt5.

--- a/doc/vcpkg-dependencies.md
+++ b/doc/vcpkg-dependencies.md
@@ -3,7 +3,7 @@
 If you prefer to install dependencies of the `robotology-superbuild` on your own existing [`vcpkg`](https://github.com/microsoft/vcpkg) installation,
 the ports that are required are the following: 
 ~~~
-./vcpkg.exe install --triplet x64-windows ace asio assimp boost-asio boost-any boost-bind boost-date-time boost-filesystem boost-format boost-interprocess boost-iostreams boost-program-options boost-property-tree boost-regex boost-smart-ptr boost-system boost-thread boost-variant boost-uuid freeglut gsl eigen3 glew glfw3 graphviz ode openssl libxml2 libjpeg-turbo nlohmann-json opencv portaudio matio sdl1 sdl2 qt5-base[latest] qt5-declarative qt5-multimedia qt5-quickcontrols qt5-quickcontrols2 sqlite3[core,tool] irrlicht
+./vcpkg.exe install --triplet x64-windows ace asio assimp boost-asio boost-any boost-bind boost-date-time boost-filesystem boost-format boost-interprocess boost-iostreams boost-program-options boost-property-tree boost-regex boost-smart-ptr boost-system boost-thread boost-variant boost-uuid freeglut gsl eigen3 glew glfw3 graphviz ode openssl libxml2 libjpeg-turbo nlohmann-json opencv portaudio matio sdl1 sdl2 qt5-base[latest] qt5-declarative qt5-multimedia qt5-quickcontrols qt5-quickcontrols2 sqlite3[core,tool] irrlicht qhull
 ~~~
 
 


### PR DESCRIPTION
See https://github.com/robotology/robotology-superbuild/issues/1269#issuecomment-1257811559 . Basically, if we install PCL with a package manager, we now install only qhull, so we would have both qhull installed and the one compiled by the superbuild. On macOS|homebrew, Windows|vcpkg and conda there is no problem with the installed qhull, so we switch to just use the qhull installed by the package manager. 

To do that also on Ubuntu with apt dependencies, we would need to drop Ubuntu 20.04 , that I am afraid it will not happen anytime soon.