### PR TITLE
Enable ROBOTOLOGY_USES_GZ_SIM with apt dependencies on Ubuntu 24.04

### DIFF
--- a/.ci/install_debian.sh
+++ b/.ci/install_debian.sh
@@ -52,8 +52,8 @@ else
     apt-get install -y libgazebo-dev
 fi
 
-# gz-sim8 binaries are only available for jammy (Ubuntu 22.04)
-if [[ ("jammy" == "$dist_version") ]]; then
+# gz-sim8 binaries are only available for jammy (Ubuntu 22.04) and noble (Ubuntu 24.04)
+if [[ ("jammy" == "$dist_version") || ("noble" == "$dist_version") ]]; then
     apt-get install -y gz-harmonic
 fi
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -261,7 +261,7 @@ jobs:
       if: (matrix.docker_image == 'ubuntu:24.04')
       run: |
        cd build
-       cmake  -DROBOTOLOGY_USES_GAZEBO:BOOL=OFF -DROBOTOLOGY_USES_GZ:BOOL=OFF .
+       cmake  -DROBOTOLOGY_USES_GAZEBO:BOOL=OFF .
 
     - name: Build  [Docker]
       run: |

--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ If you are on Ubuntu 24.04, please use conda if you want to install Gazebo Class
 
 #### `ROBOTOLOGY_USES_GZ`
 
-To install Modern Gazebo (gz-sim) on Ubuntu Jammy (22.04) and other supported Debian/Ubuntu systems, follow the instructions available at https://gazebosim.org/docs/harmonic/install_ubuntu#binary-installation-on-ubuntu .
+To install Modern Gazebo (gz-sim) on Ubuntu Jammy (22.04) and Noble (20.04) and other supported Debian/Ubuntu systems, follow the instructions available at https://gazebosim.org/docs/harmonic/install_ubuntu#binary-installation-on-ubuntu .
 
 #### `ROBOTOLOGY_USES_PYTHON`
 

--- a/doc/cmake-options.md
+++ b/doc/cmake-options.md
@@ -107,7 +107,7 @@ Not all options are supported on all platforms. The following table provides a r
 
 <b id="f2">2!</b>:`ROBOTOLOGY_ENABLE_ROBOT_TESTING` and `ROBOTOLOGY_ENABLE_ICUB_HEAD` do not support building with conda-forge dependencies on Apple Silicon.
 
-<b id="f3">3!</b>:`ROBOTOLOGY_USES_GZ_SIM`  with apt dependencies do not support building on Debian distros (only Ubuntu is supported). At the moment Ubuntu 24.04 apt packages are not available (https://github.com/gazebosim/gz-sim/issues/2390#issuecomment-2096728527). Furthermore it does not run on Windows (https://github.com/gazebosim/gz-sim/issues/2089) and have known problems on macOS (https://github.com/robotology/gz-sim-yarp-plugins/issues/90).
+<b id="f3">3!</b>:`ROBOTOLOGY_USES_GZ_SIM`  with apt dependencies do not support building on Debian distros (only Ubuntu is supported). Furthermore it does not run on Windows (https://github.com/gazebosim/gz-sim/issues/2089) and have known problems on macOS (https://github.com/robotology/gz-sim-yarp-plugins/issues/90).
 
 <b id="f4">4!</b>:`ROBOTOLOGY_USES_OCTAVE` do not support building with apt dependencies on Ubuntu 20.04.
 


### PR DESCRIPTION
See https://community.gazebosim.org/t/gazebo-harmonic-packages-available-on-ubuntu-noble/2772 .