### PR TITLE
Add workaround for breakage of brew upgrade in GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -363,7 +363,14 @@ jobs:
       run: |
         cd ${ROBOTOLOGY_SUPERBUILD_SOURCE_DIR}
         cmake --version
-        # Update homebrew 
+        # Workaround for https://github.com/robotology/robotology-superbuild/issues/1321
+        # See https://github.com/actions/setup-python/issues/577#issuecomment-1365231810
+        rm /usr/local/bin/2to3 || true
+        rm /usr/local/bin/idle3 || true
+        rm /usr/local/bin/pydoc3 || true
+        rm /usr/local/bin/python3 || true
+        rm /usr/local/bin/python3-config || true
+        # Update homebrew
         brew update
         brew upgrade
         brew install --cask xquartz

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -368,8 +368,11 @@ jobs:
         rm /usr/local/bin/2to3 || true
         rm /usr/local/bin/2to3-3.11 || true
         rm /usr/local/bin/idle3 || true
+        rm /usr/local/bin/idle3.11 || true
         rm /usr/local/bin/pydoc3 || true
+        rm /usr/local/bin/pydoc3.11 || true
         rm /usr/local/bin/python3 || true
+        rm /usr/local/bin/python3.11 || true
         rm /usr/local/bin/python3-config || true
         # Update homebrew
         brew update

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -366,6 +366,7 @@ jobs:
         # Workaround for https://github.com/robotology/robotology-superbuild/issues/1321
         # See https://github.com/actions/setup-python/issues/577#issuecomment-1365231810
         rm /usr/local/bin/2to3 || true
+        rm /usr/local/bin/2to3-3.11 || true
         rm /usr/local/bin/idle3 || true
         rm /usr/local/bin/pydoc3 || true
         rm /usr/local/bin/python3 || true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -374,6 +374,7 @@ jobs:
         rm /usr/local/bin/python3 || true
         rm /usr/local/bin/python3.11 || true
         rm /usr/local/bin/python3-config || true
+        rm /usr/local/bin/python3.11-config || true
         # Update homebrew
         brew update
         brew upgrade


### PR DESCRIPTION
Workaround for https://github.com/robotology/robotology-superbuild/issues/1321 . 

I prefer to avoid working on Homebrew this days, but unfortunatly GitHub Action upstream is taking some time to address this, so it is better to have some dirty workaround to avoid the noise of build failures.

