### PR TITLE
Drop Debian 10 Buster support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -195,7 +195,6 @@ jobs:
         docker_image:
           - "ubuntu:focal"
           - "ubuntu:jammy"
-          - "debian:buster-backports"
           - "debian:bullseye"
 
         project_tags:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -237,10 +237,7 @@ jobs:
         chmod +x ./.ci/install_debian.sh
         bash ./.ci/install_debian.sh
 
-    - name: Install CMake 3.16 [Docker/Debian Buster]
-      if: matrix.docker_image == 'debian:buster-backports'
-      run: |
-        apt-get -y -t buster-backports install cmake
+
 
     - name: Configure [Docker]
       run: |
@@ -253,12 +250,6 @@ jobs:
       run: |
        cd build
        cmake -DROBOTOLOGY_ENABLE_DYNAMICS_FULL_DEPS:BOOL=OFF -DROBOTOLOGY_USES_MUJOCO:BOOL=OFF -DROBOTOLOGY_ENABLE_ROBOT_TESTING:BOOL=OFF -DROBOTOLOGY_USES_PYTHON:BOOL=OFF .
-
-    - name: Disable profiles that are not supported in Debian Buster [Docker debian:buster-backports]
-      if: (matrix.docker_image == 'debian:buster-backports')
-      run: |
-       cd build
-       cmake -DROBOTOLOGY_ENABLE_TELEOPERATION:BOOL=OFF -DROBOTOLOGY_USES_MUJOCO:BOOL=OFF -DROBOTOLOGY_ENABLE_EVENT_DRIVEN:BOOL=OFF .
 
     - name: Disable MuJoCo for other distros released before 2022 [Docker ubuntu:focal and debian:bullseye]
       if: (matrix.docker_image == 'ubuntu:focal' || matrix.docker_image == 'debian:bullseye')

--- a/README.md
+++ b/README.md
@@ -108,7 +108,6 @@ We also support an additional deprecated way of compiling the superbuild, on Win
 The following apt-based distributions are supported and tested by the robotology-superbuild:
 * Ubuntu 20.04 (Focal Fossa)
 * Ubuntu 22.04 (Jammy Jellyfish)
-* Debian 10 (Buster)
 * Debian 11 (Bullseye)
 
 Other versions may be working, but they are not checked.
@@ -124,9 +123,8 @@ Besides the packages listed in `apt.txt` file, the script `install_apt_dependenc
 
 For what regards CMake, the robotology-superbuild requires CMake 3.16 . If you are using a recent Debian-based system such as Ubuntu 20.04, the default CMake is recent enough and you do not need to do further steps.
 
-If instead you use an older distro in which the default version of CMake is older, you can easily install a newer CMake version in several ways. For the following distributions, we recommend the following methods:  
-* Debian 10 : use the CMake in the `buster-backports` repository, following the instructions to install from backports available in  [Debian documentation](https://backports.debian.org/Instructions/).
-More details can be found at https://github.com/robotology/QA/issues/364 .
+If instead you use an older distro in which the default version of CMake is older, you can easily install a newer CMake version in several ways. For the following distributions, we recommend the following methods:
+* Ubuntu 20.04 : install a recent CMake via Kitware APT Repository, see https://apt.kitware.com/ .
 
 For some [profile](doc/cmake-options.md#profile-cmake-options) or [dependency](doc/cmake-options.md#dependencies-cmake-options) specific CMake option you may need to install additional system dependencies, following the dependency-specific documentation listed in the following. If you do not want to enable an option, you should ignore the corresponding section and continue with the installation process.
 
@@ -136,7 +134,6 @@ Note that the `ROBOTOLOGY_USES_GAZEBO` option is enabled by default, so you shou
 
 On Linux with apt dependencies install Gazebo, if you are on:
 * Ubuntu 20.04
-* Debian Buster 10
 
 follow the instructions available at https://gazebosim.org/tutorials?tut=install_ubuntu . Make sure to install also the development files, i.e. `libgazebo*-dev` on Debian/Ubuntu.
 

--- a/apt.txt
+++ b/apt.txt
@@ -11,6 +11,7 @@ libassimp-dev
 libboost-filesystem-dev
 libboost-system-dev
 libboost-thread-dev
+libdc1394-dev
 libedit-dev
 libeigen3-dev
 libgsl0-dev

--- a/apt.txt
+++ b/apt.txt
@@ -11,7 +11,6 @@ libassimp-dev
 libboost-filesystem-dev
 libboost-system-dev
 libboost-thread-dev
-libdc1394-dev
 libedit-dev
 libeigen3-dev
 libgsl0-dev

--- a/scripts/install_apt_dependencies.sh
+++ b/scripts/install_apt_dependencies.sh
@@ -7,3 +7,20 @@
 SCRIPT_DIR=$(cd "$(dirname "$BASH_SOURCE")"; cd -P "$(dirname "$(readlink "$BASH_SOURCE" || echo .)")"; pwd)
 
 xargs -a ${SCRIPT_DIR}/../apt.txt apt-get install -y
+
+# Handle libdc1394 package (see https://github.com/robotology/robotology-superbuild/issues/854)
+# On Ubuntu 20.04 install libdc1394-22-dev, otherwise libdc1394-dev
+# Remove once Ubuntu 20.04 compatibility is dropped
+ROBSUP_DISTRO_NAME=$(lsb_release -i | cut -d: -f2 | sed s/'^\t'//)
+ROBSUP_DISTRO_VERSION=$(lsb_release -r | cut -d: -f2 | sed s/'^\t'//)
+ROBSUP_DISTRO_CODENAME=$(lsb_release -c | cut -d: -f2 | sed s/'^\t'//)
+
+echo "ROBSUP_DISTRO_NAME: ${ROBSUP_DISTRO_NAME}"
+echo "ROBSUP_DISTRO_VERSION: ${ROBSUP_DISTRO_VERSION}"
+echo "ROBSUP_DISTRO_CODENAME: ${ROBSUP_DISTRO_CODENAME}"
+if [[ ("$ROBSUP_DISTRO_NAME" == "Ubuntu" && "$ROBSUP_DISTRO_VERSION" == "20.04") ]]
+then
+  apt-get install -y libdc1394-22-dev
+else
+  apt-get install -y libdc1394-dev
+fi

--- a/scripts/install_apt_dependencies.sh
+++ b/scripts/install_apt_dependencies.sh
@@ -7,20 +7,3 @@
 SCRIPT_DIR=$(cd "$(dirname "$BASH_SOURCE")"; cd -P "$(dirname "$(readlink "$BASH_SOURCE" || echo .)")"; pwd)
 
 xargs -a ${SCRIPT_DIR}/../apt.txt apt-get install -y
-
-# Handle libdc1394 package (see https://github.com/robotology/robotology-superbuild/issues/854)
-# On Ubuntu 18.04 or Debian Buster install libdc1394-22-dev, otherwise libdc1394-dev
-# Remove once Ubuntu 18.04 and Debian Buster compatibility is dropped
-ROBSUP_DISTRO_NAME=$(lsb_release -i | cut -d: -f2 | sed s/'^\t'//)
-ROBSUP_DISTRO_VERSION=$(lsb_release -r | cut -d: -f2 | sed s/'^\t'//)
-ROBSUP_DISTRO_CODENAME=$(lsb_release -c | cut -d: -f2 | sed s/'^\t'//)
-
-echo "ROBSUP_DISTRO_NAME: ${ROBSUP_DISTRO_NAME}"
-echo "ROBSUP_DISTRO_VERSION: ${ROBSUP_DISTRO_VERSION}"
-echo "ROBSUP_DISTRO_CODENAME: ${ROBSUP_DISTRO_CODENAME}"
-if [[ ("$ROBSUP_DISTRO_NAME" == "Ubuntu" && "$ROBSUP_DISTRO_VERSION" == "22.04") || ("$ROBSUP_DISTRO_NAME" == "Debian" && "$ROBSUP_DISTRO_CODENAME" == "bullseye") || ("$ROBSUP_DISTRO_NAME" == "Debian" && "$ROBSUP_DISTRO_CODENAME" == "bookworm") || ("$ROBSUP_DISTRO_NAME" == "Debian" && "$ROBSUP_DISTRO_CODENAME" == "sid") ]]
-then
-  apt-get install -y libdc1394-dev
-else
-  apt-get install -y libdc1394-22-dev
-fi


### PR DESCRIPTION
This will be required to support YARP 3.10, as otherwise we do not have easy and maintainable way of installing CMake in the version that will be required by YARP 3.10.

This was added in https://github.com/robotology/robotology-superbuild/pull/1547, but I separate it in a separate PR to better visibility. 

**IMPORTANT: This change will make future robotology-superbuild releases not compatible with pc104-based iCub robots, as the last available image for pc104 is based on Debian 10 Buster, see https://icub-tech-iit.github.io/documentation/icub_operating_systems/pc104/icub-live/#versioning .**

As Debian 10 uses glibc 2.28 (see https://repology.org/project/glibc/versions), it should be possible to install software with conda-forge dependencies on Debian 10 for some time in the future.

@Nicogene @valegagge @pattacini @maggia80 
