### PR TITLE
Correctly fix casadi and casadi-matlab-bindings TAG

### DIFF
--- a/cmake/ProjectsTagsStable.cmake
+++ b/cmake/ProjectsTagsStable.cmake
@@ -10,7 +10,8 @@ set_tag(manif_REPOSITORY robotology-dependencies/manif.git)
 set_tag(manif_TAG 0.0.4.102)
 set_tag(qhull_TAG 2020.2)
 set_tag(CppAD_TAG 20230000.0)
-set_tag(casadi 3.5.5.4)
+set_tag(casadi_TAG 3.5.5.4)
+set_tag(casadi-matlab-bindings_TAG v3.5.5.2)
 
 # Robotology projects
 set_tag(YCM_TAG master)

--- a/cmake/ProjectsTagsUnstable.cmake
+++ b/cmake/ProjectsTagsUnstable.cmake
@@ -10,7 +10,8 @@ set_tag(manif_REPOSITORY robotology-dependencies/manif.git)
 set_tag(manif_TAG 0.0.4.102)
 set_tag(qhull_TAG 2020.2)
 set_tag(CppAD_TAG 20230000.0)
-set_tag(casadi 3.5.5.4)
+set_tag(casadi_TAG 3.5.5.4)
+set_tag(casadi-matlab-bindings_TAG v3.5.5.2)
 
 # Robotology projects
 set_tag(YARP_TAG master)


### PR DESCRIPTION
Until https://github.com/robotology/robotology-superbuild/pull/1379 is correctly merged, let's make sure that we use the correct version of casadi 3.5.* .