### PR TITLE
Disable iCub_SIM compilation for Unstable branches

### DIFF
--- a/cmake/BuildICUB.cmake
+++ b/cmake/BuildICUB.cmake
@@ -16,8 +16,9 @@ if(ROBOTOLOGY_ENABLE_ICUB_HEAD)
   list(APPEND ICUB_DEPENDS icub_firmware_shared)
 endif()
 
-  # See discussion in https://github.com/robotology/icub-main/issues/551
-if (APPLE)
+# See discussion in https://github.com/robotology/icub-main/issues/551
+# Workaround for https://github.com/robotology/icub-main/issues/842
+if (APPLE OR (ROBOTOLOGY_PROJECT_TAGS STREQUAL "Unstable"))
   set(ICUBMAIN_COMPILE_SIMULATORS OFF)
 else()
   set(ICUBMAIN_COMPILE_SIMULATORS ON)


### PR DESCRIPTION
Workaround for:
* https://github.com/robotology/icub-main/issues/842
* https://github.com/robotology/robotology-superbuild/issues/1307