### PR TITLE
Remove jobs on ubuntu-18.04 and add Homebrew workaround

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,7 @@
 name: C++ CI Workflow
 
 on:
-  workflow_dispatch:
+  workflow_dispatch:https://github.com/robotology/robotology-superbuild/tree/removeubuntu1804/.github
   push:
     branches:
       - master
@@ -375,6 +375,9 @@ jobs:
         # Workaround for https://github.com/robotology/robotology-superbuild/issues/1353
         rm /usr/local/lib/libtcl8.6.dylib || true
         rm /usr/local/lib/libtk8.6.dylib ||  true
+        # Workaround for https://github.com/robotology/robotology-superbuild/issues/1383
+        rm /usr/local/bin/go || true
+        rm /usr/local/bin/gofmt || true
         # Update homebrew
         brew update
         brew upgrade

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,7 @@
 name: C++ CI Workflow
 
 on:
-  workflow_dispatch:https://github.com/robotology/robotology-superbuild/tree/removeubuntu1804/.github
+  workflow_dispatch:
   push:
     branches:
       - master

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -260,12 +260,9 @@ jobs:
       fail-fast: false
       matrix:
         build_type: [Release]
-        os: [ubuntu-18.04, ubuntu-20.04, macos-latest, windows-2019]
+        os: [ubuntu-20.04, macos-latest, windows-2019]
         project_tags: [Default, Unstable, LatestReleases]
         include:
-          - os: ubuntu-18.04
-            build_type: Release
-            cmake_generator: "Unix Makefiles"
           - os: ubuntu-20.04
             build_type: Release
             cmake_generator: "Ninja"


### PR DESCRIPTION
The ubuntu-18.04  GitHub Actions image has been removed (see https://github.blog/changelog/2022-08-09-github-actions-the-ubuntu-18-04-actions-runner-image-is-being-deprecated-and-will-be-removed-by-12-1-22/), so we can just remove the related jobs from the CI. Note that anyhow we still have Ubuntu 18.04 CI coverage (see https://github.com/robotology/robotology-superbuild/issues/481) thanks to the Docker bionic CI job.

Furthermore, I added the n-th workaround for Homebrew CI, to fix https://github.com/robotology/robotology-superbuild/issues/1383 .