### PR TITLE
 Remove Ubuntu 18.04 support from documentation and CI scripts 

### DIFF
--- a/.ci/install_debian.sh
+++ b/.ci/install_debian.sh
@@ -27,10 +27,8 @@ dist_version="$(lsb_release -c | cut -d: -f2 | sed s/'^\t'//)"
 echo "lsb_dist: ${lsb_dist}"
 echo "dist_version: ${dist_version}"
 # Just a limited amount of distros are supported by OSRF repos, for all the other we use the 
-# gazebo packages in regular repos, while on bionic we do not use ROBOTOLOGY_USES_GAZEBO
-if [[ ("bionic" == "$dist_version") ]]; then
-    true
-elif [[ ("focal" == "$dist_version" || "buster" == "$dist_version") ]]; then
+# gazebo packages in regular repos
+if [[ ("focal" == "$dist_version" || "buster" == "$dist_version") ]]; then
     mkdir -p /etc/apt/sources.list.d
     echo deb http://packages.osrfoundation.org/gazebo/$lsb_dist\-stable $dist_version main > /etc/apt/sources.list.d/gazebo-stable.list
     apt-key adv --keyserver keyserver.ubuntu.com --recv-keys D2486D2DD83DB69272AFE98867170598AF249743

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -365,13 +365,6 @@ jobs:
         cd build
         cmake -C ${ROBOTOLOGY_SUPERBUILD_SOURCE_DIR}/.ci/initial-cache.gh.cmake -G"${{ matrix.cmake_generator }}" -DYCM_EP_ADDITIONAL_CMAKE_ARGS:STRING="-DMatlab_ROOT_DIR:PATH=${GHA_Matlab_ROOT_DIR} -DMatlab_MEX_EXTENSION:STRING=${GHA_Matlab_MEX_EXTENSION}" -DROBOTOLOGY_USES_MATLAB:BOOL=ON -DYCM_BOOTSTRAP_VERBOSE=ON -DNON_INTERACTIVE_BUILD:BOOL=TRUE -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} ${{ matrix.project_tags_cmake_options }} ..
 
-    - name: Disable options unsupported on Ubuntu 18.04
-      if: contains(matrix.os, '18.04')
-      run: |
-        cd ${ROBOTOLOGY_SUPERBUILD_SOURCE_DIR}
-        cd build
-        cmake -DROBOTOLOGY_ENABLE_DYNAMICS_FULL_DEPS:BOOL=OFF -DROBOTOLOGY_ENABLE_GRASPING:BOOL=OFF -DROBOTOLOGY_ENABLE_ROBOT_TESTING:BOOL=OFF -DROBOTOLOGY_USES_PYTHON:BOOL=OFF -DROBOTOLOGY_ENABLE_TELEOPERATION:BOOL=OFF .
-
     - name: Configure [Windows]
       if: contains(matrix.os, 'windows')
       shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -168,7 +168,6 @@ jobs:
         cmake_generator:
           - "Ninja"
         docker_image:
-          - "ubuntu:bionic"
           - "ubuntu:focal"
           - "ubuntu:jammy"
           - "debian:buster-backports"
@@ -218,17 +217,6 @@ jobs:
       run: |
         apt-get -y -t buster-backports install cmake
 
-    - name: Install CMake from Kitware APT Repository [Docker/Ubuntu Bionic]
-      if: matrix.docker_image == 'ubuntu:bionic'
-      run: |
-        apt-get -y install apt-transport-https ca-certificates gnupg software-properties-common wget
-        wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | gpg --dearmor - | tee /etc/apt/trusted.gpg.d/kitware.gpg >/dev/null
-        apt-add-repository 'deb https://apt.kitware.com/ubuntu/ bionic main'
-        apt-get -y update
-        apt-get -y upgrade
-
-
-
     - name: Configure [Docker]
       run: |
         mkdir -p build
@@ -236,16 +224,10 @@ jobs:
         cmake -C ${GITHUB_WORKSPACE}/.ci/initial-cache.gh.cmake  -G"${{ matrix.cmake_generator }}" -DNON_INTERACTIVE_BUILD:BOOL=TRUE -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}  ${{ matrix.project_tags_cmake_options }}  ..
 
     - name: Disable profiles that are not supported in docker for now [Docker debian-testing and debian-buster]
-      if: (matrix.docker_image == 'debian:testing' || matrix.docker_image == 'debian:buster-backports' || matrix.docker_image == 'ubuntu:bionic')
+      if: (matrix.docker_image == 'debian:testing' || matrix.docker_image == 'debian:buster-backports')
       run: |
        cd build
        cmake -DROBOTOLOGY_ENABLE_DYNAMICS_FULL_DEPS:BOOL=OFF -DROBOTOLOGY_USES_MUJOCO:BOOL=OFF -DROBOTOLOGY_ENABLE_ROBOT_TESTING:BOOL=OFF -DROBOTOLOGY_USES_PYTHON:BOOL=OFF .
-
-    - name: Disable profiles that are not supported in Ubuntu Bionic [Docker ubuntu:bionic]
-      if: (matrix.docker_image == 'ubuntu:bionic')
-      run: |
-       cd build
-       cmake -DROBOTOLOGY_USES_GAZEBO:BOOL=OFF -DROBOTOLOGY_ENABLE_DYNAMICS_FULL_DEPS:BOOL=OFF -DROBOTOLOGY_USES_MUJOCO:BOOL=OFF -DROBOTOLOGY_ENABLE_GRASPING:BOOL=OFF -DROBOTOLOGY_ENABLE_ROBOT_TESTING:BOOL=OFF -DROBOTOLOGY_USES_PYTHON:BOOL=OFF -DROBOTOLOGY_ENABLE_TELEOPERATION:BOOL=OFF -DROBOTOLOGY_ENABLE_EVENT_DRIVEN:BOOL=OFF .
 
     - name: Disable profiles that are not supported in Debian Buster [Docker debian:buster-backports]
       if: (matrix.docker_image == 'debian:buster-backports')

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,8 @@
 # Changelog
-All notable changes to this project will be documented in this file.
 
-The format of this document is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
+This file documents notable changes to this project done before August 2023. For changes after that take, plase refers to each release notes at https://github.com/robotology/robotology-superbuild/releases .
 
-Only major changes are documented in this file, and in general no version update of specific sub-packages is included,
-as those happen on regular basis.
-
-## [Unreleased]
+## [2023.08.0] - 2023-09-10
 
 ### Removed
 

--- a/README.md
+++ b/README.md
@@ -105,6 +105,12 @@ We also support an additional deprecated way of compiling the superbuild, on Win
 
 ## Linux from source with dependencies provided by apt
 
+The following apt-based distributions are supported and tested by the robotology-superbuild:
+* Ubuntu 20.04 (Focal Fossa)
+* Ubuntu 22.04 (Jammy Jellyfish)
+* Debian 10 (Buster)
+* Debian 11 (Bullseye)
+
 ### System Dependencies
 On Debian based systems (as Ubuntu) you can install the C++ toolchain, Git, CMake and Eigen (and other dependencies necessary for the software include in `robotology-superbuild`) using `apt-get`. This can be done by installing the packages listed in the `apt.txt` file using the following script:
 ~~~
@@ -117,7 +123,6 @@ Besides the packages listed in `apt.txt` file, the script `install_apt_dependenc
 For what regards CMake, the robotology-superbuild requires CMake 3.16 . If you are using a recent Debian-based system such as Ubuntu 20.04, the default CMake is recent enough and you do not need to do further steps.
 
 If instead you use an older distro in which the default version of CMake is older, you can easily install a newer CMake version in several ways. For the following distributions, we recommend the following methods:  
-* Ubuntu 18.04 : use the latest CMake release in the [Kitware APT repository](https://apt.kitware.com/). You can find the full instructions for the installation on the website.
 * Debian 10 : use the CMake in the `buster-backports` repository, following the instructions to install from backports available in  [Debian documentation](https://backports.debian.org/Instructions/).
 More details can be found at https://github.com/robotology/QA/issues/364 .
 
@@ -129,7 +134,7 @@ Note that the `ROBOTOLOGY_USES_GAZEBO` option is enabled by default, so you shou
 
 On Linux with apt dependencies install Gazebo, if you are on:
 * Ubuntu 20.04
-* Buster 10
+* Debian Buster 10
 
 follow the instructions available at https://gazebosim.org/tutorials?tut=install_ubuntu . Make sure to install also the development files, i.e. `libgazebo*-dev` on Debian/Ubuntu.
 

--- a/README.md
+++ b/README.md
@@ -111,6 +111,8 @@ The following apt-based distributions are supported and tested by the robotology
 * Debian 10 (Buster)
 * Debian 11 (Bullseye)
 
+Other versions may be working, but they are not checked.
+
 ### System Dependencies
 On Debian based systems (as Ubuntu) you can install the C++ toolchain, Git, CMake and Eigen (and other dependencies necessary for the software include in `robotology-superbuild`) using `apt-get`. This can be done by installing the packages listed in the `apt.txt` file using the following script:
 ~~~

--- a/apt.txt
+++ b/apt.txt
@@ -40,6 +40,7 @@ qtmultimedia5-dev
 libqt5opengl5-dev
 libqhull-dev
 swig
+nlohmann-json3-dev
 libmatio-dev
 libirrlicht-dev
 libspdlog-dev

--- a/cmake/BuildiDynTree.cmake
+++ b/cmake/BuildiDynTree.cmake
@@ -20,6 +20,12 @@ if(ROBOTOLOGY_USES_PYTHON)
   list(APPEND iDynTree_OPTIONAL_CMAKE_ARGS "-DIDYNTREE_PYTHON_INSTALL_DIR=${ROBOTOLOGY_SUPERBUILD_PYTHON_INSTALL_DIR}")
 endif()
 
+# Hack for disabling IDYNTREE_USES_IRRLICHT on vcpkg,
+# remove once irrlicht+sdl is available on vcpkg,
+# and https://github.com/robotology/robotology-superbuild-dependencies-vcpkg
+# is modified to includ it
+find_package(glfw3 QUIET)
+
 ycm_ep_helper(iDynTree TYPE GIT
               STYLE GITHUB
               REPOSITORY robotology/idyntree.git
@@ -28,7 +34,7 @@ ycm_ep_helper(iDynTree TYPE GIT
               FOLDER src
               CMAKE_ARGS -DIDYNTREE_USES_IPOPT:BOOL=ON
                          -DIDYNTREE_USES_OSQPEIGEN:BOOL=ON
-                         -DIDYNTREE_USES_IRRLICHT:BOOL=ON
+                         -DIDYNTREE_USES_IRRLICHT:BOOL=${glfw3_FOUND}
                          -DIDYNTREE_USES_ASSIMP:BOOL=ON
                          -DCMAKE_DISABLE_FIND_PACKAGE_YARP:BOOL=ON
                          -DIDYNTREE_USES_YARP:BOOL=OFF

--- a/cmake/BuildiDynTree.cmake
+++ b/cmake/BuildiDynTree.cmake
@@ -20,10 +20,6 @@ if(ROBOTOLOGY_USES_PYTHON)
   list(APPEND iDynTree_OPTIONAL_CMAKE_ARGS "-DIDYNTREE_PYTHON_INSTALL_DIR=${ROBOTOLOGY_SUPERBUILD_PYTHON_INSTALL_DIR}")
 endif()
 
-# Hack for disabling IDYNTREE_USES_IRRLICHT on Ubuntu 18.04,
-# remove once https://github.com/robotology/robotology-superbuild/issues/481 is fixed
-find_package(glfw3 QUIET)
-
 ycm_ep_helper(iDynTree TYPE GIT
               STYLE GITHUB
               REPOSITORY robotology/idyntree.git
@@ -32,7 +28,7 @@ ycm_ep_helper(iDynTree TYPE GIT
               FOLDER src
               CMAKE_ARGS -DIDYNTREE_USES_IPOPT:BOOL=ON
                          -DIDYNTREE_USES_OSQPEIGEN:BOOL=ON
-                         -DIDYNTREE_USES_IRRLICHT:BOOL=${glfw3_FOUND}
+                         -DIDYNTREE_USES_IRRLICHT:BOOL=ON
                          -DIDYNTREE_USES_ASSIMP:BOOL=ON
                          -DCMAKE_DISABLE_FIND_PACKAGE_YARP:BOOL=ON
                          -DIDYNTREE_USES_YARP:BOOL=OFF

--- a/doc/cmake-options.md
+++ b/doc/cmake-options.md
@@ -79,41 +79,28 @@ Not all options are supported on all platforms. The following table provides a r
 | Option                                                              | Ubuntu/Debian, dependencies: apt | Windows, dependencies: vcpkg | conda on Linux, dependencies: conda-forge |  conda on macOS, dependencies: conda-forge | conda on Windows, dependencies: conda-forge |
 |:-------------------------------------------------------------------:|:--------------------------------:|:----------------------------:|:-----------------------------------------:|:------------------------------------------:|:-------------------------------------------:|
 | `ROBOTOLOGY_ENABLE_CORE`                                            | ✔️                               |             ✔️              |                 ✔️                        |              ✔️                           |                 ✔️                          |
-| `ROBOTOLOGY_ENABLE_ROBOT_TESTING`<sup id="a2">[2!](#f2)</sup>       | ✔️                               |             ✔️              |              ✔️                           |                 ✔️                        |               ✔️                            |
+| `ROBOTOLOGY_ENABLE_ROBOT_TESTING`       | ✔️                               |             ✔️              |              ✔️                           |                 ✔️                        |               ✔️                            |
 | `ROBOTOLOGY_ENABLE_DYNAMICS`                                        | ✔️                               |             ✔️              |                 ✔️                        |              ✔️                           |               ✔️                            |
-| `ROBOTOLOGY_ENABLE_DYNAMICS_FULL_DEPS`<sup id="a1">[1!](#f1)</sup>  | ✔️                               |             ❌              |                 ✔️                        |              ✔️                           |               ✔️                            |
+| `ROBOTOLOGY_ENABLE_DYNAMICS_FULL_DEPS` | ✔️                               |             ❌              |                 ✔️                        |              ✔️                           |               ✔️                            |
 | `ROBOTOLOGY_ENABLE_ICUB_HEAD`                                       | ✔️                               |             ✔️              |                 ✔️                        |              ✔️                           |               ✔️                            |
 | `ROBOTOLOGY_ENABLE_ICUB_BASIC_DEMOS`                                | ✔️                               |             ✔️              |                 ✔️                        |              ✔️                           |               ✔️                            |
-| `ROBOTOLOGY_ENABLE_TELEOPERATION`<sup id="a4">[4!](#f4)</sup>       | ✔️                               |             ❌              |                 ✔️                        |              ❌                           |               ✔️                            |
+| `ROBOTOLOGY_ENABLE_TELEOPERATION`       | ✔️                               |             ❌              |                 ✔️                        |              ❌                           |               ✔️                            |
 | `ROBOTOLOGY_ENABLE_HUMAN_DYNAMICS`                                  | ✔️                               |             ✔️              |                 ✔️                        |              ✔️                           |               ✔️                            |
-| `ROBOTOLOGY_ENABLE_EVENT_DRIVEN`<sup id="a6">[6!](#f6)</sup>        | ✔️                               |             ❌              |                 ✔️                        |              ❌                           |               ❌                            |
-| `ROBOTOLOGY_ENABLE_GRASPING`<sup id="a5">[5!](#f5)</sup>            | ✔️                               |             ✔️              |                 ✔️                        |              ✔️                           |               ✔️                            |
-| `ROBOTOLOGY_USES_GAZEBO`<sup id="a7">[7!](#f7)</sup>                                            | ✔️                               |             ✔️              |                 ✔️                        |              ✔️                           |               ✔️                            |
-| `ROBOTOLOGY_USES_MUJOCO`<sup id="a8">[8!](#f8)</sup>  | ✔️                               |           ❌                |                 ✔️                        |              ✔️                           |               ✔️                            |
+| `ROBOTOLOGY_ENABLE_EVENT_DRIVEN`        | ✔️                               |             ❌              |                 ✔️                        |              ❌                           |               ❌                            |
+| `ROBOTOLOGY_ENABLE_GRASPING`            | ✔️                               |             ✔️              |                 ✔️                        |              ✔️                           |               ✔️                            |
+| `ROBOTOLOGY_USES_GAZEBO`                                            | ✔️                               |             ✔️              |                 ✔️                        |              ✔️                           |               ✔️                            |
+| `ROBOTOLOGY_USES_MUJOCO`<sup id="a1">[1!](#f1)</sup>  | ✔️                               |           ❌                |                 ✔️                        |              ✔️                           |               ✔️                            |
 | `ROBOTOLOGY_USES_PCL_AND_VTK`                                       | ✔️                               |             ✔️              |                 ✔️                        |              ✔️                           |               ✔️                            |
 | `ROBOTOLOGY_USES_IGNITION`                                          | ❌                               |             ❌              |                 ✔️                        |              ❌                           |               ❌                            |
 | `ROBOTOLOGY_USES_MATLAB`                                            | ✔️                               |             ❌              |                 ✔️                        |              ✔️                           |               ✔️                            |
 | `ROBOTOLOGY_USES_OCTAVE`                                            | ✔️                               |              ❌             |                  ❌                       |        )       ❌                          |                  ❌                         |
-| `ROBOTOLOGY_USES_PYTHON`<sup id="a3">[3!](#f3)</sup>                | ✔️                               |              ❌             |                  ✔️                       |               ✔️                          |                  ✔️                         |
+| `ROBOTOLOGY_USES_PYTHON`                | ✔️                               |              ❌             |                  ✔️                       |               ✔️                          |                  ✔️                         |
 | `ROBOTOLOGY_USES_CFW2CAN`                                           |  ✔️                              |             ❌              |                 ✔️                        |              ❌                           |                 ❌                          |
 | `ROBOTOLOGY_USES_XSENS_MVN_SDK`                                     |  ❌                              |             ✔️              |                 ❌                        |              ❌                           |                 ❌                          |
 | `ROBOTOLOGY_USES_ESDCAN`                                            |  ❌                              |             ✔️              |                 ❌                        |              ❌                           |                 ✔️                          |
            
-<b id="f1">1!</b>:Since 2021.05, `ROBOTOLOGY_ENABLE_DYNAMICS_FULL_DEPS` does not support building with apt dependencies on Ubuntu 1.04 .           
-           
-<b id="f2">2!</b>:Since 2021.11, `ROBOTOLOGY_ENABLE_ROBOT_TESTING` does not support building with apt dependencies on Ubuntu 18.04 .           
-           
-<b id="f3">3!</b>:Since 2021.11, `ROBOTOLOGY_USES_PYTHON` does not support building with apt dependencies on Ubuntu 18.04 .
 
-<b id="f4">4!</b>:Since 2022.05, `ROBOTOLOGY_USES_TELEOPERATION` does not support building with apt dependencies on Ubuntu 18.04 and Debian Buster .
-
-<b id="f5">5!</b>:`ROBOTOLOGY_ENABLE_GRASPING` does not support building with apt dependencies on Ubuntu 18.04 .
-
-<b id="f6">6!</b>:`ROBOTOLOGY_ENABLE_EVENT_DRIVEN` does not support building with apt dependencies on Ubuntu 18.04 and Debian Buster .
-
-<b id="f7">7!</b>:`ROBOTOLOGY_USES_GAZEBO` does not support building with apt dependencies on Ubuntu 18.04 .
-
-<b id="f8">8!</b>:`ROBOTOLOGY_USES_MUJOCO` does not support building with apt dependencies on Debian or Ubuntu distributions older than 2022. Furthermore, it does not support build on Wndows with Visual Studio 2019, it requires Visual Studio 2022.
+<b id="f1">1!</b>:`ROBOTOLOGY_USES_MUJOCO` does not support building with apt dependencies on Debian or Ubuntu distributions older than 2022. Furthermore, it does not support build on Wndows with Visual Studio 2019, it requires Visual Studio 2022.
 
 
 
@@ -142,9 +129,6 @@ This profile is enabled by the `ROBOTOLOGY_ENABLE_DYNAMICS` CMake option.
 
 ## Dynamics full deps
 This profile is enabled by the `ROBOTOLOGY_ENABLE_DYNAMICS_FULL_DEPS` CMake option.
-
-
-**Since 2021.05, `ROBOTOLOGY_ENABLE_DYNAMICS_FULL_DEPS` is not supported with apt dependencies on Ubuntu 18.04.**
 
 **Since 2023.05, `ROBOTOLOGY_ENABLE_DYNAMICS_FULL_DEPS` is not supported with vcpkg dependencies on Windows.**
 

--- a/scripts/install_apt_dependencies.sh
+++ b/scripts/install_apt_dependencies.sh
@@ -24,12 +24,3 @@ then
 else
   apt-get install -y libdc1394-22-dev
 fi
-
-# Handle nlohmann-json3-dev dependency
-# Remove once Ubuntu 18.04 compatibility is dropped
-if [[ ("$ROBSUP_DISTRO_NAME" == "Ubuntu" && "$ROBSUP_DISTRO_VERSION" == "18.04") ]]
-then
-  :
-else
-  apt-get install -y nlohmann-json3-dev
-fi


### PR DESCRIPTION
See https://github.com/robotology/robotology-superbuild/issues/481#issuecomment-1814495739 for the reasoning behind this choice.