### PR TITLE
Remove ipopt and libxcb pinning from conda_build_config.yml

### DIFF
--- a/.github/workflows/generate-conda-packages.yaml
+++ b/.github/workflows/generate-conda-packages.yaml
@@ -150,12 +150,18 @@ jobs:
             sed -i -e 's/set(INSTALLER_VERSION "")/set(INSTALLER_VERSION 1234.0)/g' ./packaging/windows/CMakeLists.txt
             sed -i -e 's/set(CONDA_ROBOTOLOGY_SUPERBUILD_VERSION "")/set(CONDA_ROBOTOLOGY_SUPERBUILD_VERSION 1234.0)/g' ./conda/cmake/CondaGenerationOptions.cmake
 
-        - name: Set CONDA_BLD_PATH on Windows to avoid long path issues
+        - name: Set CONDA_BLD_PATH on Windows to avoid long path issues [Windows]
           if: contains(matrix.os, 'windows')
           shell: bash -l {0}
           run: |
-            echo "CONDA_BLD_PATH=C:\bld\" >> $GITHUB_ENV
+            echo "CONDA_BLD_PATH=C:\\bld" >> $GITHUB_ENV
 
+        - name: Set CONDA_BLD_PATH on non-Windows for consistency [non Windows]
+          if: !contains(matrix.os, 'windows')
+          shell: bash -l {0}
+          run: |
+            echo "CONDA_BLD_PATH=${CONDA_PREFIX}/conda-bld" >> $GITHUB_ENV
+            
         - name: Build conda packages
           shell: bash -l {0}
           run: |
@@ -217,7 +223,7 @@ jobs:
           env:
             ANACONDA_API_TOKEN: ${{ secrets.ANACONDA_API_TOKEN }}
           run: |
-            cd ${CONDA_PREFIX}/conda-bld/${{ matrix.conda_platform}}/
+            cd ${CONDA_BLD_PATH}/${{ matrix.conda_platform}}/
             ls *.tar.bz2
             anaconda upload --skip-existing *.tar.bz2
 
@@ -229,7 +235,7 @@ jobs:
           env:
             ANACONDA_API_TOKEN: ${{ secrets.ANACONDA_API_TOKEN }}
           run: |
-            cd ${CONDA_PREFIX}/conda-bld/noarch/
+            cd ${CONDA_BLD_PATH}/noarch/
             ls *.tar.bz2
             anaconda upload --skip-existing *.tar.bz2
 

--- a/.github/workflows/generate-conda-packages.yaml
+++ b/.github/workflows/generate-conda-packages.yaml
@@ -150,6 +150,12 @@ jobs:
             sed -i -e 's/set(INSTALLER_VERSION "")/set(INSTALLER_VERSION 1234.0)/g' ./packaging/windows/CMakeLists.txt
             sed -i -e 's/set(CONDA_ROBOTOLOGY_SUPERBUILD_VERSION "")/set(CONDA_ROBOTOLOGY_SUPERBUILD_VERSION 1234.0)/g' ./conda/cmake/CondaGenerationOptions.cmake
 
+        - name: Set CONDA_BLD_PATH on Windows to avoid long path issues
+          if: contains(matrix.os, 'windows')
+          shell: bash -l {0}
+          run: |
+            echo "CONDA_BLD_PATH=C:\bld\" >> $GITHUB_ENV
+
         - name: Build conda packages
           shell: bash -l {0}
           run: |

--- a/.github/workflows/generate-conda-packages.yaml
+++ b/.github/workflows/generate-conda-packages.yaml
@@ -157,7 +157,7 @@ jobs:
             echo "CONDA_BLD_PATH=C:\\bld" >> $GITHUB_ENV
 
         - name: Set CONDA_BLD_PATH on non-Windows for consistency [non Windows]
-          if: !contains(matrix.os, 'windows')
+          if: contains(matrix.os, 'macos') || contains(matrix.os, 'ubuntu')
           shell: bash -l {0}
           run: |
             echo "CONDA_BLD_PATH=${CONDA_PREFIX}/conda-bld" >> $GITHUB_ENV

--- a/conda/conda_build_config.yml
+++ b/conda/conda_build_config.yml
@@ -8,14 +8,3 @@ qt:
 
 qt_main:
   - 5.15
-
-# Workaround for:
-# * Giulio Romualdi's problem installing icub-main with latest blf 0.18.0
-# Remove once ipopt31414 migration is completed
-ipopt:
- - 3.14.14
-
-# Workaround for:
-# libxcb 1.15 migration not completed and not pinned, see https://github.com/robotology/robotology-superbuild/pull/1606#issuecomment-1965508546
-libxcb:
- - 1.15


### PR DESCRIPTION
The pin were added (see https://github.com/robotology/robotology-superbuild/pull/1606 and https://github.com/robotology/robotology-superbuild/pull/1578) because the migrations were ongoing, but both respective migrations have been completed since a long time. 

Hopefully this should help for https://github.com/robotology/robotology-superbuild/issues/1670 .