### PR TITLE
Add git diff in robotologyGitStatus script

### DIFF
--- a/scripts/robotologyGitStatus.sh
+++ b/scripts/robotologyGitStatus.sh
@@ -27,7 +27,8 @@ printGitStatus () {
     (cd $1 && echo -n "${1}: " \
     && git rev-parse --abbrev-ref HEAD \
     && git log -1 --format="%cr|%s|%H" \
-    && git status -sb); \
+    && git status -sb \
+    && git --no-pager diff --minimal); \
 }
 
 if [ -d "${superbuild_root}" ] ; then


### PR DESCRIPTION
As per title. This will help to automatically store the status of each repo contained in the superbuild