### PR TITLE
casadi: Enable SWIG_IMPORT option

### DIFF
--- a/cmake/Buildcasadi.cmake
+++ b/cmake/Buildcasadi.cmake
@@ -46,6 +46,7 @@ ycm_ep_helper(casadi TYPE GIT
                          -DCMAKE_PREFIX:PATH=lib/cmake/casadi
                          -DLIB_PREFIX:PATH=lib
                          -DBIN_PREFIX:PATH=bin
+                         -DSWIG_IMPORT:BOOL=ON
                          -DWITH_PYTHON:BOOL=${ROBOTOLOGY_USES_PYTHON}
                          -DWITH_PYTHON3:BOOL=${ROBOTOLOGY_USES_PYTHON}
                          -DCASADI_PYTHON_PIP_METADATA_INSTALL:BOOL=${ROBOTOLOGY_USES_PYTHON}


### PR DESCRIPTION
In this way, we compile the generaed Python source contaned in CasADi releases instead of generating them as part of the superbuild, saving time and avoiding regressions due to new SWIG versions, see https://github.com/robotology/robotology-superbuild/issues/1564 as an example.

Fix https://github.com/robotology/robotology-superbuild/issues/1564 .