### PR TITLE
Pin actions/checkout to v3.6.0 for Ubuntu 18.04 compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -193,7 +193,7 @@ jobs:
       image: ${{ matrix.docker_image }}
 
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@v3.6.0
 
     - name: Upgrade apt packages Debian Testing [Debian Testing]
       if: matrix.docker_image == 'debian:testing'


### PR DESCRIPTION
Fix https://github.com/robotology/robotology-superbuild/issues/1466 .