### PR TITLE
Pin Python to 3.10 on conda-forge until the issue with 3.11 is fixed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,7 +77,7 @@ jobs:
         # Dependencies
         mamba install ace asio assimp boost eigen freetype gazebo glew glfw glm graphviz gsl ipopt irrlicht libjpeg-turbo libmatio libode libxml2 nlohmann_json pcl vtk opencv portaudio qt-main sdl sdl2 sqlite tinyxml spdlog lua soxr cmake compilers make ninja pkg-config
         # Python 
-        mamba install python numpy swig pybind11 pyqt matplotlib h5py tornado u-msgpack-python pyzmq ipython
+        mamba install python=3.10 numpy swig pybind11 pyqt matplotlib h5py tornado u-msgpack-python pyzmq ipython
 
     # Additional dependencies useful only on Linux
     - name: Dependencies [Conda/Linux]

--- a/doc/cmake-options.md
+++ b/doc/cmake-options.md
@@ -430,7 +430,7 @@ sudo bash ./scripts/install_apt_python_dependencies.sh
 #### Conda
 To install python and the other required dependencies when using `conda-forge` provided dependencies, use:
 ~~~
-mamba install -c conda-forge python numpy swig pybind11 pyqt matplotlib h5py tornado u-msgpack-python pyzmq ipython
+mamba install -c conda-forge python=3.10 numpy swig pybind11 pyqt matplotlib h5py tornado u-msgpack-python pyzmq ipython
 ~~~
 
 ### Check the installation


### PR DESCRIPTION
Workaround until https://github.com/robotology/robotology-superbuild/issues/1298 is fixed.