### PR TITLE
Fix #1280 and bump `icub-firmware-models@v1.26.0`

### DIFF
--- a/releases/latest.releases.yaml
+++ b/releases/latest.releases.yaml
@@ -50,7 +50,7 @@ repositories:
   icub-models:
     type: git
     url: https://github.com/robotology/icub-models.git
-    version: v1.26.0
+    version: v1.25.0
   yarp-matlab-bindings:
     type: git
     url: https://github.com/robotology/yarp-matlab-bindings.git
@@ -142,7 +142,7 @@ repositories:
   icub-firmware-models:
     type: git
     url: https://github.com/robotology/icub-firmware-models.git
-    version: v1.25.0
+    version: v1.26.0
   yarp-device-xsensmt:
     type: git
     url: https://github.com/robotology/yarp-device-xsensmt.git


### PR DESCRIPTION
This PR reverts the wrongly assigned version to `icub-models` (ref. #1280) and advances the version of `icub-firmware-models` (as it was originally intended).