### PR TITLE
Switch expat, xcb and xorg libraries from cdt to proper packages and add xorg-libxrandr package for glfw 3.4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,7 +108,7 @@ jobs:
       run: |
         # Additional dependencies only useful on Linux
         # See https://github.com/robotology/robotology-superbuild/issues/477
-        mamba install bash-completion expat-cos7-x86_64 freeglut libdc1394 libi2c libselinux-cos7-x86_64 libxau-cos7-x86_64 libxcb-cos7-x86_64 libxdamage-cos7-x86_64 libxext-cos7-x86_64 libxfixes-cos7-x86_64 libxxf86vm-cos7-x86_64 mesa-libgl-cos7-x86_64 mesa-libgl-devel-cos7-x86_64 libxshmfence-cos7-x86_64 libxshmfence-devel-cos7-x86_64 
+        mamba install bash-completion expat freeglut libdc1394 libi2c libselinux-cos7-x86_64 xorg-libxau libxcb xorg-libxdamage xorg-libxext xorg-libxfixes xorg-libxxf86vm xorg-libxrandr mesa-libgl-cos7-x86_64 mesa-libgl-devel-cos7-x86_64 libxshmfence-cos7-x86_64 libxshmfence-devel-cos7-x86_64 
 
     # Additional dependencies useful only on Windows
     - name: Dependencies [Conda/Windows]

--- a/conda/cmake_recipe_template/meta.yaml
+++ b/conda/cmake_recipe_template/meta.yaml
@@ -38,6 +38,7 @@ requirements:
 {% endfor %}
 {# Handle specific packages required for gl on Linux, see https://conda-forge.org/docs/maintainer/knowledge_base.html?#libgl and https://github.com/conda-forge/qt-main-feedstock/blob/0a0caca0eef18d4f895ec81840dcb037a20dc844/recipe/meta.yaml#L67-L158 #}
 {# libxcb, libxfixes, libxau and expat are not documented anywhere, but without those blocktest does not build correctly #}
+{# xorg-libxrandr is actually needed by glfw 3.4 #}
 {% if require_opengl_linux %}    - xorg-libxfixes
     - xorg-libxdamage
     - xorg-libxxf86vm
@@ -45,6 +46,7 @@ requirements:
     - expat
     - xorg-libxau
     - libxcb
+    - xorg-libxrandr 
     - xorg-libxfixes {% endif %}
 {# Handle the constraint of macos >= 10.13 #}
   run:

--- a/conda/cmake_recipe_template/meta.yaml
+++ b/conda/cmake_recipe_template/meta.yaml
@@ -26,26 +26,26 @@ requirements:
     - ninja
 {% for build_dep in build_dependencies_explicit %}    - {{ build_dep }}
 {% endfor %}
-{# Handle specific packages required for gl on Linux, see https://conda-forge.org/docs/maintainer/knowledge_base.html?#libgl #}
-{# libxcb, libxfixes, libxau and expat are not documented anywhere, but without those blocktest does not build correctly #}
+{# Handle specific packages required for gl on Linux, see https://conda-forge.org/docs/maintainer/knowledge_base.html?#libgl and https://github.com/conda-forge/qt-main-feedstock/blob/0a0caca0eef18d4f895ec81840dcb037a20dc844/recipe/meta.yaml#L67-L158 #}
 {% if require_opengl_linux %}{% raw %}    - {{ cdt('mesa-libgl-devel') }}
     - {{ cdt('mesa-dri-drivers') }}
-    - {{ cdt('libselinux') }}
-    - {{ cdt('libxdamage') }}
-    - {{ cdt('libxxf86vm') }}
-    - {{ cdt('libxext') }}
-    - {{ cdt('libxcb') }}
-    - {{ cdt('libxfixes') }}
-    - {{ cdt('libxau') }}
-    - {{ cdt('expat') }}  {% endraw %}{% endif %}
+    - {{ cdt('libselinux') }}  {% endraw %}{% endif %}
 
 
   host:
 {# List all dependencies just a host. Run dependenencies should be correctly set by run_exports, except the one listed in #}
 {% for dep in dependencies %}    - {{ dep }}
 {% endfor %}
-{# Handle specific packages required for gl on Linux, see https://conda-forge.org/docs/maintainer/knowledge_base.html?#libgl #}
-{% if require_opengl_linux %}    - xorg-libxfixes {% endif %}
+{# Handle specific packages required for gl on Linux, see https://conda-forge.org/docs/maintainer/knowledge_base.html?#libgl and https://github.com/conda-forge/qt-main-feedstock/blob/0a0caca0eef18d4f895ec81840dcb037a20dc844/recipe/meta.yaml#L67-L158 #}
+{# libxcb, libxfixes, libxau and expat are not documented anywhere, but without those blocktest does not build correctly #}
+{% if require_opengl_linux %}    - xorg-libxfixes
+    - xorg-libxdamage
+    - xorg-libxxf86vm
+    - xorg-libxext
+    - expat
+    - xorg-libxau
+    - libxcb
+    - xorg-libxfixes {% endif %}
 {# Handle the constraint of macos >= 10.13 #}
   run:
     - __osx >={{ MACOSX_DEPLOYMENT_TARGET|default("10.9") }}  # [osx and x86_64]

--- a/conda/conda_build_config.yml
+++ b/conda/conda_build_config.yml
@@ -20,3 +20,8 @@ swig:
 # Remove once ipopt31414 migration is completed
 ipopt:
  - 3.14.14
+
+# Workaround for:
+# libxcb 1.15 migration not completed and not pinned, see https://github.com/robotology/robotology-superbuild/pull/1606#issuecomment-1965508546
+libxcb:
+ - 1.15

--- a/doc/conda-forge.md
+++ b/doc/conda-forge.md
@@ -144,12 +144,12 @@ mamba install -c conda-forge asio assimp boost eigen freetype gazebo glew glfw g
 
 If you are on **Linux x86-64**, you also need to install also the following packages:
 ~~~
-mamba install -c conda-forge bash-completion freeglut libdc1394 libi2c expat-cos7-x86_64 libselinux-cos7-x86_64 libxau-cos7-x86_64 libxcb-cos7-x86_64 libxdamage-cos7-x86_64 libxext-cos7-x86_64 libxfixes-cos7-x86_64 libxxf86vm-cos7-x86_64 mesa-libgl-cos7-x86_64 mesa-libgl-devel-cos7-x86_64 libxshmfence-cos7-x86_64 libxshmfence-devel-cos7-x86_64 
+mamba install -c conda-forge bash-completion freeglut libdc1394 libi2c expat  libselinux-cos7-x86_64 xorg-libxau libxcb xorg-libxdamage xorg-libxext xorg-libxfixes xorg-libxxf86vm xorg-libxrandr mesa-libgl-cos7-x86_64 mesa-libgl-devel-cos7-x86_64 libxshmfence-cos7-x86_64 libxshmfence-devel-cos7-x86_64 
 ~~~
 
 If you are on **Linux ARM 64-bit**, you also need to install also the following packages:
 ~~~
-mamba install -c conda-forge bash-completion freeglut libdc1394 libi2c expat-cos7-aarch64 libselinux-cos7-aarch64 libxau-cos7-aarch64 libxcb-cos7-aarch64 libxdamage-cos7-aarch64 libxext-cos7-aarch64 libxfixes-cos7-aarch64 libxxf86vm-cos7-aarch64 mesa-libgl-cos7-aarch64 mesa-libgl-devel-cos7-aarch64 libxshmfence-cos7-aarch64 libxshmfence-devel-cos7-aarch64 
+mamba install -c conda-forge bash-completion freeglut libdc1394 libi2c expat libselinux-cos7-aarch64 xorg-libxau libxcb xorg-libxdamage xorg-libxext xorg-libxfixes xorg-libxxf86vm xorg-libxrandr mesa-libgl-cos7-aarch64 mesa-libgl-devel-cos7-aarch64 libxshmfence-cos7-aarch64 libxshmfence-devel-cos7-aarch64 
 ~~~
 
 If you are on **Windows**, you also need to install also the following packages:


### PR DESCRIPTION
Fix issue similar to https://github.com/robotology/idyntree/issues/1156 but for the superbuild. As a cleanup, I also migrated as much as cdt as possible to regular packages.