### PR TITLE
Add workaround for MATLAB problems with faulty Linux drivers in setup.sh

### DIFF
--- a/cmake/template/setup.sh.in
+++ b/cmake/template/setup.sh.in
@@ -54,4 +54,6 @@ export YARP_DATA_DIRS=$YARP_DATA_DIRS:${ROBOTOLOGY_SUPERBUILD_INSTALL_PREFIX}/sh
 export GAZEBO_MODEL_PATH=$GAZEBO_MODEL_PATH:${ROBOTOLOGY_SUPERBUILD_INSTALL_PREFIX}/share/RRbot/robots
 # Configure the Matlab path
 export MATLABPATH=${MATLABPATH:+${MATLABPATH}:}${ROBOTOLOGY_SUPERBUILD_INSTALL_PREFIX}/mex:${ROBOTOLOGY_SUPERBUILD_INSTALL_PREFIX}/mex/+wbc/simulink/MomentumVelocityControl:${ROBOTOLOGY_SUPERBUILD_INSTALL_PREFIX}/mex/+wbc/simulink:${ROBOTOLOGY_SUPERBUILD_INSTALL_PREFIX}/mex/+wbc/examples:${ROBOTOLOGY_SUPERBUILD_INSTALL_PREFIX}/share/WBToolbox:${ROBOTOLOGY_SUPERBUILD_INSTALL_PREFIX}/share/WBToolbox/images
+# Avoid problems with buggy Linux drivers, see https://github.com/robotology/robotology-superbuild/issues/953
+export JAVA_TOOL_OPTIONS="${JAVA_TOOL_OPTIONS} -Djogl.disable.openglarbcontext=1"
 @endcmakeif ROBOTOLOGY_USES_MATLAB


### PR DESCRIPTION
This should finally fix https://github.com/robotology/robotology-superbuild/issues/953, i.e. the fact that a lot of users of the superbuild out of the box experience problems such as:
~~~
com.jogamp.opengl.GLException: X11GLXDrawableFactory - Could not initialize shared resources for X11GraphicsDevice[type .x11, connection :0, unitID 0, handle 0x0, owner false, ResourceToolkitLock[obj 0xc2145e1, isOwner false, <513205f6, 4fc7f75b>[count 0, qsz 0, owner ]]]
at jogamp.opengl.x11.glx.X11GLXDrawableFactory$SharedResourceImplementation.createSharedResource(X11GLXDrawableFactory.java:326)
at jogamp.opengl.SharedResourceRunner.run(SharedResourceRunner.java:297)
at java.lang.Thread.run(Thread.java:748)
Caused by: java.lang.NullPointerException
at jogamp.opengl.GLContextImpl.makeCurrent(GLContextImpl.java:688)
at jogamp.opengl.GLContextImpl.makeCurrent(GLContextImpl.java:580)
at jogamp.opengl.x11.glx.X11GLXDrawableFactory$SharedResourceImplementation.createSharedResource(X11GLXDrawableFactory.java:297)
... 2 more
MATLAB has experienced a low-level graphics error, and may not have drawn correctly.
Read about what you can do to prevent this issue at [Resolving Low-Level Graphics Issues then restart MATLAB](https://www.mathworks.com/help/matlab/creating_plots/resolving-low-level-graphics-issues.html).
To share details of this issue with MathWorks technical support,
please include this file with your service request.
~~~

A possible workaround for this is to set the following environment variable:
~~~
export JAVA_TOOL_OPTIONS="${JAVA_TOOL_OPTIONS} -Djogl.disable.openglarbcontext=1"
~~~

The proposed fix apparently should only create "performance and graphics quality decrease", so to avoid all the problems that we experienced in the past, in this PR we propose to add `export JAVA_TOOL_OPTIONS="${JAVA_TOOL_OPTIONS} -Djogl.disable.openglarbcontext=1"` to the Linux `setup.sh`. To avoid mantainance problem, we do not set this in the conda packages, as anyhow most of use of MATLAB-enabled conda packages is happening on Windows that is not affected by this problem.