### PR TITLE
Pass SKIP_ACE to YARP on macOS if using Apple Silicon

### DIFF
--- a/cmake/BuildYARP.cmake
+++ b/cmake/BuildYARP.cmake
@@ -21,7 +21,6 @@ else()
   set(YARP_COMPILE_BINDINGS OFF)
 endif()
 
-
 if (APPLE OR WIN32)
   set(ENABLE_USBCAMERA OFF)
 else()
@@ -37,6 +36,16 @@ endif()
 
 if(ROBOTOLOGY_USES_PYTHON)
   list(APPEND YARP_OPTIONAL_DEPS "-DCMAKE_INSTALL_PYTHON3DIR=${ROBOTOLOGY_SUPERBUILD_PYTHON_INSTALL_DIR}")
+endif()
+
+# Workaround for ace not available on arm64 on Apple in conda-forge, see
+# https://github.com/robotology/robotology-superbuild/issues/916
+# https://github.com/conda-forge/ace-feedstock/issues/29
+# See https://github.com/conda-forge/sleef-feedstock/blob/7fa2b0e5c9d9a10165809b4bb73a5840d72d0cdc/recipe/patches/353.patch#L6
+# for the logic of detecting arm builds on Apple
+if(ROBOTOLOGY_CONFIGURING_UNDER_CONDA AND APPLE
+   AND CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64|arm64")
+   list(APPEND YARP_OPTIONAL_CMAKE_ARGS "-DSKIP_ACE:BOOL=ON")
 endif()
 
 ycm_ep_helper(YARP TYPE GIT

--- a/doc/conda-forge.md
+++ b/doc/conda-forge.md
@@ -191,32 +191,6 @@ cmake ..
 cmake --build . --config Release 
 ~~~
 
-On **macOS** with a *recent* (as per 2022/2023) ARM-based processor, because of https://github.com/robotology/robotology-superbuild/issues/916, the procedure is slightly different: 
-~~~
-cd robotology-superbuild
-mkdir build
-cd build
-cmake ..
-cmake --build . --config Release 
-~~~
-At this point, you will get the error message
-~~~
-CMake Error at cmake/YarpFindDependencies.cmake:187 (message):
-  Optional package ACE not found.  Please install it or enable the option
-  "SKIP_ACE" to build yarp.
-Call Stack (most recent call first):
-  cmake/YarpFindDependencies.cmake:703 (check_skip_dependency)
-  CMakeLists.txt:60 (include)
-~~~
-So, do the following steps
-~~~
-cd src/YARP
-cmake -DSKIP_ACE:BOOL=ON .
-cd ..
-cd ..
-cmake --build . --config Release 
-~~~
-
 On **Windows**, run:
 ~~~
 cd robotology-superbuild


### PR DESCRIPTION
This removes the need of passing `SKIP_ACE` manually.