### PR TITLE
Remove CI badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,10 +8,6 @@ A [YCM Superbuild](http://robotology.github.io/ycm/gh-pages/git-master/index.htm
 If you are familiar with ROS, it is something similar to [catkin](http://wiki.ros.org/catkin/workspaces) or [colcon workspace](https://colcon.readthedocs.io/en/released/user/quick-start.html), but using pure CMake for portability reasons and for customizing the build via CMake options. Furthermore, the `robotology-superbuild` also contains some infrastructure to build **binaries** of the contained projects for some platforms. 
 You can read more about the superbuild concept in [YCM documentation](http://robotology.github.io/ycm/gh-pages/latest/index.html) or in the [related IRC paper](http://lornat75.github.io/papers/2018/domenichelli-irc.pdf).
 
-| System  | Continuous Integration Status |
-|:------:|:------:|
-|  Linux/macOS/Windows  |  ![GitHub Actions Status](https://github.com/robotology/robotology-superbuild/workflows/C++%20CI%20Workflow/badge.svg)     |
-
 Table of Contents
 =================
   * [Superbuild](#superbuild)


### PR DESCRIPTION
It was always red even if the CI was green, and to be honest it is not 2014 anymore, I do not think that CI badges are so fashionable nowadays.