### PR TITLE
conda-forge: Migrate from jpeg to libjpeg-turbo

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,8 +87,6 @@ jobs:
         # Additional dependencies only useful on Linux
         # See https://github.com/robotology/robotology-superbuild/issues/477
         mamba install bash-completion expat-cos7-x86_64 freeglut libdc1394 libi2c libselinux-cos7-x86_64 libxau-cos7-x86_64 libxcb-cos7-x86_64 libxdamage-cos7-x86_64 libxext-cos7-x86_64 libxfixes-cos7-x86_64 libxxf86vm-cos7-x86_64 mesa-libgl-cos7-x86_64 mesa-libgl-devel-cos7-x86_64 libxshmfence-cos7-x86_64 libxshmfence-devel-cos7-x86_64 
-        # Ignition Gazebo
-        mamba install libignition-gazebo6
 
     # Additional dependencies useful only on Windows
     - name: Dependencies [Conda/Windows]
@@ -138,11 +136,6 @@ jobs:
       run: |
         cd build
         cmake -DROBOTOLOGY_USES_MUJOCO:BOOL=OFF .
-
-    - name: Configure Extra [Conda/Linux]
-      if: contains(matrix.os, 'ubuntu')
-      shell: bash -l {0}
-      run: cmake -S . -B build/ -DROBOTOLOGY_USES_IGNITION:BOOL=ON
 
     # For some reason, the Strawberry perl's pkg-config is found
     # instead of the conda's one, so let's delete the /c/Strawberry directory

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,7 +75,7 @@ jobs:
       shell: bash -l {0}
       run: |
         # Dependencies
-        mamba install ace asio assimp boost eigen freetype gazebo glew glfw glm graphviz gsl ipopt irrlicht jpeg libmatio libode libxml2 nlohmann_json pcl vtk opencv portaudio qt-main sdl sdl2 sqlite tinyxml spdlog lua soxr cmake compilers make ninja pkg-config tomlplusplus libzlib ffmpeg
+        mamba install ace asio assimp boost eigen freetype gazebo glew glfw glm graphviz gsl ipopt irrlicht libjpeg-turbo libmatio libode libxml2 nlohmann_json pcl vtk opencv portaudio qt-main sdl sdl2 sqlite tinyxml spdlog lua soxr cmake compilers make ninja pkg-config tomlplusplus libzlib ffmpeg
         # Python 
         mamba install python numpy swig pybind11 pyqt matplotlib h5py tornado u-msgpack-python pyzmq ipython gst-plugins-good gst-plugins-bad
 

--- a/doc/conda-forge.md
+++ b/doc/conda-forge.md
@@ -113,12 +113,12 @@ Once you activated it, you can install packages in it. In particular the depende
 
 If you are on **Linux**, **Windows**, or **macOS** with an Intel-based processor (and not a *recent* (as per 2022/2023) ARM-based processor)
 ~~~
-mamba install -c conda-forge ace asio assimp boost eigen freetype gazebo glew glfw glm graphviz gsl ipopt irrlicht jpeg libmatio libode libxml2 nlohmann_json pcl opencv portaudio qt-main sdl sdl2 sqlite tinyxml tinyxml2 spdlog lua soxr qhull cmake compilers make ninja pkg-config tomlplusplus libzlib ffmpeg
+mamba install -c conda-forge ace asio assimp boost eigen freetype gazebo glew glfw glm graphviz gsl ipopt irrlicht libjpeg-turbo libmatio libode libxml2 nlohmann_json pcl opencv portaudio qt-main sdl sdl2 sqlite tinyxml tinyxml2 spdlog lua soxr qhull cmake compilers make ninja pkg-config tomlplusplus libzlib ffmpeg
 ~~~
 
 If you are on **macOS** with a *recent* (as per 2022/2023) ARM-based processor
 ~~~
-mamba install -c conda-forge asio assimp boost eigen freetype gazebo glew glfw glm graphviz gsl ipopt irrlicht jpeg libmatio libode libxml2 nlohmann_json pcl opencv portaudio qt-main sdl sdl2 sqlite tinyxml tinyxml2 spdlog lua soxr qhull cmake compilers make ninja pkg-config tomlplusplus libzlib ffmpeg
+mamba install -c conda-forge asio assimp boost eigen freetype gazebo glew glfw glm graphviz gsl ipopt irrlicht libjpeg-turbo libmatio libode libxml2 nlohmann_json pcl opencv portaudio qt-main sdl sdl2 sqlite tinyxml tinyxml2 spdlog lua soxr qhull cmake compilers make ninja pkg-config tomlplusplus libzlib ffmpeg
 ~~~
 
 If you are on **Linux**, you also need to install also the following packages:

--- a/doc/unsupported-homebrew-installation.md
+++ b/doc/unsupported-homebrew-installation.md
@@ -8,7 +8,7 @@ Unsupported Homebrew Installation
 ### System Dependencies
 To install the system dependencies, it is possible to use [Homebrew](http://brew.sh/):
 ```
-brew install ace assimp bash-completion boost cmake eigen graphviz gsl ipopt jpeg libedit nlohmann-json opencv pkg-config portaudio qt@5 sqlite swig tinyxml tinyxml2 libmatio irrlicht spdlog qhull zlib ffmpeg
+brew install ace assimp bash-completion boost cmake eigen graphviz gsl ipopt jpeg-turbo libedit nlohmann-json opencv pkg-config portaudio qt@5 sqlite swig tinyxml tinyxml2 libmatio irrlicht spdlog qhull zlib ffmpeg
 ```
 
 Since Qt5 is not symlinked in `/usr/local` by default in the homebrew formula, `Qt5_DIR` needs to be properly set to make sure that CMake-based projects are able to find Qt5.


### PR DESCRIPTION
The migration from jpeg to libjpeg-turbo (see https://github.com/conda-forge/conda-forge.github.io/issues/673) is still ongoing, but only a handful packages that are not used by robotology-superbuild or robotics packages in general, so it is safer to just switch to use `libjpeg-turbo` also here.