### PR TITLE
CMake: Specify enabled languages in project instead of calling enable_language

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,21 +3,15 @@
 # CopyPolicy: Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
 
 cmake_minimum_required(VERSION 3.12)
-project(robotology-superbuild NONE)
 
-## we have to enable C because it is currently used
-## by CMake to describe packages (in Config*.cmake files)
-enable_language(C)
 
-## FindACE requires CXX
-enable_language(CXX)
+## We can't specify LANGUAGES NONE as have to enable C because it is currently used
+## by CMake to describe packages (in Config*.cmake files) and FindACE requires CXX
+project(robotology-superbuild LANGUAGES C CXX)
 
 ## Set CMP0094 to NEW
-# Not done on APPLE as a workaround for https://github.com/robotology/robotology-superbuild/issues/1510
-if(NOT APPLE)
-  if(POLICY CMP0094)
-    cmake_policy(SET CMP0094 NEW)
-  endif()
+if(POLICY CMP0094)
+  cmake_policy(SET CMP0094 NEW)
 endif()
 
 # Disable in source build


### PR DESCRIPTION
I have no idea why (probably some hard to detect CMake bug) but in some cases:

~~~cmake
project(robotology-superbuild NONE)
enable_language(C)
enable_language(CXX)
~~~

make the first call to `find_package(Python3 COMPONENTS Interpreter Development REQUIRED)` fail, while:

~~~cmake
project(robotology-superbuild LANGUAGES C CXX)
~~~

works fine (beside being a more usual form).

Fix https://github.com/robotology/robotology-superbuild/issues/1541 .
Fix https://github.com/robotology/robotology-superbuild/issues/1510 .