### PR TITLE
Pin YCM to v0.16.6 to workaround YCM regression

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,6 +48,10 @@ endif()
 set(YCM_FOLDER src)
 set(YCM_COMPONENT core)
 set(YCM_MINIMUM_VERSION 0.14.0)
+# Quick workaround for https://github.com/robotology/robotology-superbuild/issues/1690
+if(NOT ${YCM_TAG})
+  set(YCM_TAG v0.16.6)
+endif()
 option(YCM_USE_CMAKE_NEXT "Use legacy YCM fork of ExternalProject module instead of upstream CMake ExternalProject" OFF)
 
 # Include logic for generating Conda recipes (by default it is disabled) and exit


### PR DESCRIPTION
Hotfix so for https://github.com/robotology/robotology-superbuild/issues/1690 so we can work on a proper solution without all the CI red.