### PR TITLE
Unify step of installation of conda-forge robotology-superbuild dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,10 +74,8 @@ jobs:
     - name: Dependencies [Conda]
       shell: bash -l {0}
       run: |
-        # Compilation related dependencies 
-        mamba install cmake compilers make ninja pkg-config
-        # Actual dependencies
-        mamba install ace asio assimp boost eigen freetype gazebo glew glfw glm graphviz gsl ipopt irrlicht libjpeg-turbo libmatio libode libxml2 nlohmann_json pcl vtk opencv pkg-config portaudio qt-main sdl sdl2 sqlite tinyxml spdlog lua soxr
+        # Dependencies
+        mamba install ace asio assimp boost eigen freetype gazebo glew glfw glm graphviz gsl ipopt irrlicht libjpeg-turbo libmatio libode libxml2 nlohmann_json pcl vtk opencv portaudio qt-main sdl sdl2 sqlite tinyxml spdlog lua soxr cmake compilers make ninja pkg-config
         # Python 
         mamba install python numpy swig pybind11 pyqt matplotlib h5py tornado u-msgpack-python pyzmq ipython
 

--- a/doc/conda-forge.md
+++ b/doc/conda-forge.md
@@ -111,7 +111,7 @@ of the robotology-superbuild.**
 
 Once you activated it, you can install packages in it. In particular the dependencies for the robotology-superbuild can be installed as:
 ~~~
-mamba install -c conda-forge ace asio assimp boost eigen freetype gazebo glew glfw glm graphviz gsl ipopt irrlicht libjpeg-turbo libmatio libode libxml2 nlohmann_json pcl opencv portaudio qt-main sdl sdl2 sqlite tinyxml spdlog lua soxr qhull conda-forge cmake compilers make ninja pkg-config
+mamba install -c conda-forge ace asio assimp boost eigen freetype gazebo glew glfw glm graphviz gsl ipopt irrlicht libjpeg-turbo libmatio libode libxml2 nlohmann_json pcl opencv portaudio qt-main sdl sdl2 sqlite tinyxml spdlog lua soxr qhull cmake compilers make ninja pkg-config
 ~~~
 
 If you are on **Linux**, you also need to install also the following packages:

--- a/doc/conda-forge.md
+++ b/doc/conda-forge.md
@@ -111,8 +111,7 @@ of the robotology-superbuild.**
 
 Once you activated it, you can install packages in it. In particular the dependencies for the robotology-superbuild can be installed as:
 ~~~
-mamba install -c conda-forge cmake compilers make ninja pkg-config
-mamba install -c conda-forge ace asio assimp boost eigen freetype gazebo glew glfw glm graphviz gsl ipopt irrlicht libjpeg-turbo libmatio libode libxml2 nlohmann_json pcl opencv pkg-config portaudio qt-main sdl sdl2 sqlite tinyxml spdlog lua soxr qhull
+mamba install -c conda-forge ace asio assimp boost eigen freetype gazebo glew glfw glm graphviz gsl ipopt irrlicht libjpeg-turbo libmatio libode libxml2 nlohmann_json pcl opencv portaudio qt-main sdl sdl2 sqlite tinyxml spdlog lua soxr qhull conda-forge cmake compilers make ninja pkg-config
 ~~~
 
 If you are on **Linux**, you also need to install also the following packages:


### PR DESCRIPTION
This should solve a problem that @lrapetti had in which following the instructions will result in an old Gazebo affected by a critical bug (https://github.com/conda-forge/gazebo-feedstock/pull/152).