### PR TITLE
Fix issue of manif fork with Python 3.11 and revert pinning of Python 3.10

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,7 +77,7 @@ jobs:
         # Dependencies
         mamba install ace asio assimp boost eigen freetype gazebo glew glfw glm graphviz gsl ipopt irrlicht libjpeg-turbo libmatio libode libxml2 nlohmann_json pcl vtk opencv portaudio qt-main sdl sdl2 sqlite tinyxml spdlog lua soxr cmake compilers make ninja pkg-config
         # Python 
-        mamba install python=3.10 numpy swig pybind11 pyqt matplotlib h5py tornado u-msgpack-python pyzmq ipython
+        mamba install python numpy swig pybind11 pyqt matplotlib h5py tornado u-msgpack-python pyzmq ipython
 
     # Additional dependencies useful only on Linux
     - name: Dependencies [Conda/Linux]

--- a/cmake/ProjectsTagsStable.cmake
+++ b/cmake/ProjectsTagsStable.cmake
@@ -7,7 +7,7 @@ endmacro()
 # External projects
 set_tag(osqp_TAG v0.6.2)
 set_tag(manif_REPOSITORY robotology-dependencies/manif.git)
-set_tag(manif_TAG 0.0.4.2)
+set_tag(manif_TAG 0.0.4.3)
 set_tag(qhull_TAG 2020.2)
 set_tag(CppAD_TAG 20220000.4)
 set_tag(casadi 3.5.5.3)

--- a/cmake/ProjectsTagsUnstable.cmake
+++ b/cmake/ProjectsTagsUnstable.cmake
@@ -7,7 +7,7 @@ endmacro()
 # External projects
 set_tag(osqp_TAG v0.6.2)
 set_tag(manif_REPOSITORY robotology-dependencies/manif.git)
-set_tag(manif_TAG 0.0.4.2)
+set_tag(manif_TAG 0.0.4.3)
 set_tag(qhull_TAG 2020.2)
 set_tag(CppAD_TAG 20220000.4)
 set_tag(casadi 3.5.5.3)

--- a/doc/cmake-options.md
+++ b/doc/cmake-options.md
@@ -430,7 +430,7 @@ sudo bash ./scripts/install_apt_python_dependencies.sh
 #### Conda
 To install python and the other required dependencies when using `conda-forge` provided dependencies, use:
 ~~~
-mamba install -c conda-forge python=3.10 numpy swig pybind11 pyqt matplotlib h5py tornado u-msgpack-python pyzmq ipython
+mamba install -c conda-forge python numpy swig pybind11 pyqt matplotlib h5py tornado u-msgpack-python pyzmq ipython
 ~~~
 
 ### Check the installation

--- a/releases/latest.releases.yaml
+++ b/releases/latest.releases.yaml
@@ -10,7 +10,7 @@ repositories:
   manif:
     type: git
     url: https://github.com/robotology-dependencies/manif.git
-    version: 0.0.4.2
+    version: 0.0.4.3
   qhull:
     type: git
     url: https://github.com/qhull/qhull.git


### PR DESCRIPTION
Fix https://github.com/robotology/robotology-superbuild/issues/1298
Revert https://github.com/robotology/robotology-superbuild/pull/1299