### PR TITLE
Buildmanif: Explicitly compile with C++17

### DIFF
--- a/cmake/Buildmanif.cmake
+++ b/cmake/Buildmanif.cmake
@@ -11,13 +11,16 @@ else()
   set(BUILD_PYTHON_BINDINGS OFF)
 endif()
 
+# We pass CMAKE_CXX_STANDARD=17 as we encountered problems when using -march=native
+# and mixing libraries compiled with C++11 and C++17, see
+# https://github.com/artivis/manif/issues/274
 ycm_ep_helper(manif TYPE GIT
               STYLE GITHUB
               REPOSITORY artivis/manif.git
               TAG master
               COMPONENT external
               FOLDER src
-              CMAKE_ARGS -DBUILD_TESTING:BOOL=OFF -DBUILD_EXAMPLES:BOOL=OFF -DBUILD_PYTHON_BINDINGS:BOOL=${BUILD_PYTHON_BINDINGS}  -DMANIFPY_PKGDIR:PATH=${YCM_EP_INSTALL_DIR}/${ROBOTOLOGY_SUPERBUILD_PYTHON_INSTALL_DIR})
+              CMAKE_ARGS -DCMAKE_CXX_STANDARD=17 -DBUILD_TESTING:BOOL=OFF -DBUILD_EXAMPLES:BOOL=OFF -DBUILD_PYTHON_BINDINGS:BOOL=${BUILD_PYTHON_BINDINGS}  -DMANIFPY_PKGDIR:PATH=${YCM_EP_INSTALL_DIR}/${ROBOTOLOGY_SUPERBUILD_PYTHON_INSTALL_DIR})
 
 set(manif_CONDA_PKG_NAME manif)
 set(manif_CONDA_PKG_CONDA_FORGE_OVERRIDE ON)

--- a/cmake/ProjectsTagsStable.cmake
+++ b/cmake/ProjectsTagsStable.cmake
@@ -7,7 +7,7 @@ endmacro()
 # External projects
 set_tag(osqp_TAG v0.6.3)
 set_tag(manif_REPOSITORY robotology-dependencies/manif.git)
-set_tag(manif_TAG 0.0.4.102)
+set_tag(manif_TAG 0.0.4.103)
 set_tag(qhull_TAG 2020.2)
 set_tag(CppAD_TAG 20230000.0)
 set_tag(proxsuite_TAG v0.3.6)

--- a/cmake/ProjectsTagsUnstable.cmake
+++ b/cmake/ProjectsTagsUnstable.cmake
@@ -7,7 +7,7 @@ endmacro()
 # External projects
 set_tag(osqp_TAG v0.6.3)
 set_tag(manif_REPOSITORY robotology-dependencies/manif.git)
-set_tag(manif_TAG 0.0.4.102)
+set_tag(manif_TAG 0.0.4.103)
 set_tag(qhull_TAG 2020.2)
 set_tag(CppAD_TAG 20230000.0)
 set_tag(proxsuite_TAG v0.3.6)

--- a/releases/latest.releases.yaml
+++ b/releases/latest.releases.yaml
@@ -10,7 +10,7 @@ repositories:
   manif:
     type: git
     url: https://github.com/robotology-dependencies/manif.git
-    version: 0.0.4.102
+    version: 0.0.4.103
   qhull:
     type: git
     url: https://github.com/qhull/qhull.git


### PR DESCRIPTION
See https://github.com/artivis/manif/issues/274 . This is only useful once https://github.com/robotology-dependencies/manif/pull/2 is merged and a new version is tagged, but I already open the PR to collect early feedback.