### PR TITLE
Only test and document official compatibility of MATLAB binary packages with MATLAB >= R2022a

### DIFF
--- a/.github/workflows/matlab-one-line-install-test.yml
+++ b/.github/workflows/matlab-one-line-install-test.yml
@@ -24,7 +24,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-22.04, macos-latest, windows-latest]
-        matlab_version: [R2020b, R2021a, R2021b, latest]
+        matlab_version: [R2022a, R2022b, latest]
         exclude:
           # R2020* is not supported on Windows on GitHub Actions
           - os: windows-latest

--- a/doc/cmake-options.md
+++ b/doc/cmake-options.md
@@ -249,12 +249,15 @@ Follow the official instructions to install Ignition on your platform, available
 Note: this installation method is not currently tested in Continuous Integration.
 
 ## MATLAB
+
 Support for this dependency is enabled by the `ROBOTOLOGY_USES_MATLAB` CMake option.
 
 **Warning: differently from other optional dependencies, MATLAB is a commercial product that requires a license to be used.**
 
 ### System Dependencies
+
 If MATLAB is not installed on your computer, install it following the instruction in https://mathworks.com/help/install/ .
+**The minimum version of MATLAB supported by the robotology-superbuild is R2022a.**
 Once you installed it, make sure that the directory containing the `matlab` executable is present in the `PATH` of your system,
 as [CMake's FindMatlab module](https://cmake.org/cmake/help/v3.5/module/FindMatlab.html) relies on this to find MATLAB.
 

--- a/doc/matlab-one-line-install.md
+++ b/doc/matlab-one-line-install.md
@@ -2,6 +2,8 @@
 
 This guide provides a simple documentation to install Robotology MATLAB/Simulink packages in a pure MATLAB workflow (so without launching **anything else** via terminal, so for example no Gazebo simulation).
 
+**Note that he minimum version of MATLAB supported by the robotology-superbuild is R2022a.**
+
 ## Installation
 ~~~matlab
 websave('install_robotology_packages.m', 'https://raw.githubusercontent.com/robotology/robotology-superbuild/master/scripts/install_robotology_packages.m')


### PR DESCRIPTION
Fix https://github.com/robotology/robotology-superbuild/issues/1461 . In https://github.com/robotology/robotology-superbuild/pull/1462/commits/f8f31010f81f54d8fd14b5d28985d487c78e110e I also document this in the documentation.