### PR TITLE
Remove embObjInertials

### DIFF
--- a/cmake/BuildICUB.cmake
+++ b/cmake/BuildICUB.cmake
@@ -83,7 +83,6 @@ ycm_ep_helper(ICUB TYPE GIT
                               -DENABLE_icubmod_embObjFTsensor:BOOL=${ROBOTOLOGY_ENABLE_ICUB_HEAD}
                               -DENABLE_icubmod_embObjMultipleFTsensors:BOOL=${ROBOTOLOGY_ENABLE_ICUB_HEAD}
                               -DENABLE_icubmod_embObjIMU:BOOL=${ROBOTOLOGY_ENABLE_ICUB_HEAD}
-                              -DENABLE_icubmod_embObjInertials:BOOL=${ROBOTOLOGY_ENABLE_ICUB_HEAD}
                               -DENABLE_icubmod_embObjMais:BOOL=${ROBOTOLOGY_ENABLE_ICUB_HEAD}
                               -DENABLE_icubmod_embObjMotionControl:BOOL=${ROBOTOLOGY_ENABLE_ICUB_HEAD}
                               -DENABLE_icubmod_embObjSkin:BOOL=${ROBOTOLOGY_ENABLE_ICUB_HEAD}


### PR DESCRIPTION
This device has been removed here:
- https://github.com/robotology/icub-main/pull/916

After that it has completely made obsolete by:
- https://github.com/robotology/icub-main/pull/894
- https://github.com/robotology/robots-configuration/pull/540