### PR TITLE
Add depedency of ergocub-software on YARP

### DIFF
--- a/cmake/Buildergocub-software.cmake
+++ b/cmake/Buildergocub-software.cmake
@@ -2,6 +2,9 @@
 # CopyPolicy: Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
 
 include(YCMEPHelper)
+include(FindOrBuildPackage)
+
+find_or_build_package(YARP QUIET)
 
 set(ergocub-software_OPTIONAL_CMAKE_ARGS "")
 
@@ -10,6 +13,7 @@ ycm_ep_helper(ergocub-software
               STYLE GITHUB
               REPOSITORY icub-tech-iit/ergocub-software.git
               TAG master
+              DEPENDS YARP
               COMPONENT core
               FOLDER src
               CMAKE_ARGS ${ergocub-software_OPTIONAL_CMAKE_ARGS})


### PR DESCRIPTION
Required since https://github.com/icub-tech-iit/ergocub-software/pull/196 .