### PR TITLE
Also set yarp-matlab-bindings_TAG unstable to yarp-3.9

### DIFF
--- a/cmake/ProjectsTagsUnstable.cmake
+++ b/cmake/ProjectsTagsUnstable.cmake
@@ -16,6 +16,7 @@ set_tag(casadi-matlab-bindings_TAG v3.6.3.1)
 
 # Robotology projects
 set_tag(YARP_TAG yarp-3.9)
+set_tag(yarp-matlab-bindings_TAG yarp-3.9)
 set_tag(ICUB_TAG devel)
 set_tag(RobotTestingFramework_TAG devel)
 set_tag(blockTest_TAG devel)


### PR DESCRIPTION
As in https://github.com/robotology/robotology-superbuild/pull/1549 we temporary pinned yarp in unstable branches to 3.9, for the same reason we need to pin also yarp-matlab-bindings .