### PR TITLE
Update casadi to 3.6.0 and add proxsuite C++ library

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -383,7 +383,7 @@ jobs:
         brew upgrade
         brew install --cask xquartz
         # Core dependencies
-        brew install ace assimp bash-completion boost cmake eigen graphviz gsl ipopt jpeg libedit nlohmann-json opencv pkg-config portaudio qt@5 sqlite swig tinyxml
+        brew install ace assimp bash-completion boost cmake eigen graphviz gsl ipopt jpeg libedit nlohmann-json opencv pkg-config portaudio qt@5 sqlite swig tinyxml tinyxml2
         # ROBOTOLOGY_ENABLE_DYNAMICS dependencies
         brew install libmatio irrlicht spdlog
         # ROBOTOLOGY_ENABLE_DYNAMICS_FULL_DEPS (qhull and cppad are installed  with brew)

--- a/apt.txt
+++ b/apt.txt
@@ -22,6 +22,7 @@ libode-dev
 libopencv-dev
 libsdl1.2-dev
 libtinyxml-dev
+libtinyxml2-dev
 libv4l-dev
 libxml2-dev
 lsb-release

--- a/cmake/Buildcasadi-matlab-bindings.cmake
+++ b/cmake/Buildcasadi-matlab-bindings.cmake
@@ -7,7 +7,7 @@ find_or_build_package(casadi QUIET)
 
 ycm_ep_helper(casadi-matlab-bindings TYPE GIT
               STYLE GITHUB
-              REPOSITORY dic-iit/casadi-matlab-bindings.git
+              REPOSITORY ami-iit/casadi-matlab-bindings.git
               TAG main
               COMPONENT dynamics
               FOLDER src

--- a/cmake/Buildcasadi.cmake
+++ b/cmake/Buildcasadi.cmake
@@ -6,6 +6,7 @@ include(YCMEPHelper)
 
 include(FindOrBuildPackage)
 find_or_build_package(osqp QUIET)
+find_or_build_package(proxsuite QUIET)
 
 if(MSVC AND ROBOTOLOGY_USES_PYTHON)
   set(WITH_COPYSIGN_UNDEF ON)
@@ -21,6 +22,9 @@ ycm_ep_helper(casadi TYPE GIT
               FOLDER src
               CMAKE_ARGS -DWITH_IPOPT:BOOL=ON
                          -DWITH_OSQP:BOOL=ON
+                         -DWITH_BUILD_OSQP:BOOL=OFF
+                         -DWITH_PROXQP:BOOL=ON
+                         -DWITH_BUILD_PROXQP:BOOL=OFF
                          -DWITH_EXAMPLES:BOOL=OFF
                          -DUSE_SYSTEM_WISE_OSQP:BOOL=ON
                          -DINCLUDE_PREFIX:PATH=include
@@ -31,12 +35,12 @@ ycm_ep_helper(casadi TYPE GIT
                          -DWITH_PYTHON3:BOOL=${ROBOTOLOGY_USES_PYTHON}
                          -DWITH_COPYSIGN_UNDEF:BOOL=${WITH_COPYSIGN_UNDEF}
                          -DPYTHON_PREFIX:PATH=${ROBOTOLOGY_SUPERBUILD_PYTHON_INSTALL_DIR}
-              DEPENDS osqp)
+              DEPENDS osqp proxsuite)
 
 set(casadi_CONDA_PKG_NAME casadi)
 set(casadi_CONDA_PKG_CONDA_FORGE_OVERRIDE ON)
 # This is a small hack. To avoid incompatibilities between the version tagged in the ami-iit fork
-# (something like 3.5.5.x) and the version available in conda-forge when generating conda metapackages
+# (something like 3.6.0.x) and the version available in conda-forge when generating conda metapackages
 # such as robotology-distro and robotology-distro-all, we override the conda package version of casadi
 # here. This needs to be removed as soon as we stop use our fork in the superbuild 
 set(casadi_CONDA_VERSION 3.6.0)

--- a/cmake/Buildcasadi.cmake
+++ b/cmake/Buildcasadi.cmake
@@ -15,6 +15,9 @@ list(APPEND casadi_DEPENDS osqp)
 if(NOT MSVC OR MSVC_VERSION VERSION_GREATER_EQUAL 1930)
   find_or_build_package(proxsuite QUIET)
   list(APPEND casadi_DEPENDS proxsuite)
+  set(casadi_WITH_PROXQP ON)
+else()
+  set(casadi_WITH_PROXQP OFF)
 endif()
 
 if(MSVC AND ROBOTOLOGY_USES_PYTHON)
@@ -33,7 +36,7 @@ ycm_ep_helper(casadi TYPE GIT
                          -DWITH_BUILD_IPOPT:BOOL=OFF
                          -DWITH_OSQP:BOOL=ON
                          -DWITH_BUILD_OSQP:BOOL=OFF
-                         -DWITH_PROXQP:BOOL=ON
+                         -DWITH_PROXQP:BOOL=${casadi_WITH_PROXQP}
                          -DWITH_BUILD_PROXQP:BOOL=OFF
                          -DWITH_TINYXML=ON
                          -DWITH_BUILD_TINYXML=OFF

--- a/cmake/Buildcasadi.cmake
+++ b/cmake/Buildcasadi.cmake
@@ -15,8 +15,8 @@ endif()
 
 ycm_ep_helper(casadi TYPE GIT
               STYLE GITHUB
-              REPOSITORY dic-iit/casadi.git
-              TAG support_osqp_0.6.2
+              REPOSITORY ami-iit/casadi.git
+              TAG 3.6_ami_integraton
               COMPONENT external
               FOLDER src
               CMAKE_ARGS -DWITH_IPOPT:BOOL=ON
@@ -39,5 +39,5 @@ set(casadi_CONDA_PKG_CONDA_FORGE_OVERRIDE ON)
 # (something like 3.5.5.x) and the version available in conda-forge when generating conda metapackages
 # such as robotology-distro and robotology-distro-all, we override the conda package version of casadi
 # here. This needs to be removed as soon as we stop use our fork in the superbuild 
-set(casadi_CONDA_VERSION 3.5.5)
+set(casadi_CONDA_VERSION 3.6.0)
 

--- a/cmake/Buildcasadi.cmake
+++ b/cmake/Buildcasadi.cmake
@@ -26,14 +26,17 @@ endif()
 ycm_ep_helper(casadi TYPE GIT
               STYLE GITHUB
               REPOSITORY ami-iit/casadi.git
-              TAG 3.6_ami_integraton
+              TAG 3.6_ami_integration
               COMPONENT external
               FOLDER src
               CMAKE_ARGS -DWITH_IPOPT:BOOL=ON
+                         -DWITH_BUILD_IPOPT:BOOL=OFF
                          -DWITH_OSQP:BOOL=ON
                          -DWITH_BUILD_OSQP:BOOL=OFF
                          -DWITH_PROXQP:BOOL=ON
                          -DWITH_BUILD_PROXQP:BOOL=OFF
+                         -DWITH_TINYXML=ON
+                         -DWITH_BUILD_TINYXML=OFF
                          -DWITH_EXAMPLES:BOOL=OFF
                          -DUSE_SYSTEM_WISE_OSQP:BOOL=ON
                          -DINCLUDE_PREFIX:PATH=include

--- a/cmake/Buildcasadi.cmake
+++ b/cmake/Buildcasadi.cmake
@@ -5,8 +5,17 @@
 include(YCMEPHelper)
 
 include(FindOrBuildPackage)
+
+set(casadi_DEPENDS "")
+
 find_or_build_package(osqp QUIET)
-find_or_build_package(proxsuite QUIET)
+list(APPEND casadi_DEPENDS osqp)
+
+# proxqp only supports MSVC Toolset v143, i.e. Visual Studio 2022
+if(NOT MSVC OR MSVC_VERSION VERSION_GREATER_EQUAL 1930)
+  find_or_build_package(proxsuite QUIET)
+  list(APPEND casadi_DEPENDS proxsuite)
+endif()
 
 if(MSVC AND ROBOTOLOGY_USES_PYTHON)
   set(WITH_COPYSIGN_UNDEF ON)
@@ -35,7 +44,7 @@ ycm_ep_helper(casadi TYPE GIT
                          -DWITH_PYTHON3:BOOL=${ROBOTOLOGY_USES_PYTHON}
                          -DWITH_COPYSIGN_UNDEF:BOOL=${WITH_COPYSIGN_UNDEF}
                          -DPYTHON_PREFIX:PATH=${ROBOTOLOGY_SUPERBUILD_PYTHON_INSTALL_DIR}
-              DEPENDS osqp proxsuite)
+              DEPENDS ${casadi_DEPENDS})
 
 set(casadi_CONDA_PKG_NAME casadi)
 set(casadi_CONDA_PKG_CONDA_FORGE_OVERRIDE ON)

--- a/cmake/Buildproxsuite.cmake
+++ b/cmake/Buildproxsuite.cmake
@@ -2,12 +2,17 @@
 
 include(YCMEPHelper)
 
+# At the moment we pass BUILD_WITH_VECTORIZATION_SUPPORT as the simde dependency
+# is available out of the box just on Ubuntu 22.04, and because anyhow casadi
+# will link the non-vectorized version
+# However, as the superbuild is tipically compiled in the same machine in
+# which the binaries run, it could make sense to actualize support vectorization
 ycm_ep_helper(proxsuite TYPE GIT
               STYLE GITHUB
               REPOSITORY Simple-Robotics/proxsuite.git
               TAG main
               COMPONENT external
               FOLDER src
-              CMAKE_ARGS -DBUILD_TESTING:BOOL=OFF -DINSTALL_DOCUMENTATION:BOOL=OFF -DBUILD_PYTHON_INTERFACE:BOOL=OFF)
+              CMAKE_ARGS -DBUILD_TESTING:BOOL=OFF -DINSTALL_DOCUMENTATION:BOOL=OFF -DBUILD_PYTHON_INTERFACE:BOOL=OFF -DBUILD_WITH_VECTORIZATION_SUPPORT:BOOL=OFF)
 
 set(proxsuite_CONDA_PKG_CONDA_FORGE_OVERRIDE ON)

--- a/cmake/Buildproxsuite.cmake
+++ b/cmake/Buildproxsuite.cmake
@@ -1,0 +1,13 @@
+# Copyright (C) Fondazione Istituto Italiano di Tecnologia
+
+include(YCMEPHelper)
+
+ycm_ep_helper(proxsuite TYPE GIT
+              STYLE GITHUB
+              REPOSITORY Simple-Robotics/proxsuite.git
+              TAG main
+              COMPONENT external
+              FOLDER src
+              CMAKE_ARGS -DBUILD_TESTING:BOOL=OFF -DINSTALL_DOCUMENTATION:BOOL=OFF -DBUILD_PYTHON_INTERFACE:BOOL=OFF)
+
+set(proxsuite_CONDA_PKG_CONDA_FORGE_OVERRIDE ON)

--- a/cmake/ProjectsTagsStable.cmake
+++ b/cmake/ProjectsTagsStable.cmake
@@ -10,8 +10,8 @@ set_tag(manif_REPOSITORY robotology-dependencies/manif.git)
 set_tag(manif_TAG 0.0.4.102)
 set_tag(qhull_TAG 2020.2)
 set_tag(CppAD_TAG 20230000.0)
-set_tag(proxsuite 0.3.6)
-set_tag(casadi 3.6.0.1)
+set_tag(proxsuite_TAG 0.3.6)
+set_tag(casadi_TAG 3.6.0.1)
 
 # Robotology projects
 set_tag(YCM_TAG master)

--- a/cmake/ProjectsTagsStable.cmake
+++ b/cmake/ProjectsTagsStable.cmake
@@ -10,7 +10,7 @@ set_tag(manif_REPOSITORY robotology-dependencies/manif.git)
 set_tag(manif_TAG 0.0.4.102)
 set_tag(qhull_TAG 2020.2)
 set_tag(CppAD_TAG 20230000.0)
-set_tag(proxsuite_TAG 0.3.6)
+set_tag(proxsuite_TAG v0.3.6)
 set_tag(casadi_TAG 3.6.0.1)
 
 # Robotology projects

--- a/cmake/ProjectsTagsStable.cmake
+++ b/cmake/ProjectsTagsStable.cmake
@@ -11,7 +11,7 @@ set_tag(manif_TAG 0.0.4.102)
 set_tag(qhull_TAG 2020.2)
 set_tag(CppAD_TAG 20230000.0)
 set_tag(proxsuite_TAG v0.3.6)
-set_tag(casadi_TAG 3.6.0.1)
+set_tag(casadi_TAG 3.6_ami_integration)
 set_tag(casadi-matlab-bindings_TAG v3.6.0.0)
 
 # Robotology projects

--- a/cmake/ProjectsTagsStable.cmake
+++ b/cmake/ProjectsTagsStable.cmake
@@ -10,7 +10,8 @@ set_tag(manif_REPOSITORY robotology-dependencies/manif.git)
 set_tag(manif_TAG 0.0.4.102)
 set_tag(qhull_TAG 2020.2)
 set_tag(CppAD_TAG 20230000.0)
-set_tag(casadi 3.5.5.4)
+set_tag(proxsuite 0.3.6)
+set_tag(casadi 3.6.0.1)
 
 # Robotology projects
 set_tag(YCM_TAG master)

--- a/cmake/ProjectsTagsUnstable.cmake
+++ b/cmake/ProjectsTagsUnstable.cmake
@@ -10,8 +10,8 @@ set_tag(manif_REPOSITORY robotology-dependencies/manif.git)
 set_tag(manif_TAG 0.0.4.102)
 set_tag(qhull_TAG 2020.2)
 set_tag(CppAD_TAG 20230000.0)
-set_tag(proxsuite 0.3.6)
-set_tag(casadi 3.6.0.1)
+set_tag(proxsuite_TAG 0.3.6)
+set_tag(casadi_TAG 3.6.0.1)
 
 # Robotology projects
 set_tag(YARP_TAG master)

--- a/cmake/ProjectsTagsUnstable.cmake
+++ b/cmake/ProjectsTagsUnstable.cmake
@@ -10,7 +10,8 @@ set_tag(manif_REPOSITORY robotology-dependencies/manif.git)
 set_tag(manif_TAG 0.0.4.102)
 set_tag(qhull_TAG 2020.2)
 set_tag(CppAD_TAG 20230000.0)
-set_tag(casadi 3.5.5.4)
+set_tag(proxsuite 0.3.6)
+set_tag(casadi 3.6.0.1)
 
 # Robotology projects
 set_tag(YARP_TAG master)

--- a/cmake/ProjectsTagsUnstable.cmake
+++ b/cmake/ProjectsTagsUnstable.cmake
@@ -10,7 +10,7 @@ set_tag(manif_REPOSITORY robotology-dependencies/manif.git)
 set_tag(manif_TAG 0.0.4.102)
 set_tag(qhull_TAG 2020.2)
 set_tag(CppAD_TAG 20230000.0)
-set_tag(proxsuite_TAG 0.3.6)
+set_tag(proxsuite_TAG v0.3.6)
 set_tag(casadi_TAG 3.6.0.1)
 
 # Robotology projects

--- a/doc/conda-forge.md
+++ b/doc/conda-forge.md
@@ -111,7 +111,7 @@ of the robotology-superbuild.**
 
 Once you activated it, you can install packages in it. In particular the dependencies for the robotology-superbuild can be installed as:
 ~~~
-mamba install -c conda-forge ace asio assimp boost eigen freetype gazebo glew glfw glm graphviz gsl ipopt irrlicht jpeg libmatio libode libxml2 nlohmann_json pcl opencv portaudio qt-main sdl sdl2 sqlite tinyxml spdlog lua soxr qhull "cmake<=3.25" compilers make ninja pkg-config tomlplusplus
+mamba install -c conda-forge ace asio assimp boost eigen freetype gazebo glew glfw glm graphviz gsl ipopt irrlicht jpeg libmatio libode libxml2 nlohmann_json pcl opencv portaudio qt-main sdl sdl2 sqlite tinyxml tinyxml2 spdlog lua soxr qhull "cmake<=3.25" compilers make ninja pkg-config tomlplusplus
 ~~~
 
 If you are on **Linux**, you also need to install also the following packages:

--- a/doc/deprecated-installation-methods.md
+++ b/doc/deprecated-installation-methods.md
@@ -75,7 +75,7 @@ All the software packages are installed using the `install` directory of the bui
 ### System Dependencies
 To install the system dependencies, it is possible to use [Homebrew](http://brew.sh/):
 ```
-brew install ace assimp bash-completion boost cmake eigen graphviz gsl ipopt jpeg libedit nlohmann-json opencv pkg-config portaudio qt@5 sqlite swig tinyxml libmatio irrlicht spdlog qhull
+brew install ace assimp bash-completion boost cmake eigen graphviz gsl ipopt jpeg libedit nlohmann-json opencv pkg-config portaudio qt@5 sqlite swig tinyxml tinyxml2 libmatio irrlicht spdlog qhull
 ```
 
 Since Qt5 is not symlinked in `/usr/local` by default in the homebrew formula, `Qt5_DIR` needs to be properly set to make sure that CMake-based projects are able to find Qt5.

--- a/doc/vcpkg-dependencies.md
+++ b/doc/vcpkg-dependencies.md
@@ -3,7 +3,7 @@
 If you prefer to install dependencies of the `robotology-superbuild` on your own existing [`vcpkg`](https://github.com/microsoft/vcpkg) installation,
 the ports that are required are the following: 
 ~~~
-./vcpkg.exe install --triplet x64-windows ace asio assimp boost-asio boost-any boost-bind boost-date-time boost-filesystem boost-format boost-interprocess boost-iostreams boost-program-options boost-property-tree boost-regex boost-smart-ptr boost-system boost-thread boost-variant boost-uuid freeglut gsl eigen3 glew glfw3 graphviz ode openssl libxml2 libjpeg-turbo nlohmann-json opencv portaudio matio sdl1 sdl2 qt5-base[latest] qt5-declarative qt5-multimedia qt5-quickcontrols qt5-quickcontrols2 sqlite3[core,tool] irrlicht qhull
+./vcpkg.exe install --triplet x64-windows ace asio assimp boost-asio boost-any boost-bind boost-date-time boost-filesystem boost-format boost-interprocess boost-iostreams boost-program-options boost-property-tree boost-regex boost-smart-ptr boost-system boost-thread boost-variant boost-uuid freeglut gsl eigen3 glew glfw3 graphviz ode openssl libxml2 libjpeg-turbo nlohmann-json opencv portaudio matio sdl1 sdl2 qt5-base[latest] qt5-declarative qt5-multimedia qt5-quickcontrols qt5-quickcontrols2 sqlite3[core,tool] irrlicht qhull tinyxml2
 ~~~
 
 

--- a/releases/latest.releases.yaml
+++ b/releases/latest.releases.yaml
@@ -22,7 +22,7 @@ repositories:
   casadi:
     type: git
     url: https://github.com/ami-iit/casadi.git
-    version: 3.5.5.4
+    version: 3.6.0.1
   YCM:
     type: git
     url: https://github.com/robotology/ycm.git
@@ -206,7 +206,7 @@ repositories:
   casadi-matlab-bindings:
     type: git
     url: https://github.com/ami-iit/casadi-matlab-bindings.git
-    version: v3.5.5.2
+    version: v3.6.0.0
   idyntree-yarp-tools:
     type: git
     url: https://github.com/robotology/idyntree-yarp-tools.git
@@ -247,3 +247,7 @@ repositories:
     type: git
     url: https://github.com/marzer/tomlplusplus.git
     version: v3.3.0
+  proxsuite:
+    type: git
+    url: https://github.com/Simple-Robotics/proxsuite.git
+    version: v0.3.6


### PR DESCRIPTION
Fix https://github.com/robotology/robotology-superbuild/issues/1378 .

Note that we add proxqp support on Windows/MSVC only if the MSVC version is >= 1930 (https://cmake.org/cmake/help/v3.26/variable/MSVC_VERSION.html), as proxqp requires v143 / Visual Studio 2022 to compile correctly, see https://github.com/Simple-Robotics/proxsuite/pull/49 .

The branch used in this PR is https://github.com/ami-iit/casadi/tree/3.6_ami_integration, that backports:
* https://github.com/casadi/casadi/pull/2906
* https://github.com/casadi/casadi/pull/2965
* https://github.com/casadi/casadi/pull/3077 
* https://github.com/casadi/casadi/pull/3078
* https://github.com/casadi/casadi/pull/3080
* https://github.com/ami-iit/casadi/pull/3
