### PR TITLE
Prevent robotologyGitStatus to close when run with double click

### DIFF
--- a/scripts/robotologyGitStatus.sh
+++ b/scripts/robotologyGitStatus.sh
@@ -44,3 +44,8 @@ for subdir in ${subdirs}; do \
 done
 echo "--------------------------------------------"
 
+# Detect if running from terminal or from double-click. https://askubuntu.com/questions/729904/how-to-check-if-script-was-executed-via-command-line-or-double-clicked
+if (( SHLVL == 1 ))
+then 
+    read -p "Press enter to continue..."
+fi


### PR DESCRIPTION
On windows it gets pretty handy to doublle click on the script to run it. In this way, the window does not disappear.

Following https://askubuntu.com/questions/729904/how-to-check-if-script-was-executed-via-command-line-or-double-clicked I have used the value of ``SHLVL`` to detect if the script is launched from an existing terminal (and hence keeping the previous behavior) or from double click

I have tested it on Windows