### PR TITLE
Pin yarp unstable branch to yarp-3.9

### DIFF
--- a/cmake/ProjectsTagsUnstable.cmake
+++ b/cmake/ProjectsTagsUnstable.cmake
@@ -15,7 +15,7 @@ set_tag(casadi_TAG 3.6.3)
 set_tag(casadi-matlab-bindings_TAG v3.6.3.0)
 
 # Robotology projects
-set_tag(YARP_TAG master)
+set_tag(YARP_TAG yarp-3.9)
 set_tag(ICUB_TAG devel)
 set_tag(RobotTestingFramework_TAG devel)
 set_tag(blockTest_TAG devel)


### PR DESCRIPTION
Until the yarp-ros situation described in https://github.com/robotology/robotology-superbuild/pull/1547#issuecomment-1829415016 is fixed.

Fix https://github.com/robotology/robotology-superbuild/issues/1536 .