### PR TITLE
Set ROBOTOLOGY_USES_PCL_AND_VTK by default to OFF

### DIFF
--- a/cmake/RobotologySuperbuildOptions.cmake
+++ b/cmake/RobotologySuperbuildOptions.cmake
@@ -19,7 +19,7 @@ option(ROBOTOLOGY_USES_PYTHON "Enable compilation of software that depend on Pyt
 
 ## Enable packages that depend on the Gazebo Classic simulator
 option(ROBOTOLOGY_USES_GAZEBO "Enable compilation of software that depends on Gazebo Classic" ON)
-option(ROBOTOLOGY_USES_PCL_AND_VTK "Enable compilation of software that depends on PCL and VTK" ON)
+option(ROBOTOLOGY_USES_PCL_AND_VTK "Enable compilation of software that depends on PCL and VTK" OFF)
 
 ## Enable packages that depend on the Ignition Gazebo simulator
 set(ROBOTOLOGY_USES_IGNITION_DEFAULT FALSE)


### PR DESCRIPTION
The option was meant to be set by default to off (see docs https://github.com/robotology/robotology-superbuild/blob/8ce7ee0344f1ee76fe4affa6d4089e229ab02a3c/doc/cmake-options.md#dependencies-cmake-options). Setting it by default to ON was just a copy and paste error introduced in https://github.com/robotology/robotology-superbuild/pull/1217 .