### PR TITLE
Remove workarounds related to CMake 3.26

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -278,16 +278,6 @@ jobs:
     steps:
     - uses: actions/checkout@master
     
-    # Workaround for https://github.com/ami-iit/bipedal-locomotion-framework/issues/636
-    # Remove once blf > 0.12.0 is released
-    - name: Cmake 3.25.3 [Ubuntu]
-      if: startsWith(matrix.os, 'ubuntu')
-      run: |
-        curl -sL https://github.com/Kitware/CMake/releases/download/v3.25.3/cmake-3.25.3-linux-x86_64.sh -o cmakeinstall.sh \
-        && chmod +x cmakeinstall.sh \
-        && sudo ./cmakeinstall.sh --prefix=/usr/local --exclude-subdir \
-        && rm cmakeinstall.sh
-    
     - name: Install files to enable compilation of mex files [Linux]
       if: contains(matrix.os, 'ubuntu') 
       run: |

--- a/doc/conda-forge.md
+++ b/doc/conda-forge.md
@@ -113,12 +113,12 @@ Once you activated it, you can install packages in it. In particular the depende
 
 If you are on **macOS** with a *recent* (as per 2022/2023) ARM-based processor
 ~~~
-mamba install -c conda-forge asio assimp boost eigen freetype gazebo glew glfw glm graphviz gsl ipopt irrlicht jpeg libmatio libode libxml2 nlohmann_json pcl opencv portaudio qt-main sdl sdl2 sqlite tinyxml tinyxml2 spdlog lua soxr qhull "cmake<=3.25" compilers make ninja pkg-config tomlplusplus
+mamba install -c conda-forge asio assimp boost eigen freetype gazebo glew glfw glm graphviz gsl ipopt irrlicht jpeg libmatio libode libxml2 nlohmann_json pcl opencv portaudio qt-main sdl sdl2 sqlite tinyxml tinyxml2 spdlog lua soxr qhull cmake compilers make ninja pkg-config tomlplusplus
 ~~~
 
 If you are on **macOS** with an Intel-based processor or you are on **Linux**,
 ~~~
-mamba install -c conda-forge ace asio assimp boost eigen freetype gazebo glew glfw glm graphviz gsl ipopt irrlicht jpeg libmatio libode libxml2 nlohmann_json pcl opencv portaudio qt-main sdl sdl2 sqlite tinyxml tinyxml2 spdlog lua soxr qhull "cmake<=3.25" compilers make ninja pkg-config tomlplusplus
+mamba install -c conda-forge ace asio assimp boost eigen freetype gazebo glew glfw glm graphviz gsl ipopt irrlicht jpeg libmatio libode libxml2 nlohmann_json pcl opencv portaudio qt-main sdl sdl2 sqlite tinyxml tinyxml2 spdlog lua soxr qhull cmake compilers make ninja pkg-config tomlplusplus
 ~~~
 
 If you are on **Linux**, you also need to install also the following packages:


### PR DESCRIPTION
Fix workaround introduced to fix https://github.com/robotology/robotology-superbuild/issues/1366 .