### PR TITLE
Do not run MATLAB tests on matlab latest/2023b version

### DIFF
--- a/.github/workflows/matlab-one-line-install-test.yml
+++ b/.github/workflows/matlab-one-line-install-test.yml
@@ -24,7 +24,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-22.04, macos-latest, windows-latest]
-        matlab_version: [R2022a, R2022b, R2023b]
+        matlab_version: [R2022a, R2022b, R2023a]
         exclude:
           # R2020* is not supported on Windows on GitHub Actions
           - os: windows-latest

--- a/.github/workflows/matlab-one-line-install-test.yml
+++ b/.github/workflows/matlab-one-line-install-test.yml
@@ -24,7 +24,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-22.04, macos-latest, windows-latest]
-        matlab_version: [R2022a, R2022b, latest]
+        matlab_version: [R2022a, R2022b, R2023b]
         exclude:
           # R2020* is not supported on Windows on GitHub Actions
           - os: windows-latest


### PR DESCRIPTION
Workaround for https://github.com/matlab-actions/run-command/issues/43
Workaround for https://github.com/robotology/robotology-superbuild/issues/1492