### PR TITLE
Bump casadi to 3.5.5.4

### DIFF
--- a/cmake/ProjectsTagsStable.cmake
+++ b/cmake/ProjectsTagsStable.cmake
@@ -10,7 +10,7 @@ set_tag(manif_REPOSITORY robotology-dependencies/manif.git)
 set_tag(manif_TAG 0.0.4.102)
 set_tag(qhull_TAG 2020.2)
 set_tag(CppAD_TAG 20220000.4)
-set_tag(casadi 3.5.5.3)
+set_tag(casadi 3.5.5.4)
 
 # Robotology projects
 set_tag(YCM_TAG ycm-0.14)

--- a/cmake/ProjectsTagsUnstable.cmake
+++ b/cmake/ProjectsTagsUnstable.cmake
@@ -10,7 +10,7 @@ set_tag(manif_REPOSITORY robotology-dependencies/manif.git)
 set_tag(manif_TAG 0.0.4.102)
 set_tag(qhull_TAG 2020.2)
 set_tag(CppAD_TAG 20220000.4)
-set_tag(casadi 3.5.5.3)
+set_tag(casadi 3.5.5.4)
 
 # Robotology projects
 set_tag(YARP_TAG master)

--- a/releases/latest.releases.yaml
+++ b/releases/latest.releases.yaml
@@ -22,7 +22,7 @@ repositories:
   casadi:
     type: git
     url: https://github.com/ami-iit/casadi.git
-    version: 3.5.5.3
+    version: 3.5.5.4
   YCM:
     type: git
     url: https://github.com/robotology/ycm.git


### PR DESCRIPTION
This is to ensure that `pip list` lists the casadi package installed by the superbuild, see:
* https://github.com/casadi/casadi/pull/2878
* https://github.com/ami-iit/casadi/pull/1

Actually fixes (even if for some reason we already closed it) https://github.com/robotology/robotology-superbuild/issues/1012 .