### PR TITLE
Set default policies of CMake as the one of CMake 3.16

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,8 @@
-# Copyright (C) 2017  iCub Facility, Istituto Italiano di Tecnologia
+# Copyright (C) Fondazione Istituto Italiano di Tecnologia
 # Authors: Silvio Traversaro <silvio.traversaro@iit.it>
 # CopyPolicy: Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
 
-cmake_minimum_required(VERSION 3.12)
+cmake_minimum_required(VERSION 3.12...3.16)
 project(robotology-superbuild NONE)
 
 ## we have to enable C because it is currently used


### PR DESCRIPTION
The main reason to do so is to ensure that https://cmake.org/cmake/help/latest/policy/CMP0094.html#policy:CMP0094 is set to NEW and fix the Python part of https://github.com/robotology/robotology-superbuild/issues/1505 .

If you are confused by the syntax, check `policy_max` argument in https://cmake.org/cmake/help/latest/command/cmake_minimum_required.html .