### PR TITLE
Buildcasadi: Enable CASADI_PYTHON_PIP_METADATA_INSTALL option

### DIFF
--- a/cmake/Buildcasadi.cmake
+++ b/cmake/Buildcasadi.cmake
@@ -48,6 +48,7 @@ ycm_ep_helper(casadi TYPE GIT
                          -DBIN_PREFIX:PATH=bin
                          -DWITH_PYTHON:BOOL=${ROBOTOLOGY_USES_PYTHON}
                          -DWITH_PYTHON3:BOOL=${ROBOTOLOGY_USES_PYTHON}
+                         -DCASADI_PYTHON_PIP_METADATA_INSTALL:BOOL=${ROBOTOLOGY_USES_PYTHON}
                          -DWITH_COPYSIGN_UNDEF:BOOL=${WITH_COPYSIGN_UNDEF}
                          -DPYTHON_PREFIX:PATH=${ROBOTOLOGY_SUPERBUILD_PYTHON_INSTALL_DIR}
               DEPENDS ${casadi_DEPENDS})


### PR DESCRIPTION
Fix comment reported in https://github.com/robotology/robotology-superbuild/issues/1378#issuecomment-1510960702 . In our fork of casadi 3.5.5 the option by default was ON (see https://github.com/ami-iit/casadi/pull/1/files#diff-75df003c8ca5bb396ddc7edb9b4b18685f77e287feaa44b6c9175d1a46364275R168), so we never did this at the superbuild level, however this is required now that we are using the upstream version after it was merged in https://github.com/casadi/casadi/pull/2878 .