### PR TITLE
Add dependency on onnruntime-cpp also on conda if ROBOTOLOGY_ENABLE_DYNAMICS_FULL_DEPS is enabled

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,7 +75,7 @@ jobs:
       shell: bash -l {0}
       run: |
         # Dependencies
-        mamba install ace asio assimp boost eigen freetype gazebo glew glfw glm graphviz==8.* gsl ipopt irrlicht libjpeg-turbo libmatio libode libxml2 nlohmann_json pcl vtk opencv portaudio qt-main sdl sdl2 sqlite tinyxml spdlog lua soxr cmake compilers make ninja pkg-config tomlplusplus libzlib ffmpeg
+        mamba install ace asio assimp boost eigen freetype gazebo glew glfw glm graphviz==8.* gsl ipopt irrlicht libjpeg-turbo libmatio libode libxml2 nlohmann_json pcl vtk opencv portaudio qt-main sdl sdl2 sqlite tinyxml spdlog lua soxr cmake compilers make ninja pkg-config tomlplusplus libzlib ffmpeg onnxruntime-cpp
         # Python 
         mamba install python numpy swig==4.1.0 pybind11 pyqt matplotlib h5py tornado u-msgpack-python pyzmq ipython gst-plugins-good gst-plugins-bad
 

--- a/cmake/Buildbipedal-locomotion-framework.cmake
+++ b/cmake/Buildbipedal-locomotion-framework.cmake
@@ -63,13 +63,12 @@ if(APPLE OR WIN32)
   list(APPEND bipedal-locomotion-framework_OPTIONAL_CMAKE_ARGS "-DENABLE_YarpRobotLoggerDevice:BOOL=OFF")
 endif()
 
-# onnxruntime
+
 # Just on Linux without conda, we download onnxruntime
-set(FRAMEWORK_USE_onnxruntime OFF)
+# On conda instead, we install onnxruntime-cpp package
 if(ROBOTOLOGY_ENABLE_DYNAMICS_FULL_DEPS)
   if(CMAKE_SYSTEM_NAME STREQUAL "Linux" AND NOT ROBOTOLOGY_CONFIGURING_UNDER_CONDA)
     include(Fetchonnxruntimebinaries)
-    set(FRAMEWORK_USE_onnxruntime ON)
   endif()
 endif()
 
@@ -89,7 +88,7 @@ ycm_ep_helper(bipedal-locomotion-framework TYPE GIT
                          -DFRAMEWORK_USE_casadi:BOOL=${ROBOTOLOGY_ENABLE_DYNAMICS_FULL_DEPS}
                          -DFRAMEWORK_USE_LieGroupControllers:BOOL=${ROBOTOLOGY_ENABLE_DYNAMICS_FULL_DEPS}
                          -DFRAMEWORK_USE_tomlplusplus:BOOL=${ROBOTOLOGY_ENABLE_DYNAMICS_FULL_DEPS}
-                         -DFRAMEWORK_USE_onnxruntime:BOOL=${FRAMEWORK_USE_onnxruntime}
+                         -DFRAMEWORK_USE_onnxruntime:BOOL=${ROBOTOLOGY_ENABLE_DYNAMICS_FULL_DEPS}
                          -DFRAMEWORK_COMPILE_PYTHON_BINDINGS:BOOL=${ROBOTOLOGY_USES_PYTHON}
                          ${bipedal-locomotion-framework_OPTIONAL_CMAKE_ARGS}
               DEPENDS ${bipedal-locomotion-framework_DEPENDS})

--- a/doc/conda-forge.md
+++ b/doc/conda-forge.md
@@ -134,12 +134,12 @@ Once you activated it, you can install packages in it. In particular the depende
 
 If you are on **Linux**, **Windows**, or **macOS** with an Intel-based processor:
 ~~~
-mamba install -c conda-forge ace asio assimp boost eigen freetype gazebo glew glfw glm "graphviz==8.*" gsl ipopt irrlicht libjpeg-turbo libmatio libode libxml2 nlohmann_json pcl opencv portaudio qt-main sdl sdl2 sqlite tinyxml tinyxml2 spdlog lua soxr qhull cmake compilers make ninja pkg-config tomlplusplus libzlib ffmpeg
+mamba install -c conda-forge ace asio assimp boost eigen freetype gazebo glew glfw glm "graphviz==8.*" gsl ipopt irrlicht libjpeg-turbo libmatio libode libxml2 nlohmann_json pcl opencv portaudio qt-main sdl sdl2 sqlite tinyxml tinyxml2 spdlog lua soxr qhull cmake compilers make ninja pkg-config tomlplusplus libzlib ffmpeg onnxruntime-cpp
 ~~~
 
 If you are on **macOS** with ARM-based processor:
 ~~~
-mamba install -c conda-forge asio assimp boost eigen freetype gazebo glew glfw glm "graphviz==8.*" gsl ipopt irrlicht libjpeg-turbo libmatio libode libxml2 nlohmann_json pcl opencv portaudio qt-main sdl sdl2 sqlite tinyxml tinyxml2 spdlog lua soxr qhull cmake compilers make ninja pkg-config tomlplusplus libzlib ffmpeg
+mamba install -c conda-forge asio assimp boost eigen freetype gazebo glew glfw glm "graphviz==8.*" gsl ipopt irrlicht libjpeg-turbo libmatio libode libxml2 nlohmann_json pcl opencv portaudio qt-main sdl sdl2 sqlite tinyxml tinyxml2 spdlog lua soxr qhull cmake compilers make ninja pkg-config tomlplusplus libzlib ffmpeg onnxruntime-cpp
 ~~~
 
 If you are on **Linux x86-64**, you also need to install also the following packages:


### PR DESCRIPTION
This completes what we started in https://github.com/robotology/robotology-superbuild/pull/1387, as now https://github.com/conda-forge/onnxruntime-feedstock/pull/56 is solved.

The corresponding change in the blf conda-forge recipe was made in https://github.com/conda-forge/bipedal-locomotion-framework-feedstock/pull/53 .