### PR TITLE
Fix support for building on Windows with Ninja

### DIFF
--- a/cmake/Buildosqp.cmake
+++ b/cmake/Buildosqp.cmake
@@ -12,7 +12,7 @@ ycm_ep_helper(osqp TYPE GIT
               FOLDER src
               CMAKE_ARGS -DUNITTESTS:BOOL=OFF
                          -DOSQP_BUILD_STATIC_LIB:BOOL=OFF
-                         -DQDLDL_BUILD_STATIC_LIB:BOOL=OFF))
+                         -DQDLDL_BUILD_STATIC_LIB:BOOL=OFF)
 
 set(osqp_CONDA_PKG_NAME libosqp)
 set(osqp_CONDA_PKG_CONDA_FORGE_OVERRIDE ON)

--- a/cmake/Buildosqp.cmake
+++ b/cmake/Buildosqp.cmake
@@ -10,7 +10,14 @@ ycm_ep_helper(osqp TYPE GIT
               TAG master
               COMPONENT external
               FOLDER src
-              CMAKE_ARGS -DUNITTESTS:BOOL=OFF)
+              CMAKE_ARGS -DUNITTESTS:BOOL=OFF
+                         -DOSQP_BUILD_STATIC_LIB:BOOL=OFF
+                         -DQDLDL_BUILD_STATIC_LIB:BOOL=OFF))
 
 set(osqp_CONDA_PKG_NAME libosqp)
 set(osqp_CONDA_PKG_CONDA_FORGE_OVERRIDE ON)
+# This is a small hack. To avoid incompatibilities between the version tagged in the robotology-dependencies fork
+# (something like 0.6.3.x) and the version available in conda-forge when generating conda metapackages
+# such as robotology-distro and robotology-distro-all, we override the conda package version of manif
+# here. This needs to be removed as soon as we stop using our fork in the superbuild 
+set(osqp_CONDA_VERSION 0.6.3)

--- a/cmake/ProjectsTagsStable.cmake
+++ b/cmake/ProjectsTagsStable.cmake
@@ -5,7 +5,8 @@ macro(set_tag tag_name tag_value)
 endmacro()
 
 # External projects
-set_tag(osqp_TAG v0.6.3)
+set_tag(osqp_REPOSITORY robotology-dependencies/osqp.git)
+set_tag(osqp_TAG v0.6.3.1)
 set_tag(manif_REPOSITORY robotology-dependencies/manif.git)
 set_tag(manif_TAG 0.0.4.103)
 set_tag(qhull_TAG 2020.2)

--- a/cmake/ProjectsTagsUnstable.cmake
+++ b/cmake/ProjectsTagsUnstable.cmake
@@ -5,7 +5,8 @@ macro(set_tag tag_name tag_value)
 endmacro()
 
 # External projects
-set_tag(osqp_TAG v0.6.3)
+set_tag(osqp_REPOSITORY robotology-dependencies/osqp.git)
+set_tag(osqp_TAG v0.6.3.1)
 set_tag(manif_REPOSITORY robotology-dependencies/manif.git)
 set_tag(manif_TAG 0.0.4.103)
 set_tag(qhull_TAG 2020.2)

--- a/releases/latest.releases.yaml
+++ b/releases/latest.releases.yaml
@@ -5,8 +5,8 @@ repositories:
     version: v3.2.0.1
   osqp:
     type: git
-    url: https://github.com/oxfordcontrol/osqp.git
-    version: v0.6.3
+    url: https://github.com/robotology-dependencies/osqp.git
+    version: v0.6.3.1
   manif:
     type: git
     url: https://github.com/robotology-dependencies/manif.git


### PR DESCRIPTION
Fix https://github.com/robotology/robotology-superbuild/issues/1083 .

To do so, it was necessary to fix support for building shared libraries and disabling static libraries in osqp 0.6.3, this was already done since a lot of time in osqp master, but as long as we do not get a release of osqp, we continue to use osqp 0.6.3 . The related commits are:
* https://github.com/robotology-dependencies/osqp/commit/060751ffcca0d0f2b800baf09b2e067310d9ddb2
* https://github.com/robotology-dependencies/qdldl/commit/3770026c0546216df29c0ea37102df20d33f2ba5