### PR TITLE
Fix generate-conda-packages job

### DIFF
--- a/.github/workflows/generate-conda-packages.yaml
+++ b/.github/workflows/generate-conda-packages.yaml
@@ -102,6 +102,7 @@ jobs:
         - name: Dependencies for conda recipes generation and upload
           shell: bash -l {0}
           run: |
+            mamba update -n base mamba
             mamba install pyyaml jinja2 conda-build ninja anaconda-client conda-forge-pinning mamba boa multisheller
 
         - name: Print used environment

--- a/.github/workflows/generate-conda-packages.yaml
+++ b/.github/workflows/generate-conda-packages.yaml
@@ -102,7 +102,7 @@ jobs:
         - name: Dependencies for conda recipes generation and upload
           shell: bash -l {0}
           run: |
-            mamba install pyyaml jinja2 conda-build ninja anaconda-client conda-forge-pinning mamba boa multisheller liblief=0.11.5
+            mamba install pyyaml jinja2 conda-build ninja anaconda-client conda-forge-pinning mamba boa multisheller
 
         - name: Print used environment
           shell: bash -l {0}

--- a/.github/workflows/generate-conda-packages.yaml
+++ b/.github/workflows/generate-conda-packages.yaml
@@ -65,10 +65,8 @@ jobs:
 
         - uses: conda-incubator/setup-miniconda@v2
           with:
-            mamba-version: "*"
-            channels: conda-forge
-            channel-priority: true
-            python-version: "3.8"
+            miniforge-variant: Mambaforge
+            miniforge-version: latest
 
         - name: Install files to enable compilation of mex files [Conda/Linux]
           if: contains(matrix.os, 'ubuntu')
@@ -98,11 +96,9 @@ jobs:
             echo "GHA_Matlab_ROOT_DIR=${GITHUB_WORKSPACE}/msdk_R2020a_mexw64" >> $GITHUB_ENV
             echo "GHA_Matlab_MEX_EXTENSION=mexw64" >> $GITHUB_ENV
 
-        # Python 3.8 is required by https://github.com/Anaconda-Platform/anaconda-client/pull/551
         - name: Dependencies for conda recipes generation and upload
           shell: bash -l {0}
           run: |
-            mamba update -n base mamba
             mamba install pyyaml jinja2 conda-build ninja anaconda-client conda-forge-pinning mamba boa multisheller
 
         - name: Print used environment

--- a/.github/workflows/generate-conda-packages.yaml
+++ b/.github/workflows/generate-conda-packages.yaml
@@ -62,6 +62,14 @@ jobs:
 
         steps:
         - uses: actions/checkout@v2
+        
+        - name: Debug conda
+          if: contains(matrix.os, 'ubuntu')
+          run: |
+            echo "==========> Checking conda"
+            which conda
+            conda config --show
+            echo "==========> Checking conda end"
 
         - uses: conda-incubator/setup-miniconda@v2
           with:


### PR DESCRIPTION
Changes:
* Use mambaforge as base installed, as done in https://github.com/robotology/robotology-superbuild/pull/840
* Drop liblief constraint, hopefully it will help with https://github.com/robotology/robotology-superbuild/issues/1315, see:
  * https://github.com/conda-forge/conda-forge.github.io/issues/1823
  * https://github.com/conda-forge/conda-smithy/pull/1686