### PR TITLE
Build as Debug by default on Windows/vcpkg

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -430,7 +430,7 @@ jobs:
         mkdir -p build
         cd build
         # ROBOTOLOGY_ENABLE_TELEOPERATION is OFF as it is unsupported on vcpkg
-        cmake -C ${ROBOTOLOGY_SUPERBUILD_SOURCE_DIR}/.ci/initial-cache.gh.cmake -A x64 -DCMAKE_TOOLCHAIN_FILE=C:/robotology/vcpkg/scripts/buildsystems/vcpkg.cmake -DROBOTOLOGY_USES_MATLAB:BOOL=OFF -DYCM_BOOTSTRAP_VERBOSE=ON -DYCM_EP_INSTALL_DIR=C:/robotology/robotology -DNON_INTERACTIVE_BUILD:BOOL=TRUE -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}  ${{ matrix.project_tags_cmake_options }} ..
+        cmake -C ${ROBOTOLOGY_SUPERBUILD_SOURCE_DIR}/.ci/initial-cache.gh.cmake -A x64 -DCMAKE_TOOLCHAIN_FILE=C:/robotology/vcpkg/scripts/buildsystems/vcpkg.cmake -DROBOTOLOGY_USES_MATLAB:BOOL=OFF -DYCM_BOOTSTRAP_VERBOSE=ON -DYCM_EP_INSTALL_DIR=C:/robotology/robotology -DNON_INTERACTIVE_BUILD:BOOL=TRUE -DCMAKE_BUILD_TYPE=Debug  ${{ matrix.project_tags_cmake_options }} ..
         cmake -DROBOTOLOGY_ENABLE_TELEOPERATION:BOOL=OFF .
 
     # Workaround for https://github.com/robotology/robotology-superbuild/issues/1139
@@ -455,8 +455,8 @@ jobs:
         # This is necessary only on macOS/homebrew, but on Linux it should be ignored
         Qt5_DIR: /usr/local/opt/qt5/lib/cmake/Qt5
 
-    # Just for  release jobs we also compile Windows in Debug, to ensure that Debug libraries are included in the installer
-    - name: Build (Debug) [Windows]
+    # Just for  release jobs we also compile Windows in Release, to ensure that Release libraries are included in the installer
+    - name: Build (Release) [Windows]
       if: github.event_name == 'release' && matrix.project_tags == 'Default' && contains(matrix.os, 'windows')
       shell: bash
       run: |
@@ -464,11 +464,11 @@ jobs:
         cd build
         # Make sure that vcpkg's ace .dll are on the PATH
         source /c/robotology/scripts/setup-deps.sh
-        cmake --build . --config Debug
+        cmake --build . --config Release
         # Cleanup build directories to avoid to fill the disk
         rm -rf ./robotology
 
-    - name: Build (Release) [Windows]
+    - name: Build (Debug) [Windows]
       if: contains(matrix.os, 'windows')
       shell: bash
       run: |
@@ -476,7 +476,7 @@ jobs:
         cd build
         # Make sure that vcpkg's ace .dll are on the PATH
         source /c/robotology/scripts/setup-deps.sh
-        cmake --build . --config Release
+        cmake --build . --config Debug
         # Cleanup build directories to avoid to fill the disk
         rm -rf ./robotology
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -424,6 +424,8 @@ jobs:
       if: contains(matrix.os, 'windows')
       shell: bash
       run: |
+        # Workaround for https://gitlab.kitware.com/cmake/cmake/-/merge_requests/7721
+        mv C:/robotology/vcpkg/installed/x64-windows/tools/pkgconf/pkgconf.exe C:/robotology/vcpkg/installed/x64-windows/tools/pkgconf/pkgconfback.exe
         cd ${ROBOTOLOGY_SUPERBUILD_SOURCE_DIR}
         # Make sure that Gazebo packages can be found by CMake
         source /c/robotology/scripts/setup-deps.sh
@@ -461,9 +463,7 @@ jobs:
       shell: bash
       run: |
         cd ${ROBOTOLOGY_SUPERBUILD_SOURCE_DIR}
-        cd build
-        # Workaround for https://gitlab.kitware.com/cmake/cmake/-/merge_requests/7721
-        cmake -DCMAKE_TOOLCHAIN_FILE=C:/robotology/vcpkg/scripts/buildsystems/vcpkg.cmake -DCMAKE_BUILD_TYPE=Release .
+        cd build    
         # Make sure that vcpkg's ace .dll are on the PATH
         source /c/robotology/scripts/setup-deps.sh
         cmake --build . --config Release
@@ -476,8 +476,6 @@ jobs:
       run: |
         cd ${ROBOTOLOGY_SUPERBUILD_SOURCE_DIR} 
         cd build
-        # Workaround for https://gitlab.kitware.com/cmake/cmake/-/merge_requests/7721
-        cmake -DCMAKE_TOOLCHAIN_FILE=C:/robotology/vcpkg/scripts/buildsystems/vcpkg.cmake -DCMAKE_BUILD_TYPE=Debug .
         # Make sure that vcpkg's ace .dll are on the PATH
         source /c/robotology/scripts/setup-deps.sh
         cmake --build . --config Debug

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -462,6 +462,8 @@ jobs:
       run: |
         cd ${ROBOTOLOGY_SUPERBUILD_SOURCE_DIR}
         cd build
+        # Workaround for https://gitlab.kitware.com/cmake/cmake/-/merge_requests/7721
+        cmake -DCMAKE_TOOLCHAIN_FILE=C:/robotology/vcpkg/scripts/buildsystems/vcpkg.cmake -DCMAKE_BUILD_TYPE=Release .
         # Make sure that vcpkg's ace .dll are on the PATH
         source /c/robotology/scripts/setup-deps.sh
         cmake --build . --config Release
@@ -474,6 +476,8 @@ jobs:
       run: |
         cd ${ROBOTOLOGY_SUPERBUILD_SOURCE_DIR} 
         cd build
+        # Workaround for https://gitlab.kitware.com/cmake/cmake/-/merge_requests/7721
+        cmake -DCMAKE_TOOLCHAIN_FILE=C:/robotology/vcpkg/scripts/buildsystems/vcpkg.cmake -DCMAKE_BUILD_TYPE=Debug .
         # Make sure that vcpkg's ace .dll are on the PATH
         source /c/robotology/scripts/setup-deps.sh
         cmake --build . --config Debug


### PR DESCRIPTION
We already build as Release on Windows/conda, so to early catch Debug problems (such as https://github.com/robotology/robotology-superbuild/issues/1252) we compile Debug on Windows/vcpkg.