### PR TITLE
Do not use find_package(glfw3) to detect if irrlicht+sdl is available

### DIFF
--- a/cmake/BuildiDynTree.cmake
+++ b/cmake/BuildiDynTree.cmake
@@ -23,8 +23,13 @@ endif()
 # Hack for disabling IDYNTREE_USES_IRRLICHT on vcpkg,
 # remove once irrlicht+sdl is available on vcpkg,
 # and https://github.com/robotology/robotology-superbuild-dependencies-vcpkg
-# is modified to includ it
-find_package(glfw3 NO_MODULE QUIET)
+# is modified to include it
+if(WIN32 AND NOT ROBOTOLOGY_CONFIGURING_UNDER_CONDA)
+   # We assume that the case Win32 and not conda is vcpkg, where we do not have irrlicht+sdl
+   set(IDYNTREE_USES_IRRLICHT OFF)
+else()
+   set(IDYNTREE_USES_IRRLICHT ON)
+endif()
 
 ycm_ep_helper(iDynTree TYPE GIT
               STYLE GITHUB
@@ -34,7 +39,7 @@ ycm_ep_helper(iDynTree TYPE GIT
               FOLDER src
               CMAKE_ARGS -DIDYNTREE_USES_IPOPT:BOOL=ON
                          -DIDYNTREE_USES_OSQPEIGEN:BOOL=ON
-                         -DIDYNTREE_USES_IRRLICHT:BOOL=${glfw3_FOUND}
+                         -DIDYNTREE_USES_IRRLICHT:BOOL=${IDYNTREE_USES_IRRLICHT}
                          -DIDYNTREE_USES_ASSIMP:BOOL=ON
                          -DCMAKE_DISABLE_FIND_PACKAGE_YARP:BOOL=ON
                          -DIDYNTREE_USES_YARP:BOOL=OFF

--- a/cmake/BuildiDynTree.cmake
+++ b/cmake/BuildiDynTree.cmake
@@ -24,7 +24,7 @@ endif()
 # remove once irrlicht+sdl is available on vcpkg,
 # and https://github.com/robotology/robotology-superbuild-dependencies-vcpkg
 # is modified to includ it
-find_package(glfw3 QUIET)
+find_package(glfw3 NO_MODULE QUIET)
 
 ycm_ep_helper(iDynTree TYPE GIT
               STYLE GITHUB


### PR DESCRIPTION
Solution for https://github.com/robotology/robotology-superbuild/issues/1597, alternative to https://github.com/robotology/robotology-superbuild/pull/1598 . The main problem of  https://github.com/robotology/robotology-superbuild/pull/1598  is that it would raise a deprecation warning after https://github.com/robotology/ycm/pull/441 is merged. Instead, we can already avoid to use the `FindGLFW3` script by passing `NO_MODULE` to `find_package(glfw3)`.