### PR TITLE
Add advanced CMake option ROBOTOLOGY_USES_CSHARP to enable compilation of C# bindings on YARP

### DIFF
--- a/cmake/BuildYARP.cmake
+++ b/cmake/BuildYARP.cmake
@@ -19,7 +19,7 @@ if(APPLE)
   list(APPEND YARP_OPTIONAL_CMAKE_ARGS "-DYARP_USE_SYSTEM_SQLite:BOOL=OFF")
 endif()
 
-if(ROBOTOLOGY_USES_PYTHON OR ROBOTOLOGY_USES_LUA)
+if(ROBOTOLOGY_USES_PYTHON OR ROBOTOLOGY_USES_LUA OR ROBOTOLOGY_USES_CSHARP)
   set(YARP_COMPILE_BINDINGS ON)
 else()
   set(YARP_COMPILE_BINDINGS OFF)
@@ -119,6 +119,7 @@ ycm_ep_helper(YARP TYPE GIT
                               -DYARP_USE_SDL:BOOL=ON
                               -DCREATE_PYTHON:BOOL=${ROBOTOLOGY_USES_PYTHON}
                               -DCREATE_LUA:BOOL=${ROBOTOLOGY_USES_LUA}
+                              -DCREATE_CSHARP:BOOL=${ROBOTOLOGY_USES_CSHARP}
                               -DENABLE_yarpmod_usbCamera:BOOL=${ENABLE_USBCAMERA}
                               -DENABLE_yarpmod_usbCameraRaw:BOOL=${ENABLE_USBCAMERA}
                               ${YARP_OPTIONAL_CMAKE_ARGS})

--- a/cmake/RobotologySuperbuildOptions.cmake
+++ b/cmake/RobotologySuperbuildOptions.cmake
@@ -16,6 +16,8 @@ option(ROBOTOLOGY_USES_OCTAVE "Enable compilation of software that depend on Oct
 option(ROBOTOLOGY_USES_LUA "Enable compilation of software that depend on Lua" FALSE)
 mark_as_advanced(ROBOTOLOGY_USES_LUA)
 option(ROBOTOLOGY_USES_PYTHON "Enable compilation of software that depend on Python" FALSE)
+option(ROBOTOLOGY_USES_CSHARP "Enable compilation of software that depends on CSharp" FALSE)
+mark_as_advanced(ROBOTOLOGY_USES_CSHARP)
 
 ## Enable packages that depend on the Gazebo Classic simulator
 option(ROBOTOLOGY_USES_GAZEBO "Enable compilation of software that depends on Gazebo Classic" ON)


### PR DESCRIPTION
Fix https://github.com/robotology/robotology-superbuild/issues/1341 .

This PR only adds the minimal logic for the `ROBOTOLOGY_USES_CSHARP` option, and it marks it is as advanced so that it is hidden by default. The steps for making this option fully supported are described in https://github.com/robotology/robotology-superbuild/issues/1347. As nobody that I am collaborating with is using C#, I will not look into this, but contribution from the community in form of Pull Request will be welcome.


