### PR TITLE
Suggest to use conda and miniforge instead of mamba and mambaforge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,12 +13,12 @@ on:
     types: [published]
   schedule:
   # * is a special character in YAML so you have to quote this string
-  # Execute a "nightly" build at 2 AM UTC 
+  # Execute a "nightly" build at 2 AM UTC
   - cron:  '0 2 * * *'
 
 
 jobs:
-  conda-build:    
+  conda-build:
     name: '[conda:Tags:${{ matrix.project_tags }}@${{ matrix.os }}@${{ matrix.build_type }}]'
     runs-on: ${{ matrix.os }}
     strategy:
@@ -39,25 +39,19 @@ jobs:
     - uses: actions/checkout@v4
 
     - uses: conda-incubator/setup-miniconda@v3
-      if: matrix.os != 'macos-14'
       with:
-        miniforge-variant: Mambaforge
+        miniforge-variant: Miniforge3
         miniforge-version: latest
 
-    - uses: conda-incubator/setup-miniconda@v3
-      if: matrix.os == 'macos-14'
-      with:
-        installer-url: https://github.com/conda-forge/miniforge/releases/download/23.11.0-0/Mambaforge-23.11.0-0-MacOSX-arm64.sh
-
     - name: Install files to enable compilation of mex files [Conda/Linux]
-      if: contains(matrix.os, 'ubuntu') 
+      if: contains(matrix.os, 'ubuntu')
       run: |
         curl -L -O https://github.com/robotology/robotology-vcpkg-ports/releases/download/storage/msdk_R2020b_mexa64.zip
         unzip msdk_R2020b_mexa64.zip
         rm msdk_R2020b_mexa64.zip
         echo "GHA_Matlab_ROOT_DIR=${GITHUB_WORKSPACE}/msdk_R2020b_mexa64" >> $GITHUB_ENV
         echo "GHA_Matlab_MEX_EXTENSION=mexa64" >> $GITHUB_ENV
-                
+
     - name: Install files to enable compilation of mex files [Conda/macOS Intel]
       if: matrix.os == 'macos-12'
       run: |
@@ -77,7 +71,7 @@ jobs:
         echo "GHA_Matlab_MEX_EXTENSION=mexmaca64" >> $GITHUB_ENV
 
     - name: Install files to enable compilation of mex files [Conda/Windows]
-      if: contains(matrix.os, 'windows') 
+      if: contains(matrix.os, 'windows')
       shell: bash
       run: |
         curl -L -O https://github.com/robotology/robotology-vcpkg-ports/releases/download/storage/msdk_R2020a_mexw64.zip
@@ -91,37 +85,37 @@ jobs:
       shell: bash -l {0}
       run: |
         # Dependencies
-        mamba install ace
+        conda install ace
 
     - name: Dependencies [Conda]
       shell: bash -l {0}
       run: |
         # Dependencies
-        mamba install asio assimp boost eigen freetype gazebo gz-sim8 glew glfw glm graphviz gsl ipopt irrlicht libjpeg-turbo libmatio libode libxml2 nlohmann_json pcl vtk opencv portaudio qt-main sdl sdl2 sqlite tinyxml spdlog lua soxr cmake compilers make ninja pkg-config tomlplusplus libzlib "ffmpeg==6.*" onnxruntime-cpp
-        # Python 
-        mamba install python numpy swig==4.1.0 pybind11 pyqt matplotlib h5py tornado u-msgpack-python pyzmq ipython gst-plugins-good gst-plugins-bad pyqtwebengine qtpy pyyaml
+        conda install asio assimp boost eigen freetype gazebo gz-sim8 glew glfw glm graphviz gsl ipopt irrlicht libjpeg-turbo libmatio libode libxml2 nlohmann_json pcl vtk opencv portaudio qt-main sdl sdl2 sqlite tinyxml spdlog lua soxr cmake compilers make ninja pkg-config tomlplusplus libzlib "ffmpeg==6.*" onnxruntime-cpp
+        # Python
+        conda install python numpy swig==4.1.0 pybind11 pyqt matplotlib h5py tornado u-msgpack-python pyzmq ipython gst-plugins-good gst-plugins-bad pyqtwebengine qtpy pyyaml
 
     # Additional dependencies useful only on Linux
     - name: Dependencies [Conda/Linux]
-      if: contains(matrix.os, 'ubuntu') 
+      if: contains(matrix.os, 'ubuntu')
       shell: bash -l {0}
       run: |
         # Additional dependencies only useful on Linux
         # See https://github.com/robotology/robotology-superbuild/issues/477
-        mamba install bash-completion freeglut libdc1394 libi2c libselinux-cos7-x86_64 xorg-libxau libxcb xorg-libxdamage xorg-libxext xorg-libxfixes xorg-libxxf86vm xorg-libxrandr mesa-libgl-cos7-x86_64 mesa-libgl-devel-cos7-x86_64 libxshmfence-cos7-x86_64 libxshmfence-devel-cos7-x86_64 
+        conda install bash-completion freeglut libdc1394 libi2c libselinux-cos7-x86_64 xorg-libxau libxcb xorg-libxdamage xorg-libxext xorg-libxfixes xorg-libxxf86vm xorg-libxrandr mesa-libgl-cos7-x86_64 mesa-libgl-devel-cos7-x86_64 libxshmfence-cos7-x86_64 libxshmfence-devel-cos7-x86_64
 
     # Additional dependencies useful only on Windows
     - name: Dependencies [Conda/Windows]
-      if: contains(matrix.os, 'windows') 
+      if: contains(matrix.os, 'windows')
       shell: bash -l {0}
       run: |
         # Additional dependencies only useful on Windows
-        mamba install -c conda-forge -c robotology esdcan freeglut
+        conda install -c conda-forge -c robotology esdcan freeglut
 
     - name: Print used environment [Conda]
       shell: bash -l {0}
       run: |
-        mamba list
+        conda list
         env
 
     - name: Set CMake generator [Conda/Linux and macOs]
@@ -166,7 +160,7 @@ jobs:
       shell: bash -l {0}
       run: |
         rm -rf /c/Strawberry
-        
+
     - name: Build  [Conda]
       shell: bash -l {0}
       run: |
@@ -292,9 +286,9 @@ jobs:
             project_tags_cmake_options: "-DROBOTOLOGY_PROJECT_TAGS=Custom -DROBOTOLOGY_PROJECT_TAGS_CUSTOM_FILE=${GITHUB_WORKSPACE}/releases/latest.releases.yaml"
     steps:
     - uses: actions/checkout@master
-    
+
     - name: Install files to enable compilation of mex files [Linux]
-      if: contains(matrix.os, 'ubuntu') 
+      if: contains(matrix.os, 'ubuntu')
       run: |
         curl -L -O https://github.com/robotology/robotology-vcpkg-ports/releases/download/storage/msdk_R2020b_mexa64.zip
         unzip msdk_R2020b_mexa64.zip
@@ -308,14 +302,14 @@ jobs:
       run: |
         ls /d/
         cp -r ${GITHUB_WORKSPACE} /c/
-        
-    - name: Define ROBOTOLOGY_SUPERBUILD_SOURCE_DIR 
+
+    - name: Define ROBOTOLOGY_SUPERBUILD_SOURCE_DIR
       if: contains(matrix.os, 'windows')
       shell: bash
       run: |
         echo "ROBOTOLOGY_SUPERBUILD_SOURCE_DIR=/c/robotology-superbuild" >> $GITHUB_ENV
 
-    - name: Define ROBOTOLOGY_SUPERBUILD_SOURCE_DIR 
+    - name: Define ROBOTOLOGY_SUPERBUILD_SOURCE_DIR
       if: contains(matrix.os, 'ubuntu')
       shell: bash
       run: |
@@ -365,7 +359,7 @@ jobs:
       if: contains(matrix.os, 'windows')
       run: |
         cd ${ROBOTOLOGY_SUPERBUILD_SOURCE_DIR}
-        # To avoid spending a huge time compiling vcpkg dependencies, we download an archive  that comes precompiled with all the ports that we need 
+        # To avoid spending a huge time compiling vcpkg dependencies, we download an archive  that comes precompiled with all the ports that we need
         choco install -y wget unzip
         # To avoid problems with non-relocatable packages, we unzip the archive exactly in the same directory
         # that has been used to create the pre-compiled archive
@@ -423,7 +417,7 @@ jobs:
       shell: bash
       run: |
         cd ${ROBOTOLOGY_SUPERBUILD_SOURCE_DIR}
-        cd build    
+        cd build
         # Make sure that vcpkg's ace .dll are on the PATH
         source /c/robotology/scripts/setup-deps.sh
         cmake --build . --config Release
@@ -434,7 +428,7 @@ jobs:
       if: contains(matrix.os, 'windows')
       shell: bash
       run: |
-        cd ${ROBOTOLOGY_SUPERBUILD_SOURCE_DIR} 
+        cd ${ROBOTOLOGY_SUPERBUILD_SOURCE_DIR}
         cd build
         # Make sure that vcpkg's ace .dll are on the PATH
         source /c/robotology/scripts/setup-deps.sh

--- a/.github/workflows/generate-conda-packages.yaml
+++ b/.github/workflows/generate-conda-packages.yaml
@@ -99,12 +99,12 @@ jobs:
         - name: Dependencies for conda recipes generation and upload
           shell: bash -l {0}
           run: |
-            mamba install pyyaml jinja2 conda-build ninja anaconda-client conda-forge-pinning mamba boa multisheller
+            conda install pyyaml jinja2 conda-build ninja anaconda-client conda-forge-pinning mamba boa multisheller
 
         - name: Print used environment
           shell: bash -l {0}
           run: |
-            mamba list
+            conda list
             env
 
         - name: Generate recipes [Linux&macOS]
@@ -163,35 +163,35 @@ jobs:
             cat */build.sh
             # We use the conda_build_config from conda-forge-pinning, and our local one
             # See https://docs.conda.io/projects/conda-build/en/latest/resources/variants.html#creating-conda-build-variant-config-files
-            # We manually specify the build order as conda build is too slow, and conda mambabuild does not support correctly multiple recipes
+            # We manually specify the build order as an old workaround for mambabuild, in theory this can be avoided, but it needs to be tested
             # see https://github.com/mamba-org/boa/issues/117
             # We also manually delete the recipe directory to avoid that it is built again,
             # specifically because we can't use --skip-existing as these packages are part of the robotology channel
-            conda mambabuild -m ${CONDA_PREFIX}/conda_build_config.yaml -m ${GITHUB_WORKSPACE}/conda/conda_build_config.yml icub-contrib-common
+            conda build -m ${CONDA_PREFIX}/conda_build_config.yaml -m ${GITHUB_WORKSPACE}/conda/conda_build_config.yml icub-contrib-common
             rm -rf icub-contrib-common
-            conda mambabuild -m ${CONDA_PREFIX}/conda_build_config.yaml -m ${GITHUB_WORKSPACE}/conda/conda_build_config.yml icub-firmware-shared
+            conda build -m ${CONDA_PREFIX}/conda_build_config.yaml -m ${GITHUB_WORKSPACE}/conda/conda_build_config.yml icub-firmware-shared
             rm -rf icub-firmware-shared
-            conda mambabuild -m ${CONDA_PREFIX}/conda_build_config.yaml -m ${GITHUB_WORKSPACE}/conda/conda_build_config.yml robots-configuration
+            conda build -m ${CONDA_PREFIX}/conda_build_config.yaml -m ${GITHUB_WORKSPACE}/conda/conda_build_config.yml robots-configuration
             rm -rf robots-configuration
             # icub-main needs robotology channel as it also depends on esdcan, and local to avoid that robotology packages are used instead of local built one
-            conda mambabuild -m ${CONDA_PREFIX}/conda_build_config.yaml -m ${GITHUB_WORKSPACE}/conda/conda_build_config.yml -c local -c conda-forge -c robotology icub-main
+            conda build -m ${CONDA_PREFIX}/conda_build_config.yaml -m ${GITHUB_WORKSPACE}/conda/conda_build_config.yml -c local -c conda-forge -c robotology icub-main
             rm -rf icub-main
-            conda mambabuild -m ${CONDA_PREFIX}/conda_build_config.yaml -m ${GITHUB_WORKSPACE}/conda/conda_build_config.yml wearables
+            conda build -m ${CONDA_PREFIX}/conda_build_config.yaml -m ${GITHUB_WORKSPACE}/conda/conda_build_config.yml wearables
             rm -rf wearables
             # Channels specified explicitly due to https://github.com/robotology/robotology-superbuild/issues/1140
-            conda mambabuild -m ${CONDA_PREFIX}/conda_build_config.yaml -m ${GITHUB_WORKSPACE}/conda/conda_build_config.yml -c local -c conda-forge human-dynamics-estimation
+            conda build -m ${CONDA_PREFIX}/conda_build_config.yaml -m ${GITHUB_WORKSPACE}/conda/conda_build_config.yml -c local -c conda-forge human-dynamics-estimation
             rm -rf human-dynamics-estimation
-            conda mambabuild -m ${CONDA_PREFIX}/conda_build_config.yaml -m ${GITHUB_WORKSPACE}/conda/conda_build_config.yml robot-log-visualizer
+            conda build -m ${CONDA_PREFIX}/conda_build_config.yaml -m ${GITHUB_WORKSPACE}/conda/conda_build_config.yml robot-log-visualizer
             rm -rf robot-log-visualizer
-            conda mambabuild -m ${CONDA_PREFIX}/conda_build_config.yaml -m ${GITHUB_WORKSPACE}/conda/conda_build_config.yml idyntree-matlab-bindings
+            conda build -m ${CONDA_PREFIX}/conda_build_config.yaml -m ${GITHUB_WORKSPACE}/conda/conda_build_config.yml idyntree-matlab-bindings
             rm -rf idyntree-matlab-bindings
-            conda mambabuild -m ${CONDA_PREFIX}/conda_build_config.yaml -m ${GITHUB_WORKSPACE}/conda/conda_build_config.yml blockfactory
+            conda build -m ${CONDA_PREFIX}/conda_build_config.yaml -m ${GITHUB_WORKSPACE}/conda/conda_build_config.yml blockfactory
             rm -rf blockfactory
-            conda mambabuild -m ${CONDA_PREFIX}/conda_build_config.yaml -m ${GITHUB_WORKSPACE}/conda/conda_build_config.yml yarp-matlab-bindings
+            conda build -m ${CONDA_PREFIX}/conda_build_config.yaml -m ${GITHUB_WORKSPACE}/conda/conda_build_config.yml yarp-matlab-bindings
             rm -rf yarp-matlab-bindings
-            conda mambabuild -m ${CONDA_PREFIX}/conda_build_config.yaml -m ${GITHUB_WORKSPACE}/conda/conda_build_config.yml wb-toolbox
+            conda build -m ${CONDA_PREFIX}/conda_build_config.yaml -m ${GITHUB_WORKSPACE}/conda/conda_build_config.yml wb-toolbox
             rm -rf wb-toolbox
-            conda mambabuild -m ${CONDA_PREFIX}/conda_build_config.yaml -m ${GITHUB_WORKSPACE}/conda/conda_build_config.yml blocktest
+            conda build -m ${CONDA_PREFIX}/conda_build_config.yaml -m ${GITHUB_WORKSPACE}/conda/conda_build_config.yml blocktest
             rm -rf blocktest
             conda build -m ${CONDA_PREFIX}/conda_build_config.yaml -m ${GITHUB_WORKSPACE}/conda/conda_build_config.yml .
 
@@ -202,8 +202,8 @@ jobs:
             cd build/conda/generated_recipes_metapackages
              # Debug generated recipes
             cat */meta.yaml
-            conda mambabuild -m ${CONDA_PREFIX}/conda_build_config.yaml -m ${GITHUB_WORKSPACE}/conda/conda_build_config.yml -c local -c conda-forge -c robotology robotology-distro
-            conda mambabuild -m ${CONDA_PREFIX}/conda_build_config.yaml -m ${GITHUB_WORKSPACE}/conda/conda_build_config.yml -c local -c conda-forge -c robotology robotology-distro-all
+            conda build -m ${CONDA_PREFIX}/conda_build_config.yaml -m ${GITHUB_WORKSPACE}/conda/conda_build_config.yml -c local -c conda-forge -c robotology robotology-distro
+            conda build -m ${CONDA_PREFIX}/conda_build_config.yaml -m ${GITHUB_WORKSPACE}/conda/conda_build_config.yml -c local -c conda-forge -c robotology robotology-distro-all
 
         - name: Upload conda packages
           shell: bash -l {0}

--- a/.github/workflows/generate-conda-packages.yaml
+++ b/.github/workflows/generate-conda-packages.yaml
@@ -167,33 +167,33 @@ jobs:
             # see https://github.com/mamba-org/boa/issues/117
             # We also manually delete the recipe directory to avoid that it is built again,
             # specifically because we can't use --skip-existing as these packages are part of the robotology channel
-            conda build -m ${CONDA_PREFIX}/conda_build_config.yaml -m ${GITHUB_WORKSPACE}/conda/conda_build_config.yml icub-contrib-common
+            conda mambabuild -m ${CONDA_PREFIX}/conda_build_config.yaml -m ${GITHUB_WORKSPACE}/conda/conda_build_config.yml icub-contrib-common
             rm -rf icub-contrib-common
-            conda build -m ${CONDA_PREFIX}/conda_build_config.yaml -m ${GITHUB_WORKSPACE}/conda/conda_build_config.yml icub-firmware-shared
+            conda mambabuild -m ${CONDA_PREFIX}/conda_build_config.yaml -m ${GITHUB_WORKSPACE}/conda/conda_build_config.yml icub-firmware-shared
             rm -rf icub-firmware-shared
-            conda build -m ${CONDA_PREFIX}/conda_build_config.yaml -m ${GITHUB_WORKSPACE}/conda/conda_build_config.yml robots-configuration
+            conda mambabuild -m ${CONDA_PREFIX}/conda_build_config.yaml -m ${GITHUB_WORKSPACE}/conda/conda_build_config.yml robots-configuration
             rm -rf robots-configuration
             # icub-main needs robotology channel as it also depends on esdcan, and local to avoid that robotology packages are used instead of local built one
-            conda build -m ${CONDA_PREFIX}/conda_build_config.yaml -m ${GITHUB_WORKSPACE}/conda/conda_build_config.yml -c local -c conda-forge -c robotology icub-main
+            conda mambabuild -m ${CONDA_PREFIX}/conda_build_config.yaml -m ${GITHUB_WORKSPACE}/conda/conda_build_config.yml -c local -c conda-forge -c robotology icub-main
             rm -rf icub-main
-            conda build -m ${CONDA_PREFIX}/conda_build_config.yaml -m ${GITHUB_WORKSPACE}/conda/conda_build_config.yml wearables
+            conda mambabuild -m ${CONDA_PREFIX}/conda_build_config.yaml -m ${GITHUB_WORKSPACE}/conda/conda_build_config.yml wearables
             rm -rf wearables
             # Channels specified explicitly due to https://github.com/robotology/robotology-superbuild/issues/1140
-            conda build -m ${CONDA_PREFIX}/conda_build_config.yaml -m ${GITHUB_WORKSPACE}/conda/conda_build_config.yml -c local -c conda-forge human-dynamics-estimation
+            conda mambabuild -m ${CONDA_PREFIX}/conda_build_config.yaml -m ${GITHUB_WORKSPACE}/conda/conda_build_config.yml -c local -c conda-forge human-dynamics-estimation
             rm -rf human-dynamics-estimation
-            conda build -m ${CONDA_PREFIX}/conda_build_config.yaml -m ${GITHUB_WORKSPACE}/conda/conda_build_config.yml robot-log-visualizer
+            conda mambabuild -m ${CONDA_PREFIX}/conda_build_config.yaml -m ${GITHUB_WORKSPACE}/conda/conda_build_config.yml robot-log-visualizer
             rm -rf robot-log-visualizer
-            conda build -m ${CONDA_PREFIX}/conda_build_config.yaml -m ${GITHUB_WORKSPACE}/conda/conda_build_config.yml idyntree-matlab-bindings
+            conda mambabuild -m ${CONDA_PREFIX}/conda_build_config.yaml -m ${GITHUB_WORKSPACE}/conda/conda_build_config.yml idyntree-matlab-bindings
             rm -rf idyntree-matlab-bindings
-            conda build -m ${CONDA_PREFIX}/conda_build_config.yaml -m ${GITHUB_WORKSPACE}/conda/conda_build_config.yml blockfactory
+            conda mambabuild -m ${CONDA_PREFIX}/conda_build_config.yaml -m ${GITHUB_WORKSPACE}/conda/conda_build_config.yml blockfactory
             rm -rf blockfactory
-            conda build -m ${CONDA_PREFIX}/conda_build_config.yaml -m ${GITHUB_WORKSPACE}/conda/conda_build_config.yml yarp-matlab-bindings
+            conda mambabuild -m ${CONDA_PREFIX}/conda_build_config.yaml -m ${GITHUB_WORKSPACE}/conda/conda_build_config.yml yarp-matlab-bindings
             rm -rf yarp-matlab-bindings
-            conda build -m ${CONDA_PREFIX}/conda_build_config.yaml -m ${GITHUB_WORKSPACE}/conda/conda_build_config.yml wb-toolbox
+            conda mambabuild -m ${CONDA_PREFIX}/conda_build_config.yaml -m ${GITHUB_WORKSPACE}/conda/conda_build_config.yml wb-toolbox
             rm -rf wb-toolbox
-            conda build -m ${CONDA_PREFIX}/conda_build_config.yaml -m ${GITHUB_WORKSPACE}/conda/conda_build_config.yml blocktest
+            conda mambabuild -m ${CONDA_PREFIX}/conda_build_config.yaml -m ${GITHUB_WORKSPACE}/conda/conda_build_config.yml blocktest
             rm -rf blocktest
-            conda build -m ${CONDA_PREFIX}/conda_build_config.yaml -m ${GITHUB_WORKSPACE}/conda/conda_build_config.yml .
+            conda mambabuild -m ${CONDA_PREFIX}/conda_build_config.yaml -m ${GITHUB_WORKSPACE}/conda/conda_build_config.yml .
 
         - name: Build conda metapackages (if necessary)
           if: github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && github.event.inputs.test_metapackages_generation == 'true')
@@ -202,8 +202,8 @@ jobs:
             cd build/conda/generated_recipes_metapackages
              # Debug generated recipes
             cat */meta.yaml
-            conda build -m ${CONDA_PREFIX}/conda_build_config.yaml -m ${GITHUB_WORKSPACE}/conda/conda_build_config.yml -c local -c conda-forge -c robotology robotology-distro
-            conda build -m ${CONDA_PREFIX}/conda_build_config.yaml -m ${GITHUB_WORKSPACE}/conda/conda_build_config.yml -c local -c conda-forge -c robotology robotology-distro-all
+            conda mambabuild -m ${CONDA_PREFIX}/conda_build_config.yaml -m ${GITHUB_WORKSPACE}/conda/conda_build_config.yml -c local -c conda-forge -c robotology robotology-distro
+            conda mambabuild -m ${CONDA_PREFIX}/conda_build_config.yaml -m ${GITHUB_WORKSPACE}/conda/conda_build_config.yml -c local -c conda-forge -c robotology robotology-distro-all
 
         - name: Upload conda packages
           shell: bash -l {0}

--- a/.github/workflows/generate-conda-packages.yaml
+++ b/.github/workflows/generate-conda-packages.yaml
@@ -63,9 +63,9 @@ jobs:
         steps:
         - uses: actions/checkout@v4
 
-        - uses: conda-incubator/setup-miniconda@v2
+        - uses: conda-incubator/setup-miniconda@v3
           with:
-            miniforge-variant: Mambaforge
+            miniforge-variant: Miniforge3
             miniforge-version: latest
 
         - name: Install files to enable compilation of mex files [Conda/Linux]

--- a/doc/cmake-options.md
+++ b/doc/cmake-options.md
@@ -357,7 +357,7 @@ sudo bash ./scripts/install_apt_python_dependencies.sh
 #### Conda
 To install python and the other required dependencies when using `conda-forge` provided dependencies, use:
 ~~~
-mamba install -c conda-forge python numpy swig==4.1.0 pybind11 pyqt matplotlib h5py tornado u-msgpack-python pyzmq ipython
+conda install -c conda-forge python numpy swig==4.1.0 pybind11 pyqt matplotlib h5py tornado u-msgpack-python pyzmq ipython
 ~~~
 
 ### Check the installation
@@ -380,7 +380,7 @@ The `ROBOTOLOGY_USES_ESDCAN` option is used to enable support for interacting wi
 
 ### System Dependencies
 To compile the software enabled by the `ROBOTOLOGY_USES_ESDCAN` option (such as the `icub-main`'s [`ecan`](http://www.icub.org/software_documentation/classyarp_1_1dev_1_1EsdCan.html) YARP driver) you need to install the esd CAN C library.
-To install this library in conda, just run `mamba install -c conda-forge -c robotology esdcan` inside your conda environment. If you installed `icub-main` from conda binary packages, the `ecan` YARP driver enabled by the `ROBOTOLOGY_USES_ESDCAN` option is already included.
+To install this library in conda, just run `conda install -c conda-forge -c robotology esdcan` inside your conda environment. If you installed `icub-main` from conda binary packages, the `ecan` YARP driver enabled by the `ROBOTOLOGY_USES_ESDCAN` option is already included.
 
 To actually run the software that uses the esd CAN devices, you also need to install the esd CAN Driver for your specific esd CAN device.
 The installers for the esd CAN Driver should have been provided by esd, so ask for them to who provided you with the esd CAN device you want to use.

--- a/doc/conda-forge.md
+++ b/doc/conda-forge.md
@@ -1,8 +1,8 @@
 # conda-forge based robotology-superbuild Installation
 
-[`conda`](https://docs.conda.io/en/latest/) is a package manager (originally for Python, but effectively language agnostic) that works on Linux, macOS and Windows. 
+[`conda`](https://docs.conda.io/en/latest/) is a package manager (originally for Python, but effectively language agnostic) that works on Linux, macOS and Windows.
 
-[`conda-forge`](https://conda-forge.org/)  is a community-mantained channel for the `conda` package manager that provides many dependencies useful for scientific software, in particular all the one that are required by the robotology-superbuild . 
+[`conda-forge`](https://conda-forge.org/)  is a community-mantained channel for the `conda` package manager that provides many dependencies useful for scientific software, in particular all the one that are required by the robotology-superbuild .
 
 For an overview of advantages and disadvantages of conda and conda-forge, check the [`conda-forge-overview.md`](conda-forge-overview.md) document. If you are just interested in installing the robotology-superbuild, please proceed to the next sections.
 
@@ -12,7 +12,7 @@ For an overview of advantages and disadvantages of conda and conda-forge, check 
 
 ## Binary installation
 
-This section describes how to install the binary packages built from the `robotology-superbuild` on conda on Windows, macOS and Linux. 
+This section describes how to install the binary packages built from the `robotology-superbuild` on conda on Windows, macOS and Linux.
 
 Depending on the speficic package, the binary packages are hosted either in [`conda-forge`](https://anaconda.org/conda-forge) or [`robotology`](https://anaconda.org/robotology). Only packages that are built as part of the profiles and options that are supported on Conda (see [documentation on CMake options](cmake-options.md)) are available as conda binary packages.
 
@@ -30,67 +30,64 @@ If you need a binary package on a platform in which it is not available, feel fr
 
 ### Install a conda distribution
 
-If you do not have a conda distribution on your system, we suggest to use the minimal 
-[`mambaforge`](https://github.com/conda-forge/miniforge#mambaforge) distribution, that uses `conda-forge` packages by default and installs the [`mamba`](https://github.com/mamba-org/mamba) command by default.
+If you do not have a conda distribution on your system, we suggest to use the minimal
+[`miniforge`](https://github.com/conda-forge/miniforge) distribution, that uses `conda-forge` packages by default.
 
-To install `mambaforge`, please follow the instructions in our [`install-mambaforge`](install-mambaforge.md) documentation. 
-
-Even if you are not using `mambaforge` and you are using instead a different `conda` distribution, to follow the instructions on this document you need to install the `mamba` package in your `base` environment. [`mamba`](https://github.com/mamba-org/mamba) is a re-implementation of some functionalities of the `conda` package manager, that is much faster.
-
+To install `miniforge`, please follow the instructions in our [`install-miniforge`](install-miniforge.md) documentation.
 
 ### Create an environment
-Differently from `apt` and `homebrew`, the `conda` package manager is an `environment`-oriented package manager, meaning that packages are not 
+Differently from `apt` and `homebrew`, the `conda` package manager is an `environment`-oriented package manager, meaning that packages are not
 installed in some global location, but rather you install packages in an `environment` (that is just a directory in your filesystem), so that you
 can easily have multiple different environments with different packages installed on your system. To read more about this, check https://docs.conda.io/projects/conda/en/4.6.1/user-guide/tasks/manage-environments.html .
 
 For this reason, to use the robotology conda packages it is suggested to first create a conda environment, and then install in it all the packages you want to use. To create a new environment called `robotologyenv`, execute the following command:
 ~~~
-mamba create -n robotologyenv
+conda create -n robotologyenv
 ~~~
 
 Once you created the `robotologyenv` environment, you can "activate" it for the current terminal (i.e. make sure that the installed packages can be found) by the command:
 ~~~
-mamba activate robotologyenv
+conda activate robotologyenv
 ~~~
 
 **IMPORTANT: if you open a new terminal, you need to manually activate the environment also there.**
 
 **IMPORTANT: To avoid strange conflicts in environment variables, it is a good idea to remove from  the environment any variable that refers to libraries or software not installed with conda. For example, if you have a robotology-superbuild installed with apt dependencies, it is a good idea to remove the source of the `setup.sh` from the `.bashrc` before using conda environments, or in Windows it can make sense to check with [Rapid Environment Editor](https://www.rapidee.com) that the environment is clean.**
 
-**IMPORTANT: On Windows, it is recommended to use Command Prompt to manage conda environments, as some packages (see https://github.com/conda-forge/gazebo-feedstock/issues/42 and https://github.com/RoboStack/ros-noetic/issues/21) have problems in activating environments on Powershell.** 
+**IMPORTANT: On Windows, it is recommended to use Command Prompt to manage conda environments, as some packages (see https://github.com/conda-forge/gazebo-feedstock/issues/42 and https://github.com/RoboStack/ros-noetic/issues/21) have problems in activating environments on Powershell.**
 
 ### Install robotology packages
 
 Once you are in an activated environment, you can install robotology packages by just running the command:
 ~~~
-mamba install -c conda-forge -c robotology <packagename>
+conda install -c conda-forge -c robotology <packagename>
 ~~~
 
-The list of available packages is available at https://anaconda.org/robotology/repo . 
+The list of available packages is available at https://anaconda.org/robotology/repo .
 
 For example, if you want to install yarp and icub-main, you simple need to install:
 ~~~
-mamba install -c conda-forge -c robotology yarp icub-main
+conda install -c conda-forge -c robotology yarp icub-main
 ~~~
 
 In addition, if you want to simulate the iCub in Gazebo Classic, you should also install `icub-models` and `gazebo-yarp-plugins`:
 ~~~
-mamba install -c conda-forge -c robotology gazebo-yarp-plugins icub-models
+conda install -c conda-forge -c robotology gazebo-yarp-plugins icub-models
 ~~~
 
 While if you want to simulate it with Modern Gazebo (gz-sim), you should install `icub-models` and `gz-sim-yarp-plugins`:
 ~~~
-mamba install -c conda-forge -c robotology gz-sim-yarp-plugins icub-models
+conda install -c conda-forge -c robotology gz-sim-yarp-plugins icub-models
 ~~~
 
 If you want to develop some C++ code on the top of these libraries, it is recommended to also install the necessary compiler and development tools directly in the same environment:
 ~~~
-mamba install -c conda-forge compilers cmake pkg-config make ninja
+conda install -c conda-forge compilers cmake pkg-config make ninja
 ~~~
 
 ## Source installation
 
-This section describes how to compile and install the robotology-superbuild with conda-forge provided dependencies on Windows, macOS and Linux. 
+This section describes how to compile and install the robotology-superbuild with conda-forge provided dependencies on Windows, macOS and Linux.
 
 In particular, this instructions cover the following conda platforms:
 
@@ -102,64 +99,59 @@ In particular, this instructions cover the following conda platforms:
 
 ### Install a conda distribution
 
-If you do not have a conda distribution on your system, we suggest to use the minimal 
-[`mambaforge`](https://github.com/conda-forge/miniforge#mambaforge) distribution, that uses `conda-forge` packages by default and installs the [`mamba`](https://github.com/mamba-org/mamba) command by default.
+If you do not have a conda distribution on your system, we suggest to use the minimal
+[`miniforge`](https://github.com/conda-forge/miniforge) distribution, that uses `conda-forge` packages by default.
 
-To install `mambaforge`, please follow the instructions in our [`install-mambaforge`](install-mambaforge.md) documentation. 
-
-Even if you are not using `mambaforge` and you are using instead a different `conda` distribution, to follow the next documentation you need to install the `mamba` package in your `base` environment, and you just  need to manually specify to use the `conda-forge` packages by adding `-c conda-forge` 
-to all `mamba install` commands.
-
-[`mamba`](https://github.com/mamba-org/mamba) is a re-implementation of some functionalities of the `conda` package manager, that is much faster.
+To install `miniforge`, please follow the instructions in our [`install-miniforge`](install-miniforge.md) documentation.
 
 ### Create an environment and install dependencies
-Differently from `apt` and `homebrew`, the `conda` package manager is an `environment`-oriented package manager, meaning that packages are not 
+Differently from `apt` and `homebrew`, the `conda` package manager is an `environment`-oriented package manager, meaning that packages are not
 installed in some global location, but rather you install packages in an `environment` (that is just a directory in your filesystem), so that you
 can easily have multiple different environments with different packages installed on your system. To read more about this, check https://docs.conda.io/projects/conda/en/4.6.1/user-guide/tasks/manage-environments.html .
 
 For this reason, to compile the superbuild it is suggested to first create a conda environment, and then install in it all the dependencies
 required by the robotology-superbuild. To create a new environment called `robsub`, execute the following command:
 ~~~
-mamba create -n robsub
+conda create -n robsub
 ~~~
 
 Once you created the `robsub` environment, you can "activate" it for the current terminal (i.e. make sure that the installed packages can be found) by the command:
 ~~~
-mamba activate robsub
+conda activate robsub
 ~~~
 
-**IMPORTANT: if you open a new terminal, you need to manually activate the environment also there. If you compiled a robotology-superbuild in a given conda environment, remember to activate it before trying to compile or run any package 
+**IMPORTANT: if you open a new terminal, you need to manually activate the environment also there. If you compiled a robotology-superbuild in a given conda environment, remember to activate it before trying to compile or run any package
 of the robotology-superbuild.**
 
 **IMPORTANT: To avoid strange conflicts in environment variables, it is a good idea to remove from  the environment any variable that refers to libraries or software not installed with conda. For example, if you have a robotology-superbuild installed with apt dependencies, it is a good idea to remove the source of the `setup.sh` from the `.bashrc` before using conda environments, or in Windows it can make sense to check with [Rapid Environment Editor](https://www.rapidee.com) that the environment is clean.**
 
-**IMPORTANT: On Windows, it is recommended to use Command Prompt to manage conda environments, as some packages (see https://github.com/conda-forge/gazebo-feedstock/issues/42 and https://github.com/RoboStack/ros-noetic/issues/21) have problems in activating environments on Powershell.** 
+**IMPORTANT: On Windows, it is recommended to use Command Prompt to manage conda environments, as some packages (see https://github.com/conda-forge/gazebo-feedstock/issues/42 and https://github.com/RoboStack/ros-noetic/issues/21) have problems in activating environments on Powershell.**
 
 Once you activated it, you can install packages in it. In particular the dependencies for the robotology-superbuild can be installed as:
 
 If you are on **Linux**, **Windows**, or **macOS** with an Intel-based processor:
 ~~~
-mamba install -c conda-forge ace asio assimp boost eigen freetype glew glfw glm graphviz gsl ipopt irrlicht libjpeg-turbo libmatio libode libxml2 nlohmann_json pcl opencv portaudio qt-main sdl sdl2 sqlite tinyxml tinyxml2 spdlog lua soxr qhull cmake compilers make ninja pkg-config tomlplusplus libzlib "ffmpeg==6.*" onnxruntime-cpp
+conda install -c conda-forge ace asio assimp boost eigen freetype glew glfw glm graphviz gsl ipopt irrlicht libjpeg-turbo libmatio libode libxml2 nlohmann_json pcl opencv portaudio qt-main sdl sdl2 sqlite tinyxml tinyxml2 spdlog lua soxr qhull cmake compilers make ninja pkg-config tomlplusplus libzlib "ffmpeg==6.*" onnxruntime-cpp
 ~~~
 
 If you are on **macOS** with ARM-based processor:
 ~~~
-mamba install -c conda-forge asio assimp boost eigen freetype glew glfw glm graphviz gsl ipopt irrlicht libjpeg-turbo libmatio libode libxml2 nlohmann_json pcl opencv portaudio qt-main sdl sdl2 sqlite tinyxml tinyxml2 spdlog lua soxr qhull cmake compilers make ninja pkg-config tomlplusplus libzlib "ffmpeg==6.*" onnxruntime-cpp
+conda install -c conda-forge asio assimp boost eigen freetype glew glfw glm graphviz gsl ipopt irrlicht libjpeg-turbo libmatio libode libxml2 nlohmann_json pcl opencv portaudio qt-main sdl sdl2 sqlite tinyxml tinyxml2 spdlog lua soxr qhull cmake compilers make ninja pkg-config tomlplusplus libzlib "ffmpeg==6.*" onnxruntime-cpp
 ~~~
 
 If you are on **Linux x86-64**, you also need to install also the following packages:
 ~~~
-mamba install -c conda-forge bash-completion freeglut libdc1394 libi2c libselinux-cos7-x86_64 xorg-libxau libxcb xorg-libxdamage xorg-libxext xorg-libxfixes xorg-libxxf86vm xorg-libxrandr mesa-libgl-cos7-x86_64 mesa-libgl-devel-cos7-x86_64 libxshmfence-cos7-x86_64 libxshmfence-devel-cos7-x86_64 
+conda install -c conda-forge bash-completion freeglut libdc1394 libi2c libselinux-cos7-x86_64 xorg-libxau libxcb xorg-libxdamage xorg-libxext xorg-libxfixes xorg-libxxf86vm xorg-libxrandr mesa-libgl-cos7-x86_64 mesa-libgl-devel-cos7-x86_64 libxshmfence-cos7-x86_64 libxshmfence-devel-cos7-x86_64
 ~~~
 
 If you are on **Linux ARM 64-bit**, you also need to install also the following packages:
 ~~~
-mamba install -c conda-forge bash-completion freeglut libdc1394 libi2c libselinux-cos7-aarch64 xorg-libxau libxcb xorg-libxdamage xorg-libxext xorg-libxfixes xorg-libxxf86vm xorg-libxrandr mesa-libgl-cos7-aarch64 mesa-libgl-devel-cos7-aarch64 libxshmfence-cos7-aarch64 libxshmfence-devel-cos7-aarch64 
+conda install -c conda-forge bash-completion freeglut libdc1394 libi2c libselinux-cos7-aarch64 xorg-libxau libxcb xorg-libxdamage xorg-libxext xorg-libxfixes xorg-libxxf86vm xorg-libxrandr mesa-libgl-cos7-aarch64 mesa-libgl-devel-cos7-aarch64 libxshmfence-cos7-aarch64 libxshmfence-devel-cos7-aarch64
 ~~~
 
 If you are on **Windows**, you also need to install also the following packages:
 ~~~
-mamba install -c conda-forge freeglut
+conda install -c conda-forge freeglut
 ~~~
 
 For some [profile](doc/cmake-options.md#profile-cmake-options) or [dependency](doc/cmake-options.md#dependencies-cmake-options) specific CMake option you may need to install additional system dependencies, following the dependency-specific documentation listed in the following. If you do not want to enable an option, you should ignore the corresponding section and continue with the installation process.
@@ -168,7 +160,7 @@ For some [profile](doc/cmake-options.md#profile-cmake-options) or [dependency](d
 
 To install python and the other required dependencies when using `conda-forge` provided dependencies, use:
 ~~~
-mamba install -c conda-forge python numpy "swig==4.1.0" pybind11 pyqt matplotlib h5py tornado u-msgpack-python pyzmq ipython gst-plugins-good gst-plugins-bad pyqtwebengine qtpy pyyaml
+conda install -c conda-forge python numpy "swig==4.1.0" pybind11 pyqt matplotlib h5py tornado u-msgpack-python pyzmq ipython gst-plugins-good gst-plugins-bad pyqtwebengine qtpy pyyaml
 ~~~
 
 #### `ROBOTOLOGY_USES_PCL_AND_VTK`
@@ -176,7 +168,7 @@ mamba install -c conda-forge python numpy "swig==4.1.0" pybind11 pyqt matplotlib
 If you install your dependencies with `conda`, just make sure to install the `pcl` and `vtk` packages:
 
 ~~~
-mamba install -c conda-forge pcl vtk
+conda install -c conda-forge pcl vtk
 ~~~
 
 #### `ROBOTOLOGY_USES_GAZEBO`
@@ -184,7 +176,7 @@ mamba install -c conda-forge pcl vtk
 If you install your dependencies with `conda`, just make sure to install the `gazebo` package:
 
 ~~~
-mamba install -c conda-forge gazebo
+conda install -c conda-forge gazebo
 ~~~
 
 #### `ROBOTOLOGY_USES_GZ_SIM`
@@ -192,11 +184,11 @@ mamba install -c conda-forge gazebo
 If you install your dependencies with `conda`, just make sure to install the `gz-sim8` package:
 
 ~~~
-mamba install -c conda-forge gz-sim8
+conda install -c conda-forge gz-sim8
 ~~~
 
 ### Clone the repo
-To compile the `robotology-superbuild` code itself, you need to clone it, following the instructions in https://github.com/robotology/robotology-superbuild#clone-the-repo . 
+To compile the `robotology-superbuild` code itself, you need to clone it, following the instructions in https://github.com/robotology/robotology-superbuild#clone-the-repo .
 
 ### Compile the robotology-superbuild
 In a terminal in which you activate the `robsub` environment, you can compile.
@@ -208,7 +200,7 @@ cd robotology-superbuild
 mkdir build
 cd build
 cmake ..
-cmake --build . --config Release 
+cmake --build . --config Release
 ~~~
 
 On **Windows**, run:
@@ -217,7 +209,7 @@ cd robotology-superbuild
 mkdir build
 cd build
 cmake -G"Visual Studio 16 2019" ..
-cmake --build . --config Release 
+cmake --build . --config Release
 ~~~
 
 **IMPORTANT: If you use Visual Studio 2022, the fourth command needs to be changed in `cmake -G"Visual Studio 17 2022" ..`. Visual Studio 2017 or earlier are not supported.**
@@ -232,12 +224,12 @@ cmake --build . --config Release
 
 On **Linux**, **macOS** or **Windows with Git Bash**, you can at this point run the software compiled by source with the robotology-superbuild in any new terminal as:
 ~~~
-mamba activate robsub
+conda activate robsub
 source ./robotology-superbuild/build/install/share/robotology-superbuild/setup.sh
 ~~~
 
-On **Windows with cmd prompt**: 
+On **Windows with cmd prompt**:
 ~~~
-mamba activate robsub
+conda activate robsub
 call ./robotology-superbuild/build/install/share/robotology-superbuild/setup.bat
 ~~~

--- a/doc/conda-powershell-troubleshooting.md
+++ b/doc/conda-powershell-troubleshooting.md
@@ -1,12 +1,8 @@
 # Conda Powershell Troubleshooting
 
-For most of the `conda` related documentation in the `robotology-superbuild`, it is assume that the command-line interpreter to use on Windows is the [Command Prompt](https://en.wikipedia.org/wiki/Cmd.exe). 
+For most of the `conda` related documentation in the `robotology-superbuild`, it is assume that the command-line interpreter to use on Windows is the [Command Prompt](https://en.wikipedia.org/wiki/Cmd.exe).
 
 While Powershell may work in some situations, powershell users may encounter the problems listed in the following. See https://github.com/robotology/robotology-superbuild/issues/890 for the reference issue on supporting Powershell in conda docs.
-
-## PowerShell and mamba init
-
-If you want to use `mamba`, note that it is not sufficient to run `mamba init` in PowerShell, as this is not supported: https://github.com/mamba-org/mamba/issues/1088 .
 
 ## PowerShell profiles and ExecutionPolicy problems
 If you use PowerShell, note that the `conda init` commands works by creating a [PowerShell profile script](https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_profiles). On new Windows machines, the default [Execution Policies](https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_execution_policies) for PowerShell is quite restrictive, and so [it does not permit to profiles to run](https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_profiles?view=powershell-7.1#profiles-and-execution-policy). If that it is the case for you, after you run `conda init` you may get a "<ProfileFilePath> cannot be loaded because running scripts is disabled on this system." error whenever you launch PowerShell. To fix this problem, you can just open an Windows Powershell with "Run as administrator", and set the execution policy of your system to allow running profile scripts:

--- a/doc/faqs.md
+++ b/doc/faqs.md
@@ -63,7 +63,7 @@ OMP: Hint This means that multiple copies of the OpenMP runtime have been linked
 ~~~
 when running MATLAB libraries installed by the robotology-superbuild, a simple workaround is to install the netlib version of libblas via:
 ~~~
-mamba install libblas=*=*netlib
+conda install libblas=*=*netlib
 ~~~
 
 See https://github.com/robotology/idyntree/issues/1109 for more details.

--- a/doc/install-miniforge.md
+++ b/doc/install-miniforge.md
@@ -15,7 +15,7 @@ For more information on conda and its use with the robotology-superbuild, please
 First of all, download the installer and install it in its default location:
 ~~~
 # Download
-curl -LO https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-Linux-x86_64.sh
+curl -LO https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-$(uname)-$(uname -m).sh
 # Install with default options
 sh ./Miniforge3-Linux-x86_64.sh -b
 ~~~
@@ -85,7 +85,7 @@ This will install miniforge in `~/miniforge3` .
 
 To use the `conda` command, you need to add the `~/miniforge3/condabin` directory to the [`PATH` environment variable](https://en.wikipedia.org/wiki/PATH_(variable)). 
 
-You can do this persistently by modifying the appropriate file via the command: 
+You can do this persistently by writing the following commands on the terminal:
 ~~~
 ~/miniforge3/condabin/conda init
 ~~~
@@ -135,13 +135,15 @@ rm -rf ~/.condarc
 
 ## Windows
 
+**For all the following instructions, we strongly suggest to use Command Prompt as shell on Windows. If you want to use Powershell, not all the mentioned feature may work, see [conda-powershell-troubleshooting documentation page](conda-powershell-troubleshooting.md) for more info.**
+
 First of all, download the installer from https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-Windows-x86_64.exe and install it by double clicking on it.
 
 If you already have a Python that you use in your system, make sure that you deselect the "Register Miniforge3 Python as my default Python" during the installation.
 
 After the installation has been completed, Miniforge should have been installed in `%HOMEDRIVE%%HOMEPATH%\AppData\Local\miniforge3`. 
 
-If you explicitly selected the for All Users install, Miniforge will be installed in `%ProgramData%\miniforge3`, in that case substitute `%HOMEDRIVE%%HOMEPATH%\AppData\Local\miniforge3` with `%ProgramData%\miniforge3` in the rest of the documentation.
+If you explicitly selected the for All Users install, Miniforge will be installed in `%ProgramData%\miniforge3`, in that case substitute `%HOMEDRIVE%%HOMEPATH%\AppData\Local\miniforge3` with `%ProgramData%\miniforge3` in the rest of the documentation. In this case you should also have admin rights (or run the console as administrator) otherwise you will get an error ("ERROR during elevated execution").
 
 To ensure that the `conda` binary can be used in your terminal, open a Command Prompt and run:
 ~~~
@@ -176,3 +178,8 @@ First of all, open a command prompt and run:
 Then go to "Add or remove programs", search for Miniforge3 and uninstall it.
 
 After that, delete the `%HOMEDRIVE%%HOMEPATH%/.conda` directory and the `%HOMEDRIVE%%HOMEPATH%/.condarc` file.
+
+⚠️ On Windows, in case you forgot to follow the previous steps and now your Command Prompt is broken, you can try the following script in PowerShell as described in https://github.com/conda-forge/miniforge/issues/164#issuecomment-1092812732:  
+```
+C:\Windows\System32\reg.exe DELETE "HKCU\Software\Microsoft\Command Processor" /v AutoRun /f`
+```

--- a/scripts/install_robotology_packages.m
+++ b/scripts/install_robotology_packages.m
@@ -7,7 +7,7 @@ function install_robotology_packages(varargin)
 
     % Build package installation directory
     install_prefix = p.Results.installPrefix;
-    
+
     % If not on Windows, check if the install path contains a space as this
     % creates an installation error later (see
     % https://github.com/robotology/robotology-superbuild/issues/780)
@@ -31,14 +31,14 @@ function install_robotology_packages(varargin)
     fprintf('Installing robotology MATLAB/Simulink binaries in %s\n', install_prefix);
 
     % The install url is created following
-    mambaforge_url_prefix = 'https://github.com/conda-forge/miniforge/releases/latest/download/';
+    miniforge_url_prefix = 'https://github.com/conda-forge/miniforge/releases/latest/download/';
     if ispc
-        mambaforge_installer_name = 'Mambaforge-Windows-x86_64.exe';
+        miniforge_installer_name = 'miniforge-Windows-x86_64.exe';
     elseif ismac
         [~, uname_m] = system('uname -m');
         % Remove newline
         uname_m = strip(uname_m);
-        mambaforge_installer_name = sprintf('Mambaforge-MacOSX-%s.sh', uname_m);
+        miniforge_installer_name = sprintf('miniforge-MacOSX-%s.sh', uname_m);
     elseif isunix
         [~, uname] = system('uname');
         % Remove newline
@@ -46,29 +46,29 @@ function install_robotology_packages(varargin)
         [~, uname_m] = system('uname -m');
         % Remove newline
         uname_m = strip(uname_m);
-        mambaforge_installer_name = sprintf('Mambaforge-%s-%s.sh', uname, uname_m);
+        miniforge_installer_name = sprintf('miniforge-%s-%s.sh', uname, uname_m);
     end
 
-    fprintf('Downloading mambaforge installer \n');
-    mambaforge_installer_url = strcat(mambaforge_url_prefix, mambaforge_installer_name);
-    websave(mambaforge_installer_name, mambaforge_installer_url);
-    fprintf('Download of mambaforge installer completed\n');
+    fprintf('Downloading miniforge installer \n');
+    miniforge_installer_url = strcat(miniforge_url_prefix, miniforge_installer_name);
+    websave(miniforge_installer_name, miniforge_installer_url);
+    fprintf('Download of miniforge installer completed\n');
 
     % See https://github.com/conda-forge/miniforge#non-interactive-install
-    fprintf('Installing mambaforge\n');
+    fprintf('Installing miniforge\n');
     if ispc
-        system(sprintf('start /wait "" %s /InstallationType=JustMe /RegisterPython=0 /S /D=%s', mambaforge_installer_name, install_prefix));
-        conda_full_path = fullfile(install_prefix, 'condabin', 'mamba.bat');
+        system(sprintf('start /wait "" %s /InstallationType=JustMe /RegisterPython=0 /S /D=%s', miniforge_installer_name, install_prefix));
+        conda_full_path = fullfile(install_prefix, 'condabin', 'conda.bat');
         % On Windows, the files in conda are installed in the Library
         % subdirectory of the prefix
         robotology_install_prefix = fullfile(install_prefix, 'Library');
     elseif isunix
-        system(sprintf('sh %s -b -p "%s"', mambaforge_installer_name, install_prefix));
-        assert(length(['#!',install_prefix,'/bin python'])<=127,'install_prefix path is too long! Shebangs cannot be longer than 127 characters (see https://github.com/robotology/robotology-superbuild/pull/1145)')        
-        conda_full_path = fullfile(install_prefix, 'condabin', 'mamba');
+        system(sprintf('sh %s -b -p "%s"', miniforge_installer_name, install_prefix));
+        assert(length(['#!',install_prefix,'/bin python'])<=127,'install_prefix path is too long! Shebangs cannot be longer than 127 characters (see https://github.com/robotology/robotology-superbuild/pull/1145)')
+        conda_full_path = fullfile(install_prefix, 'condabin', 'conda');
         robotology_install_prefix = install_prefix;
     end
-    fprintf('Installation of mambaforge completed\n');
+    fprintf('Installation of miniforge completed\n');
 
 
 
@@ -120,8 +120,8 @@ function install_robotology_packages(varargin)
     fprintf(setupID, 'setenv("BLOCKFACTORY_PLUGIN_PATH",fullfile(robotology_install_prefix,rob_shlib_install_dir,"blockfactory"));\n');
     fclose(setupID);
 
-    fprintf('Deleting mambaforge installer\n');
-    delete(mambaforge_installer_name);
+    fprintf('Deleting miniforge installer\n');
+    delete(miniforge_installer_name);
 
     fprintf('robotology MATLAB and Simulink packages are successfully installed!\n');
     fprintf('Please run %s before using the packages,\n',setup_script)

--- a/scripts/install_robotology_packages.m
+++ b/scripts/install_robotology_packages.m
@@ -33,12 +33,12 @@ function install_robotology_packages(varargin)
     % The install url is created following
     miniforge_url_prefix = 'https://github.com/conda-forge/miniforge/releases/latest/download/';
     if ispc
-        miniforge_installer_name = 'miniforge-Windows-x86_64.exe';
+        miniforge_installer_name = 'Miniforge3-Windows-x86_64.exe';
     elseif ismac
         [~, uname_m] = system('uname -m');
         % Remove newline
         uname_m = strip(uname_m);
-        miniforge_installer_name = sprintf('miniforge-MacOSX-%s.sh', uname_m);
+        miniforge_installer_name = sprintf('Miniforge3-MacOSX-%s.sh', uname_m);
     elseif isunix
         [~, uname] = system('uname');
         % Remove newline
@@ -46,7 +46,7 @@ function install_robotology_packages(varargin)
         [~, uname_m] = system('uname -m');
         % Remove newline
         uname_m = strip(uname_m);
-        miniforge_installer_name = sprintf('miniforge-%s-%s.sh', uname, uname_m);
+        miniforge_installer_name = sprintf('Miniforge3-%s-%s.sh', uname, uname_m);
     end
 
     fprintf('Downloading miniforge installer \n');


### PR DESCRIPTION
Back in time when we started using conda (~2020/2021?), the conda tool was extremely slow, and that is the reason why mamba was developed, and why we suggested everyone to use mamba. Similarly, we suggested to install mambaforge as a distribution instead of miniforge3, as mambaforge contained by default. See https://github.com/robotology/robotology-superbuild/pull/847 for the related PR.


Since those days, a lot of changed. conda has  been updated to use the mamba solver, and so it has become much faster and more and less as fast as mamba . This is true that as long as you have a recent enough `conda`, to verify that check that the commands conda config --show solver returns solver: libmamba, see https://www.anaconda.com/blog/a-faster-conda-for-a-growing-community .

For this reason, several things has started to change:

* miniforge3 started installing mamba as well, so miniforge3 is the installer suggested by the conda-forge community, while mambaforge use is discouraged (see the README of https://github.com/conda-forge/miniforge for more info)
* mamba starts to have subtle bugs (such as https://github.com/mamba-org/mamba/issues/3222) with respect to  fully supported tools like pixi and conda
* users have been historically confused by the dualism between conda and mamba (and even worse micromamba, but fortunatly we never documented its use too much).

So, also in view of the conda/pixi training that I eventually need to do and to reduce the confusion of users, I have the intention to start recommending the use of conda (in place of mamba) and miniforge3 (in place of mambaforge) everywhere in our docs, and this PR is the first step in that direction.
