### PR TITLE
Add yarp-devices-ros repo

### DIFF
--- a/cmake/Buildyarp-devices-forcetorque.cmake
+++ b/cmake/Buildyarp-devices-forcetorque.cmake
@@ -1,4 +1,4 @@
-# Copyright (C) 2019  iCub Facility, Istituto Italiano di Tecnologia
+# Copyright (C) Fondazione Istituto Italiano di Tecnologia
 # CopyPolicy: Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
 
 include(YCMEPHelper)

--- a/cmake/Buildyarp-devices-ros.cmake
+++ b/cmake/Buildyarp-devices-ros.cmake
@@ -1,0 +1,15 @@
+# Copyright (C) Fondazione Istituto Italiano di Tecnologia
+# CopyPolicy: Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
+
+include(YCMEPHelper)
+include(FindOrBuildPackage)
+
+find_or_build_package(YARP QUIET)
+
+ycm_ep_helper(yarp-devices-ros TYPE GIT
+                                    STYLE GITHUB
+                                    REPOSITORY robotology/yarp-devices-ros.git
+                                    TAG master
+                                    COMPONENT core
+                                    FOLDER src
+                                    DEPENDS YARP)

--- a/cmake/RobotologySuperbuildLogic.cmake
+++ b/cmake/RobotologySuperbuildLogic.cmake
@@ -39,6 +39,7 @@ endif()
 # Core
 if(ROBOTOLOGY_ENABLE_CORE)
   find_or_build_package(YARP)
+  find_or_build_package(yarp-devices-ros)
   find_or_build_package(ICUB)
   find_or_build_package(ICUBcontrib)
   find_or_build_package(icub-models)

--- a/releases/latest.releases.yaml
+++ b/releases/latest.releases.yaml
@@ -267,3 +267,7 @@ repositories:
     type: git
     url: https://github.com/ami-iit/resolve-robotics-uri-py.git
     version: v0.2.0
+  yarp-devices-ros:
+    type: git
+    url: https://github.com/robotology/yarp-devices-ros
+    version: v3.9.0

--- a/releases/latest.releases.yaml
+++ b/releases/latest.releases.yaml
@@ -269,5 +269,5 @@ repositories:
     version: v0.2.0
   yarp-devices-ros:
     type: git
-    url: https://github.com/robotology/yarp-devices-ros
+    url: https://github.com/robotology/yarp-devices-ros.git
     version: v3.9.0


### PR DESCRIPTION
Fix https://github.com/robotology/robotology-superbuild/issues/1617 .

~Blocked by https://github.com/robotology/yarp-devices-ros/pull/2 and by having a tag to also update the `latest.releases.yaml` file.~ Solved: https://github.com/robotology/yarp-devices-ros/releases/tag/v3.9.0 .

fyi @dariosortino @S-Dafarra 