### PR TITLE
Bump CasADi to 3.6.2

### DIFF
--- a/cmake/Buildcasadi.cmake
+++ b/cmake/Buildcasadi.cmake
@@ -29,7 +29,7 @@ endif()
 ycm_ep_helper(casadi TYPE GIT
               STYLE GITHUB
               REPOSITORY ami-iit/casadi.git
-              TAG 3.6_ami_integration
+              TAG 3.6.2_ami_integration
               COMPONENT external
               FOLDER src
               CMAKE_ARGS -DWITH_IPOPT:BOOL=ON
@@ -59,5 +59,5 @@ set(casadi_CONDA_PKG_CONDA_FORGE_OVERRIDE ON)
 # (something like 3.6.0.x) and the version available in conda-forge when generating conda metapackages
 # such as robotology-distro and robotology-distro-all, we override the conda package version of casadi
 # here. This needs to be removed as soon as we stop use our fork in the superbuild 
-set(casadi_CONDA_VERSION 3.6.0)
+set(casadi_CONDA_VERSION 3.6.2)
 

--- a/cmake/ProjectsTagsStable.cmake
+++ b/cmake/ProjectsTagsStable.cmake
@@ -11,8 +11,8 @@ set_tag(manif_TAG 0.0.4.102)
 set_tag(qhull_TAG 2020.2)
 set_tag(CppAD_TAG 20230000.0)
 set_tag(proxsuite_TAG v0.3.6)
-set_tag(casadi_TAG 3.6.0.2)
-set_tag(casadi-matlab-bindings_TAG v3.6.0.0)
+set_tag(casadi_TAG 3.6.2.1)
+set_tag(casadi-matlab-bindings_TAG v3.6.2.0)
 
 # Robotology projects
 set_tag(YCM_TAG master)

--- a/cmake/ProjectsTagsUnstable.cmake
+++ b/cmake/ProjectsTagsUnstable.cmake
@@ -11,8 +11,8 @@ set_tag(manif_TAG 0.0.4.102)
 set_tag(qhull_TAG 2020.2)
 set_tag(CppAD_TAG 20230000.0)
 set_tag(proxsuite_TAG v0.3.6)
-set_tag(casadi_TAG 3.6.0.2)
-set_tag(casadi-matlab-bindings_TAG v3.6.0.0)
+set_tag(casadi_TAG 3.6.2.1)
+set_tag(casadi-matlab-bindings_TAG v3.6.2.0)
 
 # Robotology projects
 set_tag(YARP_TAG master)

--- a/releases/latest.releases.yaml
+++ b/releases/latest.releases.yaml
@@ -22,7 +22,7 @@ repositories:
   casadi:
     type: git
     url: https://github.com/ami-iit/casadi.git
-    version: 3.6.0.2
+    version: 3.6.2.1
   YCM:
     type: git
     url: https://github.com/robotology/ycm.git


### PR DESCRIPTION
Bump CasADi to 3.6.2 . Note that fortunatly after:
* https://github.com/casadi/casadi/pull/3150
* https://github.com/casadi/casadi/pull/3149

have been merged, from 3.6.3 we can switch to use the official CasADi releases instead of our fork.