### PR TITLE
Add support for onnxruntime just on Linux with apt

### DIFF
--- a/cmake/Buildbipedal-locomotion-framework.cmake
+++ b/cmake/Buildbipedal-locomotion-framework.cmake
@@ -63,6 +63,16 @@ if(APPLE OR WIN32)
   list(APPEND bipedal-locomotion-framework_OPTIONAL_CMAKE_ARGS "-DENABLE_YarpRobotLoggerDevice:BOOL=OFF")
 endif()
 
+# onnxruntime
+# Just on Linux without conda, we download onnxruntime
+set(FRAMEWORK_USE_onnxruntime OFF)
+if(ROBOTOLOGY_ENABLE_DYNAMICS_FULL_DEPS)
+  if(CMAKE_SYSTEM_NAME STREQUAL "Linux" AND NOT ROBOTOLOGY_CONFIGURING_UNDER_CONDA)
+    include(Fetchonnxruntimebinaries)
+    set(FRAMEWORK_USE_onnxruntime ON)
+  endif()
+endif()
+
 ycm_ep_helper(bipedal-locomotion-framework TYPE GIT
               STYLE GITHUB
               REPOSITORY ami-iit/bipedal-locomotion-framework.git
@@ -79,6 +89,7 @@ ycm_ep_helper(bipedal-locomotion-framework TYPE GIT
                          -DFRAMEWORK_USE_casadi:BOOL=${ROBOTOLOGY_ENABLE_DYNAMICS_FULL_DEPS}
                          -DFRAMEWORK_USE_LieGroupControllers:BOOL=${ROBOTOLOGY_ENABLE_DYNAMICS_FULL_DEPS}
                          -DFRAMEWORK_USE_tomlplusplus:BOOL=${ROBOTOLOGY_ENABLE_DYNAMICS_FULL_DEPS}
+                         -DFRAMEWORK_USE_onnxruntime:BOOL=${FRAMEWORK_USE_onnxruntime}
                          -DFRAMEWORK_COMPILE_PYTHON_BINDINGS:BOOL=${ROBOTOLOGY_USES_PYTHON}
                          ${bipedal-locomotion-framework_OPTIONAL_CMAKE_ARGS}
               DEPENDS ${bipedal-locomotion-framework_DEPENDS})

--- a/cmake/Fetchonnxruntimebinaries.cmake
+++ b/cmake/Fetchonnxruntimebinaries.cmake
@@ -1,0 +1,37 @@
+# Copyright (C) Fondazione Istituto Italiano di Tecnologia
+
+# silence deprecation warnings in newer versions of cmake
+if(POLICY CMP0135)
+  cmake_policy(SET CMP0135 NEW)
+endif()
+
+if(NOT CMAKE_SYSTEM_NAME STREQUAL "Linux")
+    message(FATAL_ERROR "Fetchonnxruntimebinaries is only supported on Linux, not on ${CMAKE_SYSTEM_NAME}")
+endif()
+
+set(onnxruntimebinaries_VERSION "1.14.1")
+if(CMAKE_HOST_SYSTEM_PROCESSOR STREQUAL "x86_64")
+  set(onnxruntimebinaries_ARCH "x64")
+elseif(CMAKE_HOST_SYSTEM_PROCESSOR STREQUAL "aarch64")
+  set(onnxruntimebinaries_ARCH "aarch64")
+else()
+  message(FATAL_ERROR "Fetchonnxruntimebinaries is not supported on architecture ${CMAKE_HOST_SYSTEM_PROCESSOR}")
+endif()
+
+set(onnxruntimebinaries_URL "https://github.com/microsoft/onnxruntime/releases/download/v${onnxruntimebinaries_VERSION}/onnxruntime-linux-${onnxruntimebinaries_ARCH}-${onnxruntimebinaries_VERSION}.tgz")
+
+FetchContent_Declare(
+  onnxruntimebinaries
+  URL      ${onnxruntimebinaries_URL}
+)
+
+FetchContent_GetProperties(onnxruntimebinaries)
+if(NOT onnxruntimebinaries_POPULATED)
+  message(STATUS "Downloading onnxruntime binaries.")
+  FetchContent_Populate(onnxruntimebinaries)
+  file(GLOB onnxruntimebinaries_HEADERS ${onnxruntimebinaries_SOURCE_DIR}/include/*)
+  file(COPY ${onnxruntimebinaries_HEADERS} DESTINATION ${YCM_EP_INSTALL_DIR}/include)
+  file(GLOB onnxruntimebinaries_LIBRARIES ${onnxruntimebinaries_SOURCE_DIR}/lib/*)
+  file(COPY ${onnxruntimebinaries_LIBRARIES} DESTINATION ${YCM_EP_INSTALL_DIR}/lib)
+  message(STATUS "Installing onnxruntime binaries in ${YCM_EP_INSTALL_DIR}")
+endif()


### PR DESCRIPTION
Just when `ROBOTOLOGY_ENABLE_DYNAMICS_FULL_DEPS` is enabled, when we are on Linux and we are not using Conda, this PR adds support for the upcoming `FRAMEWORK_USE_onnxruntime` option of bipedal-locomotion-framework (see https://github.com/ami-iit/bipedal-locomotion-framework/pull/652).

Differently from most other dependencis handled by the robotology-superbuild, given its size and the time necessary to compile, in this case we do not compile onnxruntime from scratch, but rather we download its binaries at configuration time, and we install them. We do this just on Linux and when conda is not used.

This is just meant to be an initial test. If this binaries create problems of incompatibility with other libraries installed by apt, we will need to find another solution. Instead, for conda-provided dependencies we will try to get onnxruntime also on Windows (see https://github.com/conda-forge/onnxruntime-feedstock/pull/56), and then we could add onnxruntime as any other dependency. However, let's start using this and let's see what happens.