### PR TITLE
Disable Homebrew from CI and do not support it anymore

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -260,7 +260,7 @@ jobs:
       fail-fast: false
       matrix:
         build_type: [Release]
-        os: [ubuntu-20.04, macos-latest, windows-2019]
+        os: [ubuntu-20.04, windows-2019]
         project_tags: [Default, Unstable, LatestReleases]
         include:
           - os: ubuntu-20.04
@@ -286,16 +286,7 @@ jobs:
         rm msdk_R2020b_mexa64.zip
         echo "GHA_Matlab_ROOT_DIR=${GITHUB_WORKSPACE}/msdk_R2020b_mexa64" >> $GITHUB_ENV
         echo "GHA_Matlab_MEX_EXTENSION=mexa64" >> $GITHUB_ENV
-                
-    - name: Install files to enable compilation of mex files [macOS]
-      if: contains(matrix.os, 'macos') 
-      run: |
-        curl -L -O https://github.com/robotology/robotology-vcpkg-ports/releases/download/storage/msdk_R2020a_mexmaci64.zip
-        unzip msdk_R2020a_mexmaci64.zip
-        rm msdk_R2020a_mexmaci64.zip
-        echo "GHA_Matlab_ROOT_DIR=${GITHUB_WORKSPACE}/msdk_R2020a_mexmaci64" >> $GITHUB_ENV
-        echo "GHA_Matlab_MEX_EXTENSION=mexmaci64" >> $GITHUB_ENV
-    
+
     - name: Move robotology-superbuild in C under Windows
       if: contains(matrix.os, 'windows')
       shell: bash
@@ -310,7 +301,7 @@ jobs:
         echo "ROBOTOLOGY_SUPERBUILD_SOURCE_DIR=/c/robotology-superbuild" >> $GITHUB_ENV
 
     - name: Define ROBOTOLOGY_SUPERBUILD_SOURCE_DIR 
-      if: contains(matrix.os, 'macos') || contains(matrix.os, 'ubuntu')
+      if: contains(matrix.os, 'ubuntu')
       shell: bash
       run: |
         echo "ROBOTOLOGY_SUPERBUILD_SOURCE_DIR=${GITHUB_WORKSPACE}" >> $GITHUB_ENV
@@ -355,43 +346,6 @@ jobs:
         chmod +x ./.ci/install_debian.sh
         sudo bash ./.ci/install_debian.sh
 
-    - name: Dependencies [macOS]
-      if: contains(matrix.os, 'macos')
-      run: |
-        cd ${ROBOTOLOGY_SUPERBUILD_SOURCE_DIR}
-        cmake --version
-        # Workaround for https://github.com/robotology/robotology-superbuild/issues/1321
-        # See https://github.com/actions/setup-python/issues/577#issuecomment-1365231810
-        rm /usr/local/bin/2to3 || true
-        rm /usr/local/bin/2to3-3.11 || true
-        rm /usr/local/bin/idle3 || true
-        rm /usr/local/bin/idle3.11 || true
-        rm /usr/local/bin/pydoc3 || true
-        rm /usr/local/bin/pydoc3.11 || true
-        rm /usr/local/bin/python3 || true
-        rm /usr/local/bin/python3.11 || true
-        rm /usr/local/bin/python3-config || true
-        rm /usr/local/bin/python3.11-config || true
-        # Workaround for https://github.com/robotology/robotology-superbuild/issues/1353
-        rm /usr/local/lib/libtcl8.6.dylib || true
-        rm /usr/local/lib/libtk8.6.dylib ||  true
-        # Workaround for https://github.com/robotology/robotology-superbuild/issues/1383
-        rm /usr/local/bin/go || true
-        rm /usr/local/bin/gofmt || true
-        # Update homebrew
-        brew update
-        brew upgrade
-        brew install --cask xquartz
-        # Core dependencies
-        brew install ace assimp bash-completion boost cmake eigen graphviz gsl ipopt jpeg libedit nlohmann-json opencv pkg-config portaudio qt@5 sqlite swig tinyxml tinyxml2
-        # ROBOTOLOGY_ENABLE_DYNAMICS dependencies
-        brew install libmatio irrlicht spdlog
-        # ROBOTOLOGY_ENABLE_DYNAMICS_FULL_DEPS (qhull and cppad are installed  with brew)
-        brew install cppad qhull
-        # CI-specific dependencies
-        brew install ninja
-        cmake --version
-
     - name: Dependencies [Windows]
       if: contains(matrix.os, 'windows')
       run: |
@@ -409,21 +363,14 @@ jobs:
     # CMAKE-BASED PROJECT
     # ===================
 
-    - name: Configure [Ubuntu&macOS]
-      if: contains(matrix.os, 'macos') || contains(matrix.os, 'ubuntu')
+    - name: Configure [Ubuntu]
+      if: contains(matrix.os, 'ubuntu')
       shell: bash
       run: |
         cd ${ROBOTOLOGY_SUPERBUILD_SOURCE_DIR}
         mkdir -p build
         cd build
         cmake -C ${ROBOTOLOGY_SUPERBUILD_SOURCE_DIR}/.ci/initial-cache.gh.cmake -G"${{ matrix.cmake_generator }}" -DYCM_EP_ADDITIONAL_CMAKE_ARGS:STRING="-DMatlab_ROOT_DIR:PATH=${GHA_Matlab_ROOT_DIR} -DMatlab_MEX_EXTENSION:STRING=${GHA_Matlab_MEX_EXTENSION}" -DROBOTOLOGY_USES_MATLAB:BOOL=ON -DYCM_BOOTSTRAP_VERBOSE=ON -DNON_INTERACTIVE_BUILD:BOOL=TRUE -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} ${{ matrix.project_tags_cmake_options }} ..
-
-    - name: Disable homebrew unsupported options
-      if: contains(matrix.os, 'macos')
-      run: |
-        cd ${ROBOTOLOGY_SUPERBUILD_SOURCE_DIR}
-        cd build
-        cmake -DROBOTOLOGY_USES_OCTAVE:BOOL=OFF -DROBOTOLOGY_USES_PYTHON:BOOL=OFF -DROBOTOLOGY_USES_GAZEBO:BOOL=OFF -DROBOTOLOGY_USES_PCL_AND_VTK:BOOL=OFF -DROBOTOLOGY_ENABLE_GRASPING:BOOL=OFF .
 
     - name: Disable options unsupported on Ubuntu 18.04
       if: contains(matrix.os, '18.04')
@@ -457,18 +404,12 @@ jobs:
         cd build
         cmake -DROBOTOLOGY_ENABLE_EVENT_DRIVEN:BOOL=OFF .
 
-    - name: Build  [Ubuntu&macOS]
-      if: contains(matrix.os, 'macos') || contains(matrix.os, 'ubuntu')
+    - name: Build  [Ubuntu]
+      if:  contains(matrix.os, 'ubuntu')
       shell: bash
       run: |
         cd build
-        # Workaround for https://github.com/osrf/homebrew-simulation/issues/1235
-        # taken from https://github.com/ignition-tooling/release-tools/pull/366
-        export LIBRARY_PATH=${LIBRARY_PATH}:/usr/local/opt/icu4c/lib 
         cmake --build . --config ${{ matrix.build_type }}
-      env:
-        # This is necessary only on macOS/homebrew, but on Linux it should be ignored
-        Qt5_DIR: /usr/local/opt/qt5/lib/cmake/Qt5
 
     # Just for  release jobs we also compile Windows in Release, to ensure that Release libraries are included in the installer
     - name: Build (Release) [Windows]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,11 +3,24 @@ All notable changes to this project will be documented in this file.
 
 The format of this document is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+Only major changes are documented in this file, and in general no version update of specific sub-packages is included,
+as those happen on regular basis.
+
 ## [Unreleased]
+
+### Removed
+
+- Compilation against Homebrew dependencies is removed from the CI.
+
+## [2023.02.0] - 2023-03-10
+
+### Added
 
 - Added `ergocub-software` to the core profile.
 
 ## [2022.09.1] - 2022-10-12
+
+### Changed
 
 - Bumped `robots-configuration` to v1.27.1 .
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -77,7 +77,6 @@ if(ROBOTOLOGY_USES_GAZEBO)
     # On Windows or Conda we assume that the Gazebo's enviroment variables are already set,
     # so we set as this name a file that does not exists and so will be ignored
     set(GAZEBO_SETUP_SH_PATH "on-windows-or-conda-we-assume-that-gazebo-env-variables-are-already-set")
-  # TODO(traversaro): make sure that Gazebo exports this, for now hardcode
   elseif(APPLE)
     set(GAZEBO_SETUP_SH_PATH "/usr/local/share/gazebo/setup.sh")
   else()

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ For each project, the repository will be downloaded in the `src/<package_name>` 
 The build directory for a given project will be instead the `src/<package_name>` subdirectory of the superbuild build directory. 
 All the software packages are installed using the `install` directory of the build as installation prefix.
 
-We also support two additional deprecated ways of compiling the superbuild, on Windows using dependencies provided by [vcpkg](https://vcpkg.io/) or on macOS using dependencies provided by Homebrew](https://brew.sh/). Documentation for them can be found in [`doc/deprecated-installation-methods.md`](doc/deprecated-installation-methods.md). 
+We also support an additional deprecated way of compiling the superbuild, on Windows using dependencies provided by [vcpkg](https://vcpkg.io/). Documentation for them can be found in [`doc/deprecated-installation-methods.md`](doc/deprecated-installation-methods.md). 
 
 ## Linux from source with dependencies provided by apt
 

--- a/doc/cmake-options.md
+++ b/doc/cmake-options.md
@@ -78,34 +78,34 @@ The dependencies CMake options specify if the packages dependending on something
 
 Not all options are supported on all platforms. The following table provides a recap of which options are supported on each platform.
 
-| Option | Ubuntu/Debian, dependencies: apt |  macOS, dependencies: Homebrew | Windows, dependencies: vcpkg | conda on Linux, dependencies: conda-forge |  conda on macOS, dependencies: conda-forge | conda on Windows, dependencies: conda-forge |
-|:------:|:---------------------------------:|:----------------------------:|:-----------------------------:|:--------------------------------:|:-----------------------------:|:--------------------------------:|
-| `ROBOTOLOGY_ENABLE_CORE` |  ✔️           |        ✔️                     |             ✔️                |                 ✔️              |              ✔️                |                 ✔️              |
-| `ROBOTOLOGY_ENABLE_ROBOT_TESTING`<sup id="a2">[2!](#f2)</sup>  | ✔️   |        ✔️                     |             ✔️                |                 ✔️              |              ✔️                |                 ✔️              |
-| `ROBOTOLOGY_ENABLE_DYNAMICS`  | ✔️   |        ✔️                     |             ✔️                |                 ✔️              |              ✔️                |                 ✔️              |
-| `ROBOTOLOGY_ENABLE_DYNAMICS_FULL_DEPS`<sup id="a1">[1!](#f1)</sup>  | ✔️   |        ✔️                      |           ❌                  |                 ✔️              |              ✔️                |                 ✔️              |
-| `ROBOTOLOGY_ENABLE_ICUB_HEAD`  | ✔️   |        ✔️                     |             ✔️                |                 ✔️              |              ✔️                |                 ✔️              |
-| `ROBOTOLOGY_ENABLE_ICUB_BASIC_DEMOS`  | ✔️   |        ✔️                     |             ✔️                |                 ✔️              |              ✔️                |                 ✔️              |
-| `ROBOTOLOGY_ENABLE_TELEOPERATION`<sup id="a4">[4!](#f4)</sup>  | ✔️   |        ❌                     |             ❌                |                 ✔️              |              ❌                |                 ✔️              |
-| `ROBOTOLOGY_ENABLE_HUMAN_DYNAMICS`  | ✔️   |        ✔️                     |             ✔️                |                 ✔️              |              ✔️                |                 ✔️              |
-| `ROBOTOLOGY_ENABLE_EVENT_DRIVEN`<sup id="a6">[6!](#f6)</sup>  | ✔️   |        ❌                     |             ❌                |                 ✔️              |              ❌                |                 ❌              |
-| `ROBOTOLOGY_ENABLE_GRASPING`<sup id="a5">[5!](#f5)</sup>  | ✔️   |        ❌                     |             ✔️                |                 ✔️              |              ✔️                |                 ✔️              |
-| `ROBOTOLOGY_USES_GAZEBO` |  ✔️           |        ❌                     |             ✔️                |                 ✔️              |              ✔️                |                 ✔️              |
-| `ROBOTOLOGY_USES_PCL_AND_VTK` |  ✔️           |        ❌                     |             ✔️                |                 ✔️              |              ✔️                |                 ✔️              |
-| `ROBOTOLOGY_USES_IGNITION` |  ❌           |        ❌                     |             ❌                |                 ✔️              |              ❌                |                 ❌              |
-| `ROBOTOLOGY_USES_MATLAB` |  ✔️           |        ✔️                     |             ❌                |                 ✔️              |              ✔️                |                 ✔️              |
-| `ROBOTOLOGY_USES_OCTAVE` |  ✔️           |        ✔️                     |              ❌                |                  ❌              |               ❌                |                  ❌              |
-| `ROBOTOLOGY_USES_PYTHON`<sup id="a3">[3!](#f3)</sup> |  ✔️           |         ❌                     |              ❌                |                  ✔️              |               ✔️               |                  ✔️              |
-| `ROBOTOLOGY_USES_OCULUS_SDK` |   ❌          |         ❌                     |             ✔️                |                  ❌              |               ❌                |                  ❌            |
-| `ROBOTOLOGY_USES_CYBERITH_SDK` |   ❌           |         ❌                     |            ✔️                  |                  ❌              |               ❌                |                 ✔️              |
-| `ROBOTOLOGY_USES_CFW2CAN` |  ✔️           |        ❌                      |             ❌                 |                 ✔️              |              ❌                 |                 ❌               |
-| `ROBOTOLOGY_USES_XSENS_MVN_SDK` |  ❌            |        ❌                      |             ✔️                |                 ❌               |              ❌                 |                 ❌               |
-| `ROBOTOLOGY_USES_ESDCAN` |  ❌           |        ❌                      |             ✔️                |                 ❌               |              ❌                 |                 ✔️               |
-
-<b id="f1">1!</b>:Since 2021.05, `ROBOTOLOGY_ENABLE_DYNAMICS_FULL_DEPS` does not support building with apt dependencies on Ubuntu 18.04 .
-
-<b id="f2">2!</b>:Since 2021.11, `ROBOTOLOGY_ENABLE_ROBOT_TESTING` does not support building with apt dependencies on Ubuntu 18.04 .
-
+| Option                                                              | Ubuntu/Debian, dependencies: apt | Windows, dependencies: vcpkg | conda on Linux, dependencies: conda-forge |  conda on macOS, dependencies: conda-forge | conda on Windows, dependencies: conda-forge |
+|:-------------------------------------------------------------------:|:--------------------------------:|:----------------------------:|:-----------------------------------------:|:------------------------------------------:|:-------------------------------------------:|
+| `ROBOTOLOGY_ENABLE_CORE`                                            | ✔️                               |             ✔️              |                 ✔️                        |              ✔️                           |                 ✔️                          |
+| `ROBOTOLOGY_ENABLE_ROBOT_TESTING`<sup id="a2">[2!](#f2)</sup>       | ✔️                               |             ✔️              |              ✔️                           |                 ✔️                        |               ✔️                            |
+| `ROBOTOLOGY_ENABLE_DYNAMICS`                                        | ✔️                               |             ✔️              |                 ✔️                        |              ✔️                           |               ✔️                            |
+| `ROBOTOLOGY_ENABLE_DYNAMICS_FULL_DEPS`<sup id="a1">[1!](#f1)</sup>  | ✔️                               |             ❌              |                 ✔️                        |              ✔️                           |               ✔️                            |
+| `ROBOTOLOGY_ENABLE_ICUB_HEAD`                                       | ✔️                               |             ✔️              |                 ✔️                        |              ✔️                           |               ✔️                            |
+| `ROBOTOLOGY_ENABLE_ICUB_BASIC_DEMOS`                                | ✔️                               |             ✔️              |                 ✔️                        |              ✔️                           |               ✔️                            |
+| `ROBOTOLOGY_ENABLE_TELEOPERATION`<sup id="a4">[4!](#f4)</sup>       | ✔️                               |             ❌              |                 ✔️                        |              ❌                           |               ✔️                            |
+| `ROBOTOLOGY_ENABLE_HUMAN_DYNAMICS`                                  | ✔️                               |             ✔️              |                 ✔️                        |              ✔️                           |               ✔️                            |
+| `ROBOTOLOGY_ENABLE_EVENT_DRIVEN`<sup id="a6">[6!](#f6)</sup>        | ✔️                               |             ❌              |                 ✔️                        |              ❌                           |               ❌                            |
+| `ROBOTOLOGY_ENABLE_GRASPING`<sup id="a5">[5!](#f5)</sup>            | ✔️                               |             ✔️              |                 ✔️                        |              ✔️                           |               ✔️                            |
+| `ROBOTOLOGY_USES_GAZEBO`                                            | ✔️                               |             ✔️              |                 ✔️                        |              ✔️                           |               ✔️                            |
+| `ROBOTOLOGY_USES_PCL_AND_VTK`                                       | ✔️                               |             ✔️              |                 ✔️                        |              ✔️                           |               ✔️                            |
+| `ROBOTOLOGY_USES_IGNITION`                                          | ❌                               |             ❌              |                 ✔️                        |              ❌                           |               ❌                            |
+| `ROBOTOLOGY_USES_MATLAB`                                            | ✔️                               |             ❌              |                 ✔️                        |              ✔️                           |               ✔️                            |
+| `ROBOTOLOGY_USES_OCTAVE`                                            | ✔️                               |              ❌             |                  ❌                       |        )       ❌                          |                  ❌                         |
+| `ROBOTOLOGY_USES_PYTHON`<sup id="a3">[3!](#f3)</sup>                | ✔️                               |              ❌             |                  ✔️                       |               ✔️                          |                  ✔️                         |
+| `ROBOTOLOGY_USES_OCULUS_SDK`                                        | ❌                               |             ✔️              |                  ❌                       |               ❌                          |                  ❌                         |
+| `ROBOTOLOGY_USES_CYBERITH_SDK`                                      | ❌                               |            ✔️               |                  ❌                       |               ❌                          |                 ✔️                          |
+| `ROBOTOLOGY_USES_CFW2CAN`                                           |  ✔️                              |             ❌              |                 ✔️                        |              ❌                           |                 ❌                          |
+| `ROBOTOLOGY_USES_XSENS_MVN_SDK`                                     |  ❌                              |             ✔️              |                 ❌                        |              ❌                           |                 ❌                          |
+| `ROBOTOLOGY_USES_ESDCAN`                                            |  ❌                              |             ✔️              |                 ❌                        |              ❌                           |                 ✔️                          |
+           
+<b id="f1">1!</b>:Since 2021.05, `ROBOTOLOGY_ENABLE_DYNAMICS_FULL_DEPS` does not support building with apt dependencies on Ubuntu 1.04 .           
+           
+<b id="f2">2!</b>:Since 2021.11, `ROBOTOLOGY_ENABLE_ROBOT_TESTING` does not support building with apt dependencies on Ubuntu 18.04 .           
+           
 <b id="f3">3!</b>:Since 2021.11, `ROBOTOLOGY_USES_PYTHON` does not support building with apt dependencies on Ubuntu 18.04 .
 
 <b id="f4">4!</b>:Since 2022.05, `ROBOTOLOGY_USES_TELEOPERATION` does not support building with apt dependencies on Ubuntu 18.04 and Debian Buster .

--- a/doc/deprecated-installation-methods.md
+++ b/doc/deprecated-installation-methods.md
@@ -9,7 +9,6 @@ Table of Contents
 * [Binary Installation](#binary-installation)
   * [Windows installed generated with vcpkg dependencies](#windows-from-binary-installer-generated-with-vcpkg-dependencies)
 * [Source Installation](#source-installation)
-  * [macOS using Homebrew dependencies](#macos-from-source-using-homebrew-dependencies)
   * [Windows using pre-compiled vcpkg dependencies](#windows-from-source-using-vcpkg-dependencies)
 
 
@@ -69,58 +68,6 @@ When compiled from source, `robotology-superbuild` will download and build a num
 For each project, the repository will be downloaded in the `src/<package_name>` subdirectory of the superbuild root. 
 The build directory for a given project will be instead the `src/<package_name>` subdirectory of the superbuild build directory. 
 All the software packages are installed using the `install` directory of the build as installation prefix.
-
-## macOS from source using Homebrew dependencies 
-
-### System Dependencies
-To install the system dependencies, it is possible to use [Homebrew](http://brew.sh/):
-```
-brew install ace assimp bash-completion boost cmake eigen graphviz gsl ipopt jpeg libedit nlohmann-json opencv pkg-config portaudio qt@5 sqlite swig tinyxml tinyxml2 libmatio irrlicht spdlog qhull
-```
-
-Since Qt5 is not symlinked in `/usr/local` by default in the homebrew formula, `Qt5_DIR` needs to be properly set to make sure that CMake-based projects are able to find Qt5.
-```
-export Qt5_DIR=/usr/local/opt/qt5/lib/cmake/Qt5
-```
-
-If you want to enable a [profile](cmake-options.md#profile-cmake-options) or a [dependency](cmake-options.md#dependencies-cmake-options) specific CMake option, you may need to install additional system dependencies following the dependency-specific documentation (in particular, the `ROBOTOLOGY_USES_GAZEBO` option is enabled by default, so you should disable it as it is not supported on macOS with Homebrew dependencies):
-* [`ROBOTOLOGY_USES_GAZEBO`](cmake-options.md#gazebo)
-
-### Superbuild
-```
-cd robotology-superbuild
-mkdir build
-cd build
-```
-
-To use GNU Makefile generators:
-```bash
-cmake ../
-make
-```
-To use Xcode project generators
-```bash
-cmake ../ -G Xcode
-xcodebuild [-configuration Release|Debug] [-jobs <n>] [-list | -target <target_name>]
-```
-`-list` gives the list of available targets.
-
-**Note: as of late 2020, the Xcode 12 generator is not supported, for more info see https://github.com/robotology/ycm/issues/368. 
-  All previous versions instead should work fine. If you have Xcode 12 installed in your macOS system, please use the GNU Makefiles generator.**
-
-### Configure your environment
-The superbuild provides an automatically generated `setup.sh` sh script that will set all the necessary enviromental variables to use the software installed in the robotology-superbuild. To do so automatically for any new terminal that you open, append the following line to the `.bash_profile` file:
-```
-source <directory-where-you-downloaded-robotology-superbuild>/build/install/share/robotology-superbuild/setup.sh
-```
-
-To use the updated `.bash_profile` in your terminal you should run the following command:
-```bash
-user@host:~$ source ~/.bash_profile
-```
-or simply open a new terminal.
-
-If for any reason you do not want to use the provided `setup.sh` script and you want to manage your enviroment variables manually, please refer to the documentation available at [`doc/environment-variables-configuration.md `](environment-variables-configuration.md).
 
 ## Windows from source using vcpkg dependencies
 

--- a/doc/developers-faqs.md
+++ b/doc/developers-faqs.md
@@ -48,7 +48,7 @@ ycm_ep_helper(<package>
                         
 * Add `find_or_build_package(<package>)` in the `cmake/RobotologySuperbuildLogic.cmake` file, under the `if(ROBOTOLOGY_ENABLE_<profile>)` of the selected profile.
 * If the package is important "enough" (it was not added just because it is a dependency) added it to the table in [`doc/cmake-options.md#profile-cmake-options`](cmake-options.md#profile-cmake-options) .
-* If the dependencies of the packages are available in `apt`, `homebrew` or Windows installers, document how to install them in the profile docs in the README. If any dependency is not available through this means, add it as a new package of the superbuid.
+* If the dependencies of the packages are available in `apt`, `conda-forge` or `vcpkg`, document how to install them in the documentation. If any dependency is not available through this means, add it as a new package of the superbuid.
 * For more details, see  upstream YCM docs http://robotology.github.io/ycm/gh-pages/latest/manual/ycm-superbuild-example.7.html#superbuild-example-developer-point-of-view
 
 ## How to add a new profile

--- a/doc/environment-variables-configuration.md
+++ b/doc/environment-variables-configuration.md
@@ -63,7 +63,7 @@ For all dependecies option not listed, no additional configuration is necessary.
 The following enviroment variables need to be appended with robotology-superbuild related directories:
 ~~~
 # Gazebo related env variables (see http://gazebosim.org/tutorials?tut=components#EnvironmentVariables )
-# This is /usr/local/share/gazebo/setup.sh if Gazebo was installed in macOS using homebrew
+# This is only necessary if are using apt, if you are using conda-forge do not include the next line
 source /usr/share/gazebo/setup.sh
 export GAZEBO_PLUGIN_PATH=${GAZEBO_PLUGIN_PATH}:${ROBOTOLOGY_SUPERBUILD_INSTALL_PREFIX}/lib
 export GAZEBO_MODEL_PATH=${GAZEBO_MODEL_PATH}:${ROBOTOLOGY_SUPERBUILD_INSTALL_PREFIX}/share/gazebo/models:${ROBOTOLOGY_SUPERBUILD_INSTALL_PREFIX}/share/iCub/robots:${ROBOTOLOGY_SUPERBUILD_INSTALL_PREFIX}/share:${ROBOTOLOGY_SUPERBUILD_INSTALL_PREFIX}/share/ergoCub/robots

--- a/doc/install-mambaforge.md
+++ b/doc/install-mambaforge.md
@@ -101,7 +101,7 @@ If you are using a non-bash shell such as `zsh`, you also need to run:
 ~~~
 
 By default, this command also automatically initialize the [`base` conda environment](https://conda.io/projects/conda/en/latest/user-guide/tasks/manage-environments.html#activating-an-environment) whenever you start a terminal.
-As this could interfere with other uses of your system (for example compilation against libraries installed via `brew`), it is recommended to disable this by setting:
+As this could interfere with other uses of your system (for example compilation against libraries installed via `apt`), it is recommended to disable this by setting:
 ~~~
 conda config --set auto_activate_base false
 ~~~

--- a/doc/unsupported-homebrew-installation.md
+++ b/doc/unsupported-homebrew-installation.md
@@ -1,0 +1,56 @@
+Unsupported Homebrew Installation
+=================================
+
+**IMPORTANT: This document describes installation with Homebrew, that is not currently supported and not tested in Continuous Integration. PR to fix errors or problems are welcome, but not mantainance is done on this documentation by robotology-superbuild mantainers.** 
+
+## macOS from source using Homebrew dependencies 
+
+### System Dependencies
+To install the system dependencies, it is possible to use [Homebrew](http://brew.sh/):
+```
+brew install ace assimp bash-completion boost cmake eigen graphviz gsl ipopt jpeg libedit nlohmann-json opencv pkg-config portaudio qt@5 sqlite swig tinyxml tinyxml2 libmatio irrlicht spdlog qhull
+```
+
+Since Qt5 is not symlinked in `/usr/local` by default in the homebrew formula, `Qt5_DIR` needs to be properly set to make sure that CMake-based projects are able to find Qt5.
+```
+export Qt5_DIR=/usr/local/opt/qt5/lib/cmake/Qt5
+```
+
+If you want to enable a [profile](cmake-options.md#profile-cmake-options) or a [dependency](cmake-options.md#dependencies-cmake-options) specific CMake option, you may need to install additional system dependencies following the dependency-specific documentation (in particular, the `ROBOTOLOGY_USES_GAZEBO` option is enabled by default, so you should disable it as it is not supported on macOS with Homebrew dependencies):
+* [`ROBOTOLOGY_USES_GAZEBO`](cmake-options.md#gazebo)
+
+### Superbuild
+```
+cd robotology-superbuild
+mkdir build
+cd build
+```
+
+To use GNU Makefile generators:
+```bash
+cmake ../
+make
+```
+To use Xcode project generators
+```bash
+cmake ../ -G Xcode
+xcodebuild [-configuration Release|Debug] [-jobs <n>] [-list | -target <target_name>]
+```
+`-list` gives the list of available targets.
+
+**Note: as of late 2020, the Xcode 12 generator is not supported, for more info see https://github.com/robotology/ycm/issues/368. 
+  All previous versions instead should work fine. If you have Xcode 12 installed in your macOS system, please use the GNU Makefiles generator.**
+
+### Configure your environment
+The superbuild provides an automatically generated `setup.sh` sh script that will set all the necessary enviromental variables to use the software installed in the robotology-superbuild. To do so automatically for any new terminal that you open, append the following line to the `.bash_profile` file:
+```
+source <directory-where-you-downloaded-robotology-superbuild>/build/install/share/robotology-superbuild/setup.sh
+```
+
+To use the updated `.bash_profile` in your terminal you should run the following command:
+```bash
+user@host:~$ source ~/.bash_profile
+```
+or simply open a new terminal.
+
+If for any reason you do not want to use the provided `setup.sh` script and you want to manage your enviroment variables manually, please refer to the documentation available at [`doc/environment-variables-configuration.md `](environment-variables-configuration.md).


### PR DESCRIPTION
As announced in https://github.com/robotology/robotology-superbuild/issues/842#issuecomment-1500326241, this PR removes Homebrew support and documentation.  