### PR TITLE
Explicitly pass OSQP_IS_V1 option to osqp-eigen to avoid problems in vcpkg/Debug corner case

### DIFF
--- a/cmake/BuildOsqpEigen.cmake
+++ b/cmake/BuildOsqpEigen.cmake
@@ -12,7 +12,7 @@ ycm_ep_helper(OsqpEigen TYPE GIT
               TAG master
               COMPONENT dynamics
               FOLDER src
-              CMAKE_ARGS -DBUILD_TESTING:BOOL=OFF
+              CMAKE_ARGS -DBUILD_TESTING:BOOL=OFF -DOSQP_IS_V1:BOOL=OFF
               DEPENDS osqp)
 
 set(OsqpEigen_CONDA_PKG_NAME osqp-eigen)


### PR DESCRIPTION
Requires https://github.com/robotology/osqp-eigen/pull/145 .
Fix https://github.com/robotology/robotology-superbuild/issues/1451 .