### PR TITLE
Add ref names, including branches and tags in robotologyGitStatus script

### DIFF
--- a/scripts/robotologyGitStatus.sh
+++ b/scripts/robotologyGitStatus.sh
@@ -26,7 +26,7 @@ printGitStatus () {
     echo "--------------------------------------------"
     (cd $1 && echo -n "${1}: " \
     && git rev-parse --abbrev-ref HEAD \
-    && git log -1 --format="%cr|%s|%H" \
+    && git log -1 --format="%cr|%s|%H|%D" \
     && git status -sb \
     && git --no-pager diff --minimal); \
 }


### PR DESCRIPTION
This will update the git log as 
```
git log -1 --format="%cr|%s|%H|%D"
```

In this command:

- `%cr`: Relative date (e.g., "2 days ago").
- `%s`: Subject.
- `%H`: Commit hash.
- `%D`: Ref names, including branches and tags.

For instance we will have
```
2 days ago|Commit message here|abcdef123456| (HEAD -> main, tag: v1.0, origin/main)
```