### PR TITLE
Avoid cmake 3.26 when installing dependencies from conda-forge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,7 +75,7 @@ jobs:
       shell: bash -l {0}
       run: |
         # Dependencies
-        mamba install ace asio assimp boost eigen freetype gazebo glew glfw glm graphviz gsl ipopt irrlicht jpeg libmatio libode libxml2 nlohmann_json pcl vtk "opencv==4.6" portaudio qt-main sdl sdl2 sqlite tinyxml spdlog lua soxr cmake compilers make ninja pkg-config
+        mamba install ace asio assimp boost eigen freetype gazebo glew glfw glm graphviz gsl ipopt irrlicht jpeg libmatio libode libxml2 nlohmann_json pcl vtk "opencv==4.6" portaudio qt-main sdl sdl2 sqlite tinyxml spdlog lua soxr "cmake==3.25" compilers make ninja pkg-config
         # Python 
         mamba install python numpy swig pybind11 pyqt matplotlib h5py tornado u-msgpack-python pyzmq ipython
 

--- a/doc/conda-forge.md
+++ b/doc/conda-forge.md
@@ -111,7 +111,7 @@ of the robotology-superbuild.**
 
 Once you activated it, you can install packages in it. In particular the dependencies for the robotology-superbuild can be installed as:
 ~~~
-mamba install -c conda-forge ace asio assimp boost eigen freetype gazebo glew glfw glm graphviz gsl ipopt irrlicht jpeg libmatio libode libxml2 nlohmann_json pcl "opencv<=4.6" portaudio qt-main sdl sdl2 sqlite tinyxml spdlog lua soxr qhull cmake compilers make ninja pkg-config
+mamba install -c conda-forge ace asio assimp boost eigen freetype gazebo glew glfw glm graphviz gsl ipopt irrlicht jpeg libmatio libode libxml2 nlohmann_json pcl "opencv<=4.6" portaudio qt-main sdl sdl2 sqlite tinyxml spdlog lua soxr qhull "cmake<=3.25" compilers make ninja pkg-config
 ~~~
 
 If you are on **Linux**, you also need to install also the following packages:


### PR DESCRIPTION
Temporary workaround for https://github.com/robotology/robotology-superbuild/issues/1366 at least for conda-forge, while on homebrew we can't pin software to older versions.