### PR TITLE
[CI]: Replaced `set-output`

### DIFF
--- a/.github/workflows/generate-conda-packages.yaml
+++ b/.github/workflows/generate-conda-packages.yaml
@@ -43,7 +43,7 @@ jobs:
           run: |
             # Get CONDA_BUILD_NUMBER via grep and set it to an environment variable
             export CONDA_BUILD_NUMBER=`grep "CONDA_BUILD_NUMBER" ./conda/cmake/CondaGenerationOptions.cmake | grep -oe '\([0-9.]*\)'`
-            echo "::set-output name=conda_build_number::${CONDA_BUILD_NUMBER}"
+            echo "conda_build_number=${CONDA_BUILD_NUMBER}" >> $GITHUB_OUTPUT
 
     generate-conda-packages:
         name: "Generate conda packages @${{ matrix.os }}"

--- a/.github/workflows/icubTechIIT_code.yml
+++ b/.github/workflows/icubTechIIT_code.yml
@@ -12,7 +12,7 @@ jobs:
         steps:
         - name: Get the version
           id: get_version
-          run: echo ::set-output name=VERSION::$(echo $GITHUB_REF | cut -d / -f 3)
+          run: echo "VERSION=$(echo $GITHUB_REF | cut -d / -f 3)" >> $GITHUB_OUTPUT
 
         - name: Get Token
           id: get_workflow_token


### PR DESCRIPTION
`set-output` is now deprecated as per https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/.