### PR TITLE
Disable blf's YarpRobotLoggerDevice  compilation on macOS and Windows

### DIFF
--- a/cmake/Buildbipedal-locomotion-framework.cmake
+++ b/cmake/Buildbipedal-locomotion-framework.cmake
@@ -53,6 +53,11 @@ if(ROBOTOLOGY_USES_PCL_AND_VTK)
   list(APPEND bipedal-locomotion-framework_OPTIONAL_CMAKE_ARGS "-DFRAMEWORK_USE_PCL:BOOL=ON")
 endif()
 
+# Workaround for part of https://github.com/robotology/robotology-superbuild/issues/1307
+if(APPLE OR WIN32)
+  list(APPEND bipedal-locomotion-framework_OPTIONAL_CMAKE_ARGS "-DENABLE_YarpRobotLoggerDevice:BOOL=OFF")
+endif()
+
 ycm_ep_helper(bipedal-locomotion-framework TYPE GIT
               STYLE GITHUB
               REPOSITORY ami-iit/bipedal-locomotion-framework.git


### PR DESCRIPTION
Workaround for https://github.com/robotology/robotology-superbuild/issues/1307, to get the Stable branches to compile fine.