### PR TITLE
Remove workarounds for https://github.com/robotology/robotology-superbuild/issues/1139

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -144,12 +144,6 @@ jobs:
       shell: bash -l {0}
       run: cmake -S . -B build/ -DROBOTOLOGY_USES_IGNITION:BOOL=ON
 
-    # Workaround for https://github.com/robotology/robotology-superbuild/issues/1139
-    - name: Configure Unstable [Conda]
-      if: contains(matrix.project_tags, 'Unstable')
-      shell: bash -l {0}
-      run: cmake -S . -B build/ -DROBOTOLOGY_ENABLE_EVENT_DRIVEN:BOOL=OFF
-
     # For some reason, the Strawberry perl's pkg-config is found
     # instead of the conda's one, so let's delete the /c/Strawberry directory
     - name: Debug pkg-config problem
@@ -264,13 +258,6 @@ jobs:
       run: |
        cd build
        cmake  -DROBOTOLOGY_USES_MUJOCO:BOOL=OFF .
-
-    # Workaround for https://github.com/robotology/robotology-superbuild/issues/1139
-    - name: Configure Unstable [Docker]
-      if: contains(matrix.project_tags, 'Unstable')
-      run: |
-        cd build
-        cmake -DROBOTOLOGY_ENABLE_EVENT_DRIVEN:BOOL=OFF .
 
     - name: Build  [Docker]
       run: |
@@ -417,15 +404,6 @@ jobs:
         # ROBOTOLOGY_ENABLE_TELEOPERATION is OFF as it is unsupported on vcpkg
         cmake -C ${ROBOTOLOGY_SUPERBUILD_SOURCE_DIR}/.ci/initial-cache.gh.cmake -A x64 -DCMAKE_TOOLCHAIN_FILE=C:/robotology/vcpkg/scripts/buildsystems/vcpkg.cmake -DROBOTOLOGY_USES_MATLAB:BOOL=OFF -DYCM_BOOTSTRAP_VERBOSE=ON -DYCM_EP_INSTALL_DIR=C:/robotology/robotology -DNON_INTERACTIVE_BUILD:BOOL=TRUE -DCMAKE_BUILD_TYPE=Debug  ${{ matrix.project_tags_cmake_options }} ..
         cmake -DROBOTOLOGY_ENABLE_TELEOPERATION:BOOL=OFF .
-
-    # Workaround for https://github.com/robotology/robotology-superbuild/issues/1139
-    - name: Configure Unstable
-      if: contains(matrix.project_tags, 'Unstable')
-      shell: bash
-      run: |
-        cd ${ROBOTOLOGY_SUPERBUILD_SOURCE_DIR}
-        cd build
-        cmake -DROBOTOLOGY_ENABLE_EVENT_DRIVEN:BOOL=OFF .
 
     - name: Disable options unsupported on Ubuntu 20.04 and vcpkg
       if: contains(matrix.os, '20.04') || contains(matrix.os, 'windows')


### PR DESCRIPTION
They should not be not necessary anymore.