### PR TITLE
Fix settings.json cmake merged commands location

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,6 @@
 {
     "C_Cpp.default.compileCommands": "${config:cmake.buildDirectory}/compile_commands.json",
-    "cmake.mergedCompileCommands": "${config:cmake.buildDirectory}/compile_commands.json",
+    "cmake.mergedCompileCommands": "${command:cmake.buildDirectory}/compile_commands.json",
     "clangd.arguments": [
         "--compile-commands-dir=${config:cmake.buildDirectory}/"
     ],


### PR DESCRIPTION
I was having problems with the mergedCompileCommands setting: the expression was not evaluated correctly and so the file was generated in the wrong folder.

This should correct the behaviour.