### PR TITLE
Install jpeg until conda-forge is migrated to libjpeg-turbo

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,7 +75,7 @@ jobs:
       shell: bash -l {0}
       run: |
         # Dependencies
-        mamba install ace asio assimp boost eigen freetype gazebo glew glfw glm graphviz gsl ipopt irrlicht libjpeg-turbo libmatio libode libxml2 nlohmann_json pcl vtk "opencv==4.6" portaudio qt-main sdl sdl2 sqlite tinyxml spdlog lua soxr cmake compilers make ninja pkg-config
+        mamba install ace asio assimp boost eigen freetype gazebo glew glfw glm graphviz gsl ipopt irrlicht jpeg libmatio libode libxml2 nlohmann_json pcl vtk "opencv==4.6" portaudio qt-main sdl sdl2 sqlite tinyxml spdlog lua soxr cmake compilers make ninja pkg-config
         # Python 
         mamba install python numpy swig pybind11 pyqt matplotlib h5py tornado u-msgpack-python pyzmq ipython
 

--- a/doc/conda-forge.md
+++ b/doc/conda-forge.md
@@ -111,7 +111,7 @@ of the robotology-superbuild.**
 
 Once you activated it, you can install packages in it. In particular the dependencies for the robotology-superbuild can be installed as:
 ~~~
-mamba install -c conda-forge ace asio assimp boost eigen freetype gazebo glew glfw glm graphviz gsl ipopt irrlicht libjpeg-turbo libmatio libode libxml2 nlohmann_json pcl "opencv<=4.6" portaudio qt-main sdl sdl2 sqlite tinyxml spdlog lua soxr qhull cmake compilers make ninja pkg-config
+mamba install -c conda-forge ace asio assimp boost eigen freetype gazebo glew glfw glm graphviz gsl ipopt irrlicht jpeg libmatio libode libxml2 nlohmann_json pcl "opencv<=4.6" portaudio qt-main sdl sdl2 sqlite tinyxml spdlog lua soxr qhull cmake compilers make ninja pkg-config
 ~~~
 
 If you are on **Linux**, you also need to install also the following packages:


### PR DESCRIPTION
Until conda-forge fully migrates to libjpeg-turbo (see https://github.com/conda-forge/conda-forge.github.io/issues/673), we should install the old plan jpeg library.

Fix https://github.com/robotology/robotology-superbuild/issues/1344 .