### PR TITLE
ICUB tag fixing deprecated OpenGL libraries

### DIFF
--- a/releases/2022.02.1.yaml
+++ b/releases/2022.02.1.yaml
@@ -34,7 +34,7 @@ repositories:
   ICUB:
     type: git
     url: https://github.com/robotology/icub-main.git
-    version: v1.24.0
+    version: v1.24.1
   ICUBcontrib:
     type: git
     url: https://github.com/robotology/icub-contrib-common.git


### PR DESCRIPTION
Set the default tag of ICUB repository to the 1.24.1, to avoid OpenGL errors raised at buildtime.