### PR TITLE
YARP: Enable compilation of bottle_compression_zlib, depthimage_compression_zlib and image_compression_ffmpeg portmonitors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,7 +75,7 @@ jobs:
       shell: bash -l {0}
       run: |
         # Dependencies
-        mamba install ace asio assimp boost eigen freetype gazebo glew glfw glm graphviz gsl ipopt irrlicht jpeg libmatio libode libxml2 nlohmann_json pcl vtk opencv portaudio qt-main sdl sdl2 sqlite tinyxml spdlog lua soxr cmake compilers make ninja pkg-config tomlplusplus
+        mamba install ace asio assimp boost eigen freetype gazebo glew glfw glm graphviz gsl ipopt irrlicht jpeg libmatio libode libxml2 nlohmann_json pcl vtk opencv portaudio qt-main sdl sdl2 sqlite tinyxml spdlog lua soxr cmake compilers make ninja pkg-config tomlplusplus libzlib ffmpeg
         # Python 
         mamba install python numpy swig pybind11 pyqt matplotlib h5py tornado u-msgpack-python pyzmq ipython
 

--- a/apt.txt
+++ b/apt.txt
@@ -63,3 +63,12 @@ libglew-dev
 libglm-dev
 libfreetype6-dev
 libsqlite3-dev
+libavcodec-dev 
+libavdevice-dev
+libavfilter-dev
+libavformat-dev
+libavutil-dev
+libpostproc-dev
+libswresample-dev
+libswscale-dev
+zlib1g-dev

--- a/cmake/BuildYARP.cmake
+++ b/cmake/BuildYARP.cmake
@@ -65,6 +65,9 @@ ycm_ep_helper(YARP TYPE GIT
                               -DENABLE_yarpcar_bayer:BOOL=ON
                               -DENABLE_yarpcar_mjpeg:BOOL=ON
                               -DENABLE_yarpcar_portmonitor:BOOL=ON
+                              -DENABLE_yarppm_bottle_compression_zlib:BOOL=ON
+                              -DENABLE_yarppm_depthimage_compression_zlib:BOOL=ON
+                              -DENABLE_yarppm_image_compression_ffmpeg:BOOL=ON
                               -DENABLE_yarppm_depthimage_to_mono:BOOL=ON
                               -DENABLE_yarppm_depthimage_to_rgb:BOOL=ON
                               -DENABLE_yarpidl_thrift:BOOL=ON

--- a/doc/conda-forge.md
+++ b/doc/conda-forge.md
@@ -113,12 +113,12 @@ Once you activated it, you can install packages in it. In particular the depende
 
 If you are on **Linux**, **Windows**, or **macOS** with an Intel-based processor (and not a *recent* (as per 2022/2023) ARM-based processor)
 ~~~
-mamba install -c conda-forge ace asio assimp boost eigen freetype gazebo glew glfw glm graphviz gsl ipopt irrlicht jpeg libmatio libode libxml2 nlohmann_json pcl opencv portaudio qt-main sdl sdl2 sqlite tinyxml tinyxml2 spdlog lua soxr qhull cmake compilers make ninja pkg-config tomlplusplus
+mamba install -c conda-forge ace asio assimp boost eigen freetype gazebo glew glfw glm graphviz gsl ipopt irrlicht jpeg libmatio libode libxml2 nlohmann_json pcl opencv portaudio qt-main sdl sdl2 sqlite tinyxml tinyxml2 spdlog lua soxr qhull cmake compilers make ninja pkg-config tomlplusplus libzlib ffmpeg
 ~~~
 
 If you are on **macOS** with a *recent* (as per 2022/2023) ARM-based processor
 ~~~
-mamba install -c conda-forge asio assimp boost eigen freetype gazebo glew glfw glm graphviz gsl ipopt irrlicht jpeg libmatio libode libxml2 nlohmann_json pcl opencv portaudio qt-main sdl sdl2 sqlite tinyxml tinyxml2 spdlog lua soxr qhull cmake compilers make ninja pkg-config tomlplusplus
+mamba install -c conda-forge asio assimp boost eigen freetype gazebo glew glfw glm graphviz gsl ipopt irrlicht jpeg libmatio libode libxml2 nlohmann_json pcl opencv portaudio qt-main sdl sdl2 sqlite tinyxml tinyxml2 spdlog lua soxr qhull cmake compilers make ninja pkg-config tomlplusplus libzlib ffmpeg
 ~~~
 
 If you are on **Linux**, you also need to install also the following packages:

--- a/doc/unsupported-homebrew-installation.md
+++ b/doc/unsupported-homebrew-installation.md
@@ -8,7 +8,7 @@ Unsupported Homebrew Installation
 ### System Dependencies
 To install the system dependencies, it is possible to use [Homebrew](http://brew.sh/):
 ```
-brew install ace assimp bash-completion boost cmake eigen graphviz gsl ipopt jpeg libedit nlohmann-json opencv pkg-config portaudio qt@5 sqlite swig tinyxml tinyxml2 libmatio irrlicht spdlog qhull
+brew install ace assimp bash-completion boost cmake eigen graphviz gsl ipopt jpeg libedit nlohmann-json opencv pkg-config portaudio qt@5 sqlite swig tinyxml tinyxml2 libmatio irrlicht spdlog qhull zlib ffmpeg
 ```
 
 Since Qt5 is not symlinked in `/usr/local` by default in the homebrew formula, `Qt5_DIR` needs to be properly set to make sure that CMake-based projects are able to find Qt5.

--- a/doc/vcpkg-dependencies.md
+++ b/doc/vcpkg-dependencies.md
@@ -3,7 +3,7 @@
 If you prefer to install dependencies of the `robotology-superbuild` on your own existing [`vcpkg`](https://github.com/microsoft/vcpkg) installation,
 the ports that are required are the following: 
 ~~~
-./vcpkg.exe install --triplet x64-windows ace asio assimp boost-asio boost-any boost-bind boost-date-time boost-filesystem boost-format boost-interprocess boost-iostreams boost-program-options boost-property-tree boost-regex boost-smart-ptr boost-system boost-thread boost-variant boost-uuid freeglut gsl eigen3 glew glfw3 graphviz ode openssl libxml2 libjpeg-turbo nlohmann-json opencv portaudio matio sdl1 sdl2 qt5-base[latest] qt5-declarative qt5-multimedia qt5-quickcontrols qt5-quickcontrols2 sqlite3[core,tool] irrlicht qhull tinyxml2
+./vcpkg.exe install --triplet x64-windows ace asio assimp boost-asio boost-any boost-bind boost-date-time boost-filesystem boost-format boost-interprocess boost-iostreams boost-program-options boost-property-tree boost-regex boost-smart-ptr boost-system boost-thread boost-variant boost-uuid freeglut gsl eigen3 glew glfw3 graphviz ode openssl libxml2 libjpeg-turbo nlohmann-json opencv portaudio matio sdl1 sdl2 qt5-base[latest] qt5-declarative qt5-multimedia qt5-quickcontrols qt5-quickcontrols2 sqlite3[core,tool] irrlicht qhull tinyxml2 ffmpeg zlib
 ~~~
 
 


### PR DESCRIPTION
This PR enable in YARP the CMake options to ensure that the following portmonitor are enabled:
* `bottle_compression_zlib`
* `depthimage_compression_zlib`
* `image_compression_ffmpeg`

These portmonitors are already used by the HSP team working on ergocub (fyi @andrearosasco) and can be useful for anyone sending big amount of data over a YARP network (@S-Dafarra @GiulioRomualdi @mebbaid @davidegorbani).

This PR also adds the required dependencis (ffmpeg and zlib) to the dependency of the superbuild. This was already discussed in https://github.com/robotology/robotology-superbuild/issues/1071, but we decided not to proceed as some devices in YARP (`ffmpeg_grabber` and `ffmpeg_writer`) were not compatible with ffmpeg 5. However, it turns out that `image_compression_ffmpeg` can be used and can be useful on its own, so I think it make sense to proceed with this change, even because it would permit some HSP/ergoCub demo to run with a stock superbuild.

The corresponding PR in the yarp-feedstock recipe is: https://github.com/conda-forge/yarp-feedstock/pull/31 .
