### PR TITLE
Disable ROBOTOLOGY_ENABLE_EVENT_DRIVEN on Ubuntu Bionic and Debian Buster

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -233,13 +233,13 @@ jobs:
       if: (matrix.docker_image == 'ubuntu:bionic')
       run: |
        cd build
-       cmake -DROBOTOLOGY_ENABLE_DYNAMICS_FULL_DEPS:BOOL=OFF -DROBOTOLOGY_ENABLE_GRASPING:BOOL=OFF -DROBOTOLOGY_ENABLE_ROBOT_TESTING:BOOL=OFF -DROBOTOLOGY_USES_PYTHON:BOOL=OFF -DROBOTOLOGY_ENABLE_TELEOPERATION:BOOL=OFF .
+       cmake -DROBOTOLOGY_ENABLE_DYNAMICS_FULL_DEPS:BOOL=OFF -DROBOTOLOGY_ENABLE_GRASPING:BOOL=OFF -DROBOTOLOGY_ENABLE_ROBOT_TESTING:BOOL=OFF -DROBOTOLOGY_USES_PYTHON:BOOL=OFF -DROBOTOLOGY_ENABLE_TELEOPERATION:BOOL=OFF -DROBOTOLOGY_ENABLE_EVENT_DRIVEN:BOOL=OFF .
 
     - name: Disable profiles that are not supported in Debian Buster [Docker debian:buster-backports]
       if: (matrix.docker_image == 'debian:buster-backports')
       run: |
        cd build
-       cmake -DROBOTOLOGY_ENABLE_TELEOPERATION:BOOL=OFF .
+       cmake -DROBOTOLOGY_ENABLE_TELEOPERATION:BOOL=OFF -DROBOTOLOGY_ENABLE_EVENT_DRIVEN:BOOL=OFF .
 
     # Workaround for https://github.com/robotology/robotology-superbuild/issues/1139
     - name: Configure Unstable [Docker]

--- a/doc/cmake-options.md
+++ b/doc/cmake-options.md
@@ -88,7 +88,7 @@ Not all options are supported on all platforms. The following table provides a r
 | `ROBOTOLOGY_ENABLE_ICUB_BASIC_DEMOS`  | ✔️   |        ✔️                     |             ✔️                |                 ✔️              |              ✔️                |                 ✔️              |
 | `ROBOTOLOGY_ENABLE_TELEOPERATION`<sup id="a4">[4!](#f4)</sup>  | ✔️   |        ❌                     |             ❌                |                 ✔️              |              ❌                |                 ✔️              |
 | `ROBOTOLOGY_ENABLE_HUMAN_DYNAMICS`  | ✔️   |        ✔️                     |             ✔️                |                 ✔️              |              ✔️                |                 ✔️              |
-| `ROBOTOLOGY_ENABLE_EVENT_DRIVEN`  | ✔️   |        ❌                     |             ❌                |                 ✔️              |              ❌                |                 ❌              |
+| `ROBOTOLOGY_ENABLE_EVENT_DRIVEN`<sup id="a6">[6!](#f6)</sup>  | ✔️   |        ❌                     |             ❌                |                 ✔️              |              ❌                |                 ❌              |
 | `ROBOTOLOGY_ENABLE_GRASPING`<sup id="a5">[5!](#f5)</sup>  | ✔️   |        ❌                     |             ✔️                |                 ✔️              |              ✔️                |                 ✔️              |
 | `ROBOTOLOGY_USES_GAZEBO` |  ✔️           |        ❌                     |             ✔️                |                 ✔️              |              ✔️                |                 ✔️              |
 | `ROBOTOLOGY_USES_PCL_AND_VTK` |  ✔️           |        ❌                     |             ✔️                |                 ✔️              |              ✔️                |                 ✔️              |
@@ -111,6 +111,8 @@ Not all options are supported on all platforms. The following table provides a r
 <b id="f4">4!</b>:Since 2022.05, `ROBOTOLOGY_USES_TELEOPERATION` does not support building with apt dependencies on Ubuntu 18.04 and Debian Buster .
 
 <b id="f5">5!</b>:`ROBOTOLOGY_ENABLE_GRASPING` does not support building with apt dependencies on Ubuntu 18.04 .
+
+<b id="f6">6!</b>:`ROBOTOLOGY_ENABLE_EVENT_DRIVEN` does not support building with apt dependencies on Ubuntu 18.04 and Debian Buster .
 
 
 Profile-specific documentation


### PR DESCRIPTION
Fix https://github.com/robotology/robotology-superbuild/issues/1392 .