### PR TITLE
Add vscode settings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,7 @@
 {
     "C_Cpp.default.compileCommands": "${config:cmake.buildDirectory}/compile_commands.json",
     "cmake.mergedCompileCommands": "${config:cmake.buildDirectory}/compile_commands.json",
+    "clangd.arguments": [
+        "--compile-commands-dir=${config:cmake.buildDirectory}/"
+    ],
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,4 @@
 {
-    "C_Cpp.default.compileCommands": "${workspaceFolder}/build/merged_compile_commands.json",
-    "cmake.mergedCompileCommands": "${workspaceFolder}/build/merged_compile_commands.json"
+    "C_Cpp.default.compileCommands": "${config:cmake.buildDirectory}/compile_commands.json",
+    "cmake.mergedCompileCommands": "${config:cmake.buildDirectory}/compile_commands.json",
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,4 @@
+{
+    "C_Cpp.default.compileCommands": "${workspaceFolder}/build/merged_compile_commands.json",
+    "cmake.mergedCompileCommands": "${workspaceFolder}/build/merged_compile_commands.json"
+}

--- a/cmake/RobotologySuperbuildOptions.cmake
+++ b/cmake/RobotologySuperbuildOptions.cmake
@@ -3,10 +3,8 @@
 
 set(YCM_USE_CMAKE_PROPOSED TRUE CACHE BOOL "Use files including unmerged cmake patches")
 
-  set(CMAKE_EXPORT_COMPILE_COMMANDS "ON"
-    CACHE BOOL "Enable/Disable output of compile commands during generation."
-    )
-  mark_as_advanced(CMAKE_EXPORT_COMPILE_COMMANDS)
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON CACHE BOOL "Enable/Disable output of compile commands during generation.")
+mark_as_advanced(CMAKE_EXPORT_COMPILE_COMMANDS)
 
 # YCM options
 option(YCM_DISABLE_SYSTEM_PACKAGES "Disable use of all the system installed packages" ON)

--- a/cmake/RobotologySuperbuildOptions.cmake
+++ b/cmake/RobotologySuperbuildOptions.cmake
@@ -3,7 +3,10 @@
 
 set(YCM_USE_CMAKE_PROPOSED TRUE CACHE BOOL "Use files including unmerged cmake patches")
 
-set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+  set(CMAKE_EXPORT_COMPILE_COMMANDS "ON"
+    CACHE BOOL "Enable/Disable output of compile commands during generation."
+    )
+  mark_as_advanced(CMAKE_EXPORT_COMPILE_COMMANDS)
 
 # YCM options
 option(YCM_DISABLE_SYSTEM_PACKAGES "Disable use of all the system installed packages" ON)

--- a/cmake/RobotologySuperbuildOptions.cmake
+++ b/cmake/RobotologySuperbuildOptions.cmake
@@ -3,6 +3,8 @@
 
 set(YCM_USE_CMAKE_PROPOSED TRUE CACHE BOOL "Use files including unmerged cmake patches")
 
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+
 # YCM options
 option(YCM_DISABLE_SYSTEM_PACKAGES "Disable use of all the system installed packages" ON)
 


### PR DESCRIPTION
In this PR I add the VSCode `settings.json` and the CMake options needed to enable the intellisense integration for the superbuild.

See https://github.com/robotology/robotology-superbuild/issues/1596 for the discussion.