### PR TITLE
Align option name `ROBOTOLOGY_USES_GZ`

### DIFF
--- a/doc/cmake-options.md
+++ b/doc/cmake-options.md
@@ -63,7 +63,7 @@ The dependencies CMake options specify if the packages dependending on something
 | CMake Option | Description | Default Value | Dependency-specific documentation |
 |:------------:|:-----------:|:-------------:|:---------------------------------:|
 | `ROBOTOLOGY_USES_GAZEBO`  | Include software and plugins that depend on the [Gazebo Classic simulator](https://classic.gazebosim.org/).  | `ON` | [Documentation on Gazebo Classic dependency.](#gazebo-classic-simulator) |
-| `ROBOTOLOGY_USES_GZ_SIM`  | Include software and plugins that depend on the [Modern Gazebo (gz-sim) simulator](http://gazebosim.org/). | `OFF` | [Documentation on Modern Gazebo (gz-sim) dependency.](#modern-gazebo-simulator) |
+| `ROBOTOLOGY_USES_GZ`  | Include software and plugins that depend on the [Modern Gazebo (gz-sim) simulator](http://gazebosim.org/). | `OFF` | [Documentation on Modern Gazebo (gz-sim) dependency.](#modern-gazebo-simulator) |
 | `ROBOTOLOGY_USES_MUJOCO`  | Include software and plugins that depend on the [MuJoCo simulator](https://mujoco.org/).  | `ON` | [Documentation on MuJoCo dependency.](#mujoco) |
 | `ROBOTOLOGY_USES_PCL_AND_VTK`  | Include software and plugins that depend on the [PCL](https://pointclouds.org/) or [VTK](https://vtk.org/). | `OFF`   | [Documentation on PCL and VTK dependency.](#pcl_and_vtk) |
 | `ROBOTOLOGY_USES_IGNITION` | Include software that depends on [Ignition](ignitionrobotics.org/). | `OFF` | [Documentation on Ignition Gazebo dependency.](#ignition) |
@@ -91,7 +91,7 @@ Not all options are supported on all platforms. The following table provides a r
 | `ROBOTOLOGY_ENABLE_EVENT_DRIVEN`        | ✔️                               |             ❌              |                 ✔️                        |              ❌                           |               ❌                            |
 | `ROBOTOLOGY_ENABLE_GRASPING`            | ✔️                               |             ✔️              |                 ✔️                        |              ✔️                           |               ✔️                            |
 | `ROBOTOLOGY_USES_GAZEBO`                                            | ✔️                               |             ✔️              |                 ✔️                        |              ✔️                           |               ✔️                            |
-| `ROBOTOLOGY_USES_GZ_SIM`<sup id="a3">[3!](#f3)</sup>                                          | ✔️                               |             ❌              |                 ✔️                        |              ✔️                           |               ✔️                            |
+| `ROBOTOLOGY_USES_GZ`<sup id="a3">[3!](#f3)</sup>                                          | ✔️                               |             ❌              |                 ✔️                        |              ✔️                           |               ✔️                            |
 | `ROBOTOLOGY_USES_MUJOCO`<sup id="a1">[1!](#f1)</sup>  | ✔️                               |           ❌                |                 ✔️                        |              ✔️                           |               ✔️                            |
 | `ROBOTOLOGY_USES_PCL_AND_VTK`                                       | ✔️                               |             ✔️              |                 ✔️                        |              ✔️                           |               ✔️                            |
 | `ROBOTOLOGY_USES_IGNITION`                                          | ❌                               |             ❌              |                 ✔️                        |              ❌                           |               ❌                            |
@@ -107,7 +107,7 @@ Not all options are supported on all platforms. The following table provides a r
 
 <b id="f2">2!</b>:`ROBOTOLOGY_ENABLE_ROBOT_TESTING` does not support building with conda-forge dependencies on Apple Silicon.
 
-<b id="f3">3!</b>:`ROBOTOLOGY_USES_GZ_SIM`  with apt dependencies do not support building on Debian distros (only Ubuntu is supported). Furthermore it does not run on Windows (https://github.com/gazebosim/gz-sim/issues/2089) and have known problems on macOS (https://github.com/robotology/gz-sim-yarp-plugins/issues/90).
+<b id="f3">3!</b>:`ROBOTOLOGY_USES_GZ`  with apt dependencies do not support building on Debian distros (only Ubuntu is supported). Furthermore it does not run on Windows (https://github.com/gazebosim/gz-sim/issues/2089) and have known problems on macOS (https://github.com/robotology/gz-sim-yarp-plugins/issues/90).
 
 <b id="f4">4!</b>:`ROBOTOLOGY_USES_OCTAVE` do not support building with apt dependencies on Ubuntu 20.04.
 
@@ -208,10 +208,10 @@ Follow the steps in  https://github.com/robotology/icub-models#use-the-models-wi
 
 ## Modern Gazebo simulator
 
-Support for this dependency is enabled by the `ROBOTOLOGY_USES_GZ_SIM` CMake option, that enables the software that depends on "Modern Gazebo" (gz-sim).
+Support for this dependency is enabled by the `ROBOTOLOGY_USES_GZ` CMake option, that enables the software that depends on "Modern Gazebo" (gz-sim).
 
 > [!IMPORTANT]  
-> At the moment the `ROBOTOLOGY_USES_GZ_SIM` does not run on Windows (https://github.com/gazebosim/gz-sim/issues/2089) and have known problems on macOS (https://github.com/robotology/gz-sim-yarp-plugins/issues/90). Furthermore, it is not supported on non-Ubuntu Debian distributions with apt dependencies.
+> At the moment the `ROBOTOLOGY_USES_GZ` does not run on Windows (https://github.com/gazebosim/gz-sim/issues/2089) and have known problems on macOS (https://github.com/robotology/gz-sim-yarp-plugins/issues/90). Furthermore, it is not supported on non-Ubuntu Debian distributions with apt dependencies.
 
 
 

--- a/doc/conda-forge.md
+++ b/doc/conda-forge.md
@@ -180,7 +180,7 @@ If you install your dependencies with `conda`, just make sure to install the `ga
 conda install -c conda-forge gazebo
 ~~~
 
-#### `ROBOTOLOGY_USES_GZ_SIM`
+#### `ROBOTOLOGY_USES_GZ`
 
 If you install your dependencies with `conda`, just make sure to install the `gz-sim8` package:
 


### PR DESCRIPTION
Somewhere in the documentation the option was erroneously called `ROBOTOLOGY_USES_GZ_SIM`