### PR TITLE
GitHub Actions: Free disk space to avoid out of disk space errors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -196,7 +196,7 @@ jobs:
     - uses: actions/checkout@v3.6.0
 
     - name: Free Disk Space (Ubuntu)
-      uses: jlumbroso/free-disk-space@v1
+      uses: jlumbroso/free-disk-space@v1.2.0
       with:
         tool-cache: false
         android: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -195,6 +195,17 @@ jobs:
     steps:
     - uses: actions/checkout@v3.6.0
 
+    - name: Free Disk Space (Ubuntu)
+      uses: jlumbroso/free-disk-space@v1
+      with:
+        tool-cache: false
+        android: true
+        dotnet: true
+        haskell: true
+        large-packages: true
+        docker-images: false
+        swap-storage: false
+
     - name: Upgrade apt packages Debian Testing [Debian Testing]
       if: matrix.docker_image == 'debian:testing'
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -191,20 +191,20 @@ jobs:
 
     container:
       image: ${{ matrix.docker_image }}
+      volumes:
+        - /usr/local:/host_usr_local
 
     steps:
     - uses: actions/checkout@v3.6.0
 
-    - name: Free Disk Space (Ubuntu)
-      uses: jlumbroso/free-disk-space@v1.2.0
-      with:
-        tool-cache: false
-        android: true
-        dotnet: true
-        haskell: true
-        large-packages: true
-        docker-images: false
-        swap-storage: false
+    - name: Free disk space in host machine
+      run: |
+        rm -rf /host_usr_local/graalvm/
+        rm -rf /host_usr_local/.ghcup/
+        rm -rf /host_usr_local/share/powershell
+        rm -rf /host_usr_local/share/chromium
+        rm -rf /host_usr_local/lib/android
+        rm -rf /host_usr_local/lib/node_modules
 
     - name: Upgrade apt packages Debian Testing [Debian Testing]
       if: matrix.docker_image == 'debian:testing'


### PR DESCRIPTION
Fix https://github.com/robotology/robotology-superbuild/issues/1472 by deleting unused directories (from https://github.com/apache/flink/blob/53702736382b80fa905494e69654061a84741e84/tools/azure-pipelines/free_disk_space.sh#L48C1-L53C40) in the host machine. Given that we had this problem in actions that are running in a contained, we had first to mount the folder that contained the files to delete in the container.