### PR TITLE
Enable the POS service by default when ICUB_HEAD in enabled

### DIFF
--- a/cmake/BuildICUB.cmake
+++ b/cmake/BuildICUB.cmake
@@ -89,6 +89,7 @@ ycm_ep_helper(ICUB TYPE GIT
                                     -DENABLE_icubmod_embObjVirtualAnalogSensor:BOOL=${ROBOTOLOGY_ENABLE_ICUB_HEAD}
                                     -DENABLE_icubmod_parametricCalibrator:BOOL=${ROBOTOLOGY_ENABLE_ICUB_HEAD}
                                     -DENABLE_icubmod_parametricCalibratorEth:BOOL=${ROBOTOLOGY_ENABLE_ICUB_HEAD}
+                                    -DENABLE_icubmod_embObjPOS:BOOL=${ROBOTOLOGY_ENABLE_ICUB_HEAD}
                                     -DENABLE_icubmod_xsensmtx:BOOL=${ENABLE_icubmod_xsensmtx}
                                     -DENABLE_icubmod_socketcan:BOOL=${ENABLE_icubmod_socketcan}
                                     -DICUB_USE_icub_firmware_shared:BOOL=${ROBOTOLOGY_ENABLE_ICUB_HEAD}


### PR DESCRIPTION
**What's new:**

- This change enables the POS service by default when building the `robotology-superbuild` with ICUB_HEAD=ON. The `POS` service is mandatory to be able to read the absolute encoders mounted on `ergoCub's` hands. 


**Notes:**
- Other robots are not affected by this change
