### PR TITLE
Pass YCM_USE_CMAKE_NEXT set to OFF in normal-build (i.e. apt with gha image and vcpkg on windows) workflow and bump YCM to v0.16.5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -379,7 +379,7 @@ jobs:
         cd ${ROBOTOLOGY_SUPERBUILD_SOURCE_DIR}
         mkdir -p build
         cd build
-        cmake -C ${ROBOTOLOGY_SUPERBUILD_SOURCE_DIR}/.ci/initial-cache.gh.cmake -G"${{ matrix.cmake_generator }}" -DYCM_EP_ADDITIONAL_CMAKE_ARGS:STRING="-DMatlab_ROOT_DIR:PATH=${GHA_Matlab_ROOT_DIR} -DMatlab_MEX_EXTENSION:STRING=${GHA_Matlab_MEX_EXTENSION}" -DROBOTOLOGY_USES_MATLAB:BOOL=ON -DYCM_BOOTSTRAP_VERBOSE=ON -DNON_INTERACTIVE_BUILD:BOOL=TRUE -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} ${{ matrix.project_tags_cmake_options }} ..
+        cmake -C ${ROBOTOLOGY_SUPERBUILD_SOURCE_DIR}/.ci/initial-cache.gh.cmake -G"${{ matrix.cmake_generator }}" -DYCM_EP_ADDITIONAL_CMAKE_ARGS:STRING="-DMatlab_ROOT_DIR:PATH=${GHA_Matlab_ROOT_DIR} -DMatlab_MEX_EXTENSION:STRING=${GHA_Matlab_MEX_EXTENSION}" -DROBOTOLOGY_USES_MATLAB:BOOL=ON -DYCM_BOOTSTRAP_VERBOSE=ON -DNON_INTERACTIVE_BUILD:BOOL=TRUE -DYCM_USE_CMAKE_NEXT:BOOL=OFF -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} ${{ matrix.project_tags_cmake_options }} ..
 
     - name: Configure [Windows]
       if: contains(matrix.os, 'windows')
@@ -393,7 +393,7 @@ jobs:
         mkdir -p build
         cd build
         # ROBOTOLOGY_ENABLE_TELEOPERATION is OFF as it is unsupported on vcpkg
-        cmake -C ${ROBOTOLOGY_SUPERBUILD_SOURCE_DIR}/.ci/initial-cache.gh.cmake -A x64 -DCMAKE_TOOLCHAIN_FILE=C:/robotology/vcpkg/scripts/buildsystems/vcpkg.cmake -DROBOTOLOGY_USES_MATLAB:BOOL=OFF -DYCM_BOOTSTRAP_VERBOSE=ON -DYCM_EP_INSTALL_DIR=C:/robotology/robotology -DNON_INTERACTIVE_BUILD:BOOL=TRUE -DCMAKE_BUILD_TYPE=Debug  ${{ matrix.project_tags_cmake_options }} ..
+        cmake -C ${ROBOTOLOGY_SUPERBUILD_SOURCE_DIR}/.ci/initial-cache.gh.cmake -A x64 -DCMAKE_TOOLCHAIN_FILE=C:/robotology/vcpkg/scripts/buildsystems/vcpkg.cmake -DROBOTOLOGY_USES_MATLAB:BOOL=OFF -DYCM_BOOTSTRAP_VERBOSE=ON -DYCM_EP_INSTALL_DIR=C:/robotology/robotology -DNON_INTERACTIVE_BUILD:BOOL=TRUE -DCMAKE_BUILD_TYPE=Debug -DYCM_USE_CMAKE_NEXT:BOOL=OFF ${{ matrix.project_tags_cmake_options }} ..
         cmake -DROBOTOLOGY_ENABLE_TELEOPERATION:BOOL=OFF .
 
     - name: Disable options unsupported on Ubuntu 20.04 and vcpkg

--- a/cmake/ProjectsTagsStable.cmake
+++ b/cmake/ProjectsTagsStable.cmake
@@ -15,7 +15,7 @@ set_tag(casadi_TAG 3.6.5.backport3724)
 set_tag(casadi-matlab-bindings_TAG v3.6.5.0)
 
 # Robotology projects
-set_tag(YCM_TAG 0d6b1a5a0f14c6334acd1d2b8ae3efceb51fe56c)
+set_tag(YCM_TAG fix50)
 set_tag(YARP_TAG yarp-3.9)
 set_tag(yarp-matlab-bindings_TAG yarp-3.9)
 set_tag(gym-ignition_TAG v1.3.1)

--- a/cmake/ProjectsTagsStable.cmake
+++ b/cmake/ProjectsTagsStable.cmake
@@ -15,7 +15,7 @@ set_tag(casadi_TAG 3.6.5.backport3724)
 set_tag(casadi-matlab-bindings_TAG v3.6.5.0)
 
 # Robotology projects
-set_tag(YCM_TAG fix50)
+set_tag(YCM_TAG master)
 set_tag(YARP_TAG yarp-3.9)
 set_tag(yarp-matlab-bindings_TAG yarp-3.9)
 set_tag(gym-ignition_TAG v1.3.1)

--- a/cmake/ProjectsTagsStable.cmake
+++ b/cmake/ProjectsTagsStable.cmake
@@ -15,7 +15,7 @@ set_tag(casadi_TAG 3.6.5.backport3724)
 set_tag(casadi-matlab-bindings_TAG v3.6.5.0)
 
 # Robotology projects
-set_tag(YCM_TAG master)
+set_tag(YCM_TAG 0d6b1a5a0f14c6334acd1d2b8ae3efceb51fe56c)
 set_tag(YARP_TAG yarp-3.9)
 set_tag(yarp-matlab-bindings_TAG yarp-3.9)
 set_tag(gym-ignition_TAG v1.3.1)

--- a/releases/latest.releases.yaml
+++ b/releases/latest.releases.yaml
@@ -26,7 +26,7 @@ repositories:
   YCM:
     type: git
     url: https://github.com/robotology/ycm.git
-    version: v0.16.4
+    version: v0.16.5
   YARP:
     type: git
     url: https://github.com/robotology/yarp.git


### PR DESCRIPTION
Historically, ycm-cmake-modules have been carrying on a patched version of CMake's ExternalProject module that made sure that it was never possible for ExternalProject to delete a source directory of a repo (the one contained in `robotology-superbuild/src/<package>`) if one had local modifications and it did not set `YCM_EP_DEVEL_MODE_<package>` to `ON` . For more details, see: 

* The part of CMake code that actually deletes a folder: https://gitlab.kitware.com/cmake/cmake/-/blob/v3.30.0/Modules/ExternalProject/shared_internal_commands.cmake?ref_type=heads#L1005-L1029).
* The long discussion of this YCM local modification: https://github.com/robotology/ycm-cmake-modules/issues/50

Unfortunately, the modification was never merged upstream, and it is not anymore possible for me to keep the forked ExternalProject version aligned with the CMake's upstream `ExternalProject`. So in this PR we set `YCM_USE_CMAKE_NEXT` to `OFF` to stop using YCM's ExternalProject module, and start using the regular CMake's ExternalProject for `apt` builds on Ubuntu 20.04 . Eventually we will propagate this change by making `YCM_USE_CMAKE_NEXT` set to `OFF` by default.

Fix https://github.com/robotology/robotology-superbuild/issues/1671 .

> [!IMPORTANT]  
> With `YCM_USE_CMAKE_NEXT` set to `ON`, the robotology-superbuild raised an error if you called `make update-all` or `ninja update-all` and there was repo with local modification with `YCM_EP_DEVEL_MODE_<package>` set to `OFF`. By setting `YCM_USE_CMAKE_NEXT` to `OFF`, instead the robotology-superbuild will discard the local modifications. To avoid losing data, **never call the `update-all` target** if you have local modifications in a package and you did not set `YCM_EP_DEVEL_MODE_<package>` to `ON` for that package.