### PR TITLE
Remove legacy workaround for conda packages generation

### DIFF
--- a/cmake/BuildICUB.cmake
+++ b/cmake/BuildICUB.cmake
@@ -94,12 +94,7 @@ ycm_ep_helper(ICUB TYPE GIT
                                     -DCREATE_PYTHON:BOOL=${ROBOTOLOGY_USES_PYTHON}
                                     -DCREATE_LUA:BOOL=${ROBOTOLOGY_USES_LUA})
 
-# Options related to generation of conda binary packages
-# ipopt pinning to 3.14.10 and explicit run dependency are workarounds,
-# see https://github.com/robotology/robotology-superbuild/pull/1333
-# for more info
-set(ICUB_CONDA_DEPENDENCIES ace libopencv gsl ipopt=3.14.10 libode qt-main sdl)
-set(ICUB_CONDA_RUN_DEPENDENCIES_EXPLICIT ipopt=3.14.10)
+set(ICUB_CONDA_DEPENDENCIES ace libopencv gsl ipopt libode qt-main sdl)
 
 if(NOT (APPLE OR WIN32))
   list(APPEND ICUB_CONDA_DEPENDENCIES libdc1394)

--- a/conda/conda_build_config.yml
+++ b/conda/conda_build_config.yml
@@ -8,14 +8,3 @@ qt:
 
 qt_main:
   - 5.15
-  
-ipopt:
-  - 3.14.8
-
-# Some packages (vtk) to build require a specific version of boost but without
-# any run or run_dependency
-# Workaround for https://github.com/robotology/robotology-superbuild/pull/1277
-boost:
-  - 1.78.0
-boost_cpp:
-  - 1.78.0


### PR DESCRIPTION
The problem have been fixed upstream.