### PR TITLE
Pin swig to 4.1.0 to avoid 4.2.0 casadi failure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,7 +77,7 @@ jobs:
         # Dependencies
         mamba install ace asio assimp boost eigen freetype gazebo glew glfw glm graphviz==8.* gsl ipopt irrlicht libjpeg-turbo libmatio libode libxml2 nlohmann_json pcl vtk opencv portaudio qt-main sdl sdl2 sqlite tinyxml spdlog lua soxr cmake compilers make ninja pkg-config tomlplusplus libzlib ffmpeg
         # Python 
-        mamba install python numpy swig pybind11 pyqt matplotlib h5py tornado u-msgpack-python pyzmq ipython gst-plugins-good gst-plugins-bad
+        mamba install python numpy swig==4.1.0 pybind11 pyqt matplotlib h5py tornado u-msgpack-python pyzmq ipython gst-plugins-good gst-plugins-bad
 
     # Additional dependencies useful only on Linux
     - name: Dependencies [Conda/Linux]

--- a/doc/cmake-options.md
+++ b/doc/cmake-options.md
@@ -341,7 +341,7 @@ sudo bash ./scripts/install_apt_python_dependencies.sh
 #### Conda
 To install python and the other required dependencies when using `conda-forge` provided dependencies, use:
 ~~~
-mamba install -c conda-forge python numpy swig pybind11 pyqt matplotlib h5py tornado u-msgpack-python pyzmq ipython
+mamba install -c conda-forge python numpy swig==4.1.0 pybind11 pyqt matplotlib h5py tornado u-msgpack-python pyzmq ipython
 ~~~
 
 ### Check the installation

--- a/doc/conda-forge.md
+++ b/doc/conda-forge.md
@@ -163,7 +163,7 @@ For some [profile](doc/cmake-options.md#profile-cmake-options) or [dependency](d
 
 To install python and the other required dependencies when using `conda-forge` provided dependencies, use:
 ~~~
-mamba install -c conda-forge python numpy swig pybind11 pyqt matplotlib h5py tornado u-msgpack-python pyzmq ipython gst-plugins-good gst-plugins-bad
+mamba install -c conda-forge python numpy swig==4.1.0 pybind11 pyqt matplotlib h5py tornado u-msgpack-python pyzmq ipython gst-plugins-good gst-plugins-bad
 ~~~
 
 #### `ROBOTOLOGY_USES_PCL_AND_VTK`


### PR DESCRIPTION
Workaround for https://github.com/robotology/robotology-superbuild/issues/1564, it can be removed once https://github.com/casadi/casadi/issues/3527 is fixed.