### PR TITLE
pixi: Lower minimum linux kernel version required to 4.18

### DIFF
--- a/pixi.lock
+++ b/pixi.lock
@@ -10,8 +10,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-2_gnu.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/_sysroot_linux-64_curr_repodata_hack-3-h69a702a_16.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ace-8.0.1-he02047a_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/aiohappyeyeballs-2.3.5-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/aiohttp-3.10.3-py310h5b4e0ec_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/aiohappyeyeballs-2.4.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aiohttp-3.10.5-py310h5b4e0ec_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/aiosignal-1.3.1-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/alsa-lib-1.2.12-h4ab18f5_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ampl-mp-3.1.0-h2cc385e_1006.tar.bz2
@@ -49,7 +49,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/brotli-bin-1.1.0-hd590300_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/bullet-cpp-3.25-hcc13569_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-h4bc722e_7.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/c-ares-1.32.3-h4bc722e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/c-ares-1.33.0-ha66036c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/c-compiler-1.7.0-hd590300_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ca-certificates-2024.7.4-hbcca054_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/cached-property-1.5.2-hd8ed1ab_1.tar.bz2
@@ -102,8 +102,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/gdk-pixbuf-2.42.12-hb9ae30d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/geos-3.12.1-h59595ed_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/geotiff-1.7.1-h6b2125f_15.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/gettext-0.22.5-h59595ed_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/gettext-tools-0.22.5-h59595ed_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gettext-0.22.5-he02047a_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gettext-tools-0.22.5-he02047a_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/gfortran-12.4.0-h236703b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/gfortran_impl_linux-64-12.4.0-hc568b83_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/gfortran_linux-64-12.4.0-hd748a6a_0.conda
@@ -159,8 +159,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libabseil-20240116.2-cxx17_he02047a_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libaec-1.1.3-h59595ed_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libarchive-3.7.4-hfca40fe_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libasprintf-0.22.5-h661eb56_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libasprintf-devel-0.22.5-h661eb56_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libasprintf-0.22.5-he8f35ee_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libasprintf-devel-0.22.5-he8f35ee_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libass-0.17.1-h8fe9dca_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libblas-3.9.0-23_linux64_openblas.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libboost-1.84.0-hba137d9_3.conda
@@ -186,6 +186,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libdrm-2.4.122-h4ab18f5_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/libdrm-cos7-x86_64-2.4.97-h9b0a68f_1105.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libedit-3.1.20191231-he28a2e2_2.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libegl-1.7.0-ha4b6fd6_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libev-4.33-hd590300_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libevent-2.1.12-hf998b51_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.6.2-h59595ed_0.conda
@@ -196,14 +197,17 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcrypt-1.11.0-h4ab18f5_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgd-2.3.3-h119a65a_9.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-3.8.4-h7c88fdf_5.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgettextpo-0.22.5-h59595ed_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgettextpo-devel-0.22.5-h59595ed_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgettextpo-0.22.5-he02047a_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgettextpo-devel-0.22.5-he02047a_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-ng-14.1.0-h69a702a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran5-14.1.0-hc5f4f2c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgl-1.7.0-ha4b6fd6_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libglib-2.80.2-hf974151_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libglu-9.0.0-hac7e632_1003.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libglvnd-1.7.0-ha4b6fd6_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/libglvnd-cos7-x86_64-1.0.1-h9b0a68f_1105.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/libglvnd-glx-cos7-x86_64-1.0.1-h9b0a68f_1105.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libglx-1.7.0-ha4b6fd6_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgomp-14.1.0-h77fa898_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgoogle-cloud-2.23.0-h9be4e54_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgoogle-cloud-storage-2.23.0-hc7a4891_1.conda
@@ -312,8 +316,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/lz4-c-1.9.4-hcb278e6_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/lzo-2.10-hd590300_1001.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/make-4.3-hd18ef5c_1.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/matplotlib-3.9.1-py310hff52083_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/matplotlib-base-3.9.1-py310hf02ac8c_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/matplotlib-3.9.2-py310hff52083_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/matplotlib-base-3.9.2-py310hf02ac8c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/matplotlib-inline-0.1.7-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mesa-khr-devel-cos7-x86_64-18.3.4-h9b0a68f_1105.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/mesa-libgl-cos7-x86_64-18.3.4-h9b0a68f_1105.tar.bz2
@@ -332,14 +336,14 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.5-h59595ed_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/nettle-3.9.1-h7ab15ed_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ninja-1.12.1-h297d8ca_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/nlohmann_json-3.11.3-h59595ed_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/nlohmann_json-3.11.3-he02047a_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/nspr-4.35-h27087fc_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/nss-3.103-h593d115_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/numpy-1.26.4-py310hb13e2d6_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ocl-icd-2.3.2-hd590300_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/octomap-1.9.8-h924138e_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ogre-1.10.12.1-hb5e08f3_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/ogre-next-2.3.3-h1b25c05_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ogre-next-2.3.3-ha916a4f_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/onnxruntime-cpp-1.18.1-h0c98366_0_cpu.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/openal-soft-1.23.1-h00ab1b0_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/opencv-4.10.0-qt6_py310h681cb09_600.conda
@@ -372,9 +376,9 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pulseaudio-client-17.0-hb77b528_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pure_eval-0.2.3-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/py-opencv-4.10.0-qt6_py310h3d6a5e7_600.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/pybind11-2.13.1-py310h25c7140_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pybind11-2.13.4-py310haa687a3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pybind11-abi-4-hd8ed1ab_3.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/pybind11-global-2.13.1-py310h25c7140_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pybind11-global-2.13.4-py310haa687a3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.18.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.1.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pyqt-5.15.9-py310h04931ad_5.conda
@@ -383,9 +387,9 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pyside6-6.7.2-py310heb5a38e_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.10.14-hd12c33a_0_cpython.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/python_abi-3.10-4_cp310.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/python_abi-3.10-5_cp310.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pyyaml-6.0.2-py310h5b4e0ec_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/pyzmq-26.1.0-py310h7d2b5bf_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pyzmq-26.1.1-py310h7d2b5bf_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/qhull-2020.2-h434a139_5.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/qt-main-5.15.8-hc9dc06e_21.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/qt-webengine-5.15.8-h3e791b3_6.conda
@@ -399,7 +403,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/s2n-1.4.13-he19d79f_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/sdl-1.2.68-h293081c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/sdl2-2.30.5-hef7aa77_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-72.1.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-72.2.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/simbody-3.7-h64f3f5a_3.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/sip-6.7.12-py310hc6cd4ac_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.16.0-pyh6c4a22f_0.tar.bz2
@@ -491,8 +495,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/_openmp_mutex-4.5-2_gnu.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/_sysroot_linux-aarch64_curr_repodata_hack-4-h57d6b7b_16.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ace-8.0.1-hf9b3779_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/aiohappyeyeballs-2.3.5-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/aiohttp-3.10.3-py310hb52b2da_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/aiohappyeyeballs-2.4.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/aiohttp-3.10.5-py310hb52b2da_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/aiosignal-1.3.1-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/alsa-lib-1.2.12-h68df207_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ampl-mp-3.1.0-h05efe27_1006.tar.bz2
@@ -530,7 +534,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/brotli-bin-1.1.0-h31becfc_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/bullet-cpp-3.25-py310h10ffd4f_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/bzip2-1.0.8-h68df207_7.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/c-ares-1.32.3-h68df207_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/c-ares-1.33.0-hfcffcd1_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/c-compiler-1.7.0-h31becfc_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ca-certificates-2024.7.4-hcefe29a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/cached-property-1.5.2-hd8ed1ab_1.tar.bz2
@@ -582,8 +586,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gdk-pixbuf-2.42.12-ha61d561_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/geos-3.12.1-h2f0025b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/geotiff-1.7.1-h3e58e51_15.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gettext-0.22.5-h2f0025b_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gettext-tools-0.22.5-h2f0025b_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gettext-0.22.5-h0a1ffab_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gettext-tools-0.22.5-h0a1ffab_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gfortran-12.4.0-h7e62973_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gfortran_impl_linux-aarch64-12.4.0-h38ad816_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gfortran_linux-aarch64-12.4.0-hb03c106_0.conda
@@ -638,8 +642,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libabseil-20240116.2-cxx17_h0a1ffab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libaec-1.1.3-h2f0025b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libarchive-3.7.4-h2c0effa_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libasprintf-0.22.5-h7b6a552_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libasprintf-devel-0.22.5-h7b6a552_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libasprintf-0.22.5-h87f4aca_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libasprintf-devel-0.22.5-h87f4aca_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libass-0.17.1-h36b5d3b_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libblas-3.9.0-23_linuxaarch64_openblas.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libboost-1.84.0-hb41fec8_3.conda
@@ -664,6 +668,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libdrm-2.4.122-h68df207_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/libdrm-cos7-aarch64-2.4.97-h9b0a68f_1105.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libedit-3.1.20191231-he28a2e2_2.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libegl-1.7.0-hd24410f_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libev-4.33-h31becfc_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libevent-2.1.12-h4ba1bb4_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libexpat-2.6.2-h2f0025b_0.conda
@@ -674,14 +679,17 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgcrypt-1.11.0-h68df207_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgd-2.3.3-hcd22fd5_9.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-3.8.4-h89485ce_5.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgettextpo-0.22.5-h2f0025b_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgettextpo-devel-0.22.5-h2f0025b_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgettextpo-0.22.5-h0a1ffab_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgettextpo-devel-0.22.5-h0a1ffab_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgfortran-ng-14.1.0-he9431aa_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgfortran5-14.1.0-h9420597_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgl-1.7.0-hd24410f_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libglib-2.80.2-h34bac0b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libglu-9.0.0-hf4b6fbe_1003.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libglvnd-1.7.0-hd24410f_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/libglvnd-cos7-aarch64-1.0.1-h9b0a68f_1105.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/libglvnd-glx-cos7-aarch64-1.0.1-h9b0a68f_1105.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libglx-1.7.0-hd24410f_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgomp-14.1.0-he277a41_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgoogle-cloud-2.23.0-hd739bbb_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgoogle-cloud-storage-2.23.0-hdb39181_1.conda
@@ -787,8 +795,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/lz4-c-1.9.4-hd600fc2_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/lzo-2.10-h31becfc_1001.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/make-4.3-h309ac5b_1.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/matplotlib-3.9.1-py310hbbe02a8_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/matplotlib-base-3.9.1-py310hf9f654d_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/matplotlib-3.9.2-py310hbbe02a8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/matplotlib-base-3.9.2-py310hf9f654d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/matplotlib-inline-0.1.7-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mesa-libgl-cos7-aarch64-18.3.4-h9b0a68f_1105.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/mesa-libglapi-cos7-aarch64-18.3.4-h9b0a68f_1105.tar.bz2
@@ -805,13 +813,13 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ncurses-6.5-h0425590_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/nettle-3.9.1-h9d1147b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ninja-1.12.1-h70be974_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/nlohmann_json-3.11.3-h2f0025b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/nlohmann_json-3.11.3-h0a1ffab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/nspr-4.35-h4de3ea5_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/nss-3.103-hfe4779c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/numpy-1.26.4-py310hcbab775_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/octomap-1.9.8-hdd96247_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ogre-1.10.12.1-h70aca81_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ogre-next-2.3.3-h736244c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ogre-next-2.3.3-hdfe6764_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/onnxruntime-cpp-1.18.1-h8a69790_0_cpu.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/openal-soft-1.23.1-h2a328a1_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/opencv-4.10.0-headless_py310h7535627_1.conda
@@ -844,9 +852,9 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pulseaudio-client-17.0-h729494f_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pure_eval-0.2.3-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/py-opencv-4.10.0-headless_py310h8f60461_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pybind11-2.13.1-py310h6cd5c4a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pybind11-2.13.4-py310h6cd5c4a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pybind11-abi-4-hd8ed1ab_3.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pybind11-global-2.13.1-py310h6cd5c4a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pybind11-global-2.13.4-py310h6cd5c4a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.18.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.1.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pyqt-5.15.9-py310h948ff9b_5.conda
@@ -855,9 +863,9 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pyside6-6.7.2-py310h5a2e0b3_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/python-3.10.14-hbbe8eec_0_cpython.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/python_abi-3.10-4_cp310.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/python_abi-3.10-5_cp310.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pyyaml-6.0.2-py310hb52b2da_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pyzmq-26.1.0-py310he875deb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pyzmq-26.1.1-py310he875deb_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/qhull-2020.2-h70be974_5.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/qt-main-5.15.8-ha53cfd4_21.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/qt-webengine-5.15.8-hdddff8d_6.conda
@@ -871,7 +879,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/s2n-1.4.13-h52a6840_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/sdl-1.2.68-h32cd00b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/sdl2-2.30.5-h484386f_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-72.1.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-72.2.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/simbody-3.7-h43d9ae1_3.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/sip-6.8.3-py310h0d1d2ea_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.16.0-pyh6c4a22f_0.tar.bz2
@@ -961,8 +969,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/zziplib-0.13.69-h650d8d0_2.conda
       osx-64:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/ace-8.0.1-hf036a51_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/aiohappyeyeballs-2.3.5-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/aiohttp-3.10.3-py311h72ae277_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/aiohappyeyeballs-2.4.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/aiohttp-3.10.5-py311h72ae277_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/aiosignal-1.3.1-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/osx-64/ampl-mp-3.1.0-h2beb688_1006.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/osx-64/aom-3.9.1-hf036a51_0.conda
@@ -993,7 +1001,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/brotli-bin-1.1.0-h0dc2134_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/bullet-cpp-3.25-h7be5568_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/bzip2-1.0.8-hfdf4475_7.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/c-ares-1.32.3-h51dda26_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/c-ares-1.33.0-h51dda26_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/c-compiler-1.7.0-h282daa2_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/ca-certificates-2024.7.4-h8857fd0_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/cached-property-1.5.2-hd8ed1ab_1.tar.bz2
@@ -1051,8 +1059,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/gdk-pixbuf-2.42.12-ha587570_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/geos-3.12.1-h93d8f39_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/geotiff-1.7.1-h509af15_15.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/gettext-0.22.5-h5ff76d1_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/gettext-tools-0.22.5-h5ff76d1_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/gettext-0.22.5-hdfe23c8_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/gettext-tools-0.22.5-hdfe23c8_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/gfortran-12.3.0-h2c809b3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/gfortran_impl_osx-64-12.3.0-hc328e78_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/gfortran_osx-64-12.3.0-h18f7dce_1.conda
@@ -1086,7 +1094,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/imath-3.1.11-h2d185b6_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/ipopt-3.14.16-h8b46a37_4.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ipython-8.26.0-pyh707e725_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/irrlicht-1.8.5-h5bfa9a0_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/irrlicht-1.8.5-hc01355b_5.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/isl-0.26-imath32_h2e86a7b_101.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/jasper-4.2.4-hb10263b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jedi-0.19.1-pyhd8ed1ab_0.conda
@@ -1104,8 +1112,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libabseil-20240116.2-cxx17_hf036a51_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libaec-1.1.3-h73e2aa4_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libarchive-3.7.4-h20e244c_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libasprintf-0.22.5-h5ff76d1_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libasprintf-devel-0.22.5-h5ff76d1_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libasprintf-0.22.5-hdfe23c8_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libasprintf-devel-0.22.5-hdfe23c8_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libass-0.17.1-h80904bb_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libblas-3.9.0-22_osx64_openblas.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libboost-1.84.0-h739af76_3.conda
@@ -1123,7 +1131,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libclang13-18.1.8-default_h9ff962c_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libcrc32c-1.1.2-he49afe7_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libcurl-8.9.1-hfcf2730_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libcxx-18.1.8-heced48a_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libcxx-18.1.8-heced48a_4.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libdeflate-1.20-h49d49c5_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libedit-3.1.20191231-h0678c8f_2.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libev-4.33-h10d778d_2.conda
@@ -1132,8 +1140,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libflac-1.4.3-he965462_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libgd-2.3.3-h0dceb68_9.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-3.8.4-h2239303_5.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgettextpo-0.22.5-h5ff76d1_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgettextpo-devel-0.22.5-h5ff76d1_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgettextpo-0.22.5-hdfe23c8_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgettextpo-devel-0.22.5-hdfe23c8_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libgfortran-5.0.0-13_2_0_h97931a8_3.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/libgfortran-devel_osx-64-12.3.0-h0b6f5ec_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libgfortran5-13.2.0-h2873a65_3.conda
@@ -1165,8 +1173,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libignition-msgs5-5.11.0-h2de7f5f_9.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libignition-tools1-1.5.0-h4425e3a_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libignition-transport8-8.4.0-h339ba34_11.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libintl-0.22.5-h5ff76d1_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libintl-devel-0.22.5-h5ff76d1_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libintl-0.22.5-hdfe23c8_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libintl-devel-0.22.5-hdfe23c8_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libjpeg-turbo-3.0.0-h0dc2134_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libkml-1.3.0-hfcbc525_1020.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/liblapack-3.9.0-22_osx64_openblas.conda
@@ -1225,15 +1233,15 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libxml2-2.12.7-hc603aa4_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libzip-1.10.1-hc158999_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libzlib-1.3.1-h87427d6_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/llvm-openmp-18.1.8-h15ab845_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/llvm-openmp-18.1.8-h15ab845_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/llvm-tools-16.0.6-hbedff68_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/loguru-0.7.2-py311h6eed73b_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/lua-5.4.6-hf600f6b_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/lz4-c-1.9.4-hf0c8a7f_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/lzo-2.10-h10d778d_1001.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/make-4.3-h22f3db7_1.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/matplotlib-3.9.1-py311h6eed73b_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/matplotlib-base-3.9.1-py311hf31e254_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/matplotlib-3.9.2-py311h6eed73b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/matplotlib-base-3.9.2-py311hf31e254_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/matplotlib-inline-0.1.7-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/metis-5.1.0-he965462_1007.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/minizip-4.0.7-h62b0c8d_0.conda
@@ -1250,13 +1258,13 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/ncurses-6.5-h5846eda_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/nettle-3.9.1-h8e11ae5_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/ninja-1.12.1-h3c5361c_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/nlohmann_json-3.11.3-h73e2aa4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/nlohmann_json-3.11.3-hf036a51_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/nspr-4.35-hea0b92c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/nss-3.103-he7eb89d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/numpy-1.26.4-py311hc43a94b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/octomap-1.9.8-hb8565cd_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/osx-64/ogre-1.10.12.1-h2c9a09f_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/ogre-next-2.3.3-h74574cf_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/ogre-next-2.3.3-h0aac46b_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/onnxruntime-cpp-1.18.1-hd50bfdd_0_cpu.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/openal-soft-1.23.1-h7728843_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/opencv-4.10.0-headless_py311hc00a5b2_1.conda
@@ -1288,9 +1296,9 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/pugixml-1.14-he965462_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pure_eval-0.2.3-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/py-opencv-4.10.0-headless_py311h0c3459f_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/pybind11-2.13.1-py311h46c8309_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/pybind11-2.13.4-py311h46c8309_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pybind11-abi-4-hd8ed1ab_3.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/pybind11-global-2.13.1-py311h46c8309_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/pybind11-global-2.13.4-py311h46c8309_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.18.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.1.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/pyqt-5.15.9-py311h5b1a2bc_5.conda
@@ -1298,9 +1306,9 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/pyqtwebengine-5.15.9-py311hfec3007_5.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/python-3.11.9-h657bba9_0_cpython.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/python_abi-3.11-4_cp311.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/python_abi-3.11-5_cp311.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/pyyaml-6.0.2-py311h72ae277_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/pyzmq-26.1.0-py311hdb04418_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/pyzmq-26.1.1-py311hdb04418_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/qhull-2020.2-h3c5361c_5.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/qt-main-5.15.8-hecaf5c3_21.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/qt-webengine-5.15.8-h5f65913_4.conda
@@ -1313,7 +1321,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/ruby-3.3.3-ha604482_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/sdl-1.2.68-hce1cd6f_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/sdl2-2.30.5-hf036a51_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-72.1.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-72.2.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/sigtool-0.1.3-h88f4db0_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/osx-64/simbody-3.7-h43072b6_3.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/osx-64/sip-6.7.12-py311hd39e593_0.conda
@@ -1381,8 +1389,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/zziplib-0.13.69-h97fe558_2.conda
       osx-arm64:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ace-8.0.1-h00cdb27_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/aiohappyeyeballs-2.3.5-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aiohttp-3.10.3-py312h7e5086c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/aiohappyeyeballs-2.4.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aiohttp-3.10.5-py312h7e5086c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/aiosignal-1.3.1-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ampl-mp-3.1.0-hbec66e7_1006.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aom-3.9.1-h7bae524_0.conda
@@ -1413,7 +1421,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/brotli-bin-1.1.0-hb547adb_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/bullet-cpp-3.25-py312h9e53831_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/bzip2-1.0.8-h99b78c6_7.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/c-ares-1.32.3-h99b78c6_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/c-ares-1.33.0-h99b78c6_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/c-compiler-1.7.0-h6aa9301_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ca-certificates-2024.7.4-hf0a4a13_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/cached-property-1.5.2-hd8ed1ab_1.tar.bz2
@@ -1470,8 +1478,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/gdk-pixbuf-2.42.12-h7ddc832_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/geos-3.12.1-h965bd2d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/geotiff-1.7.1-h7bcba05_15.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/gettext-0.22.5-h8fbad5d_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/gettext-tools-0.22.5-h8fbad5d_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/gettext-0.22.5-h8414b35_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/gettext-tools-0.22.5-h8414b35_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/gfortran-12.3.0-h1ca8e4b_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/gfortran_impl_osx-arm64-12.3.0-h53ed385_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/gfortran_osx-arm64-12.3.0-h57527a5_1.conda
@@ -1505,7 +1513,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/imath-3.1.11-h1059232_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ipopt-3.14.16-h387674d_4.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ipython-8.26.0-pyh707e725_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/irrlicht-1.8.5-h1344824_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/irrlicht-1.8.5-hdfd4c6d_5.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/isl-0.26-imath32_h347afa1_101.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/jasper-4.2.4-h6c4e4ef_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jedi-0.19.1-pyhd8ed1ab_0.conda
@@ -1523,8 +1531,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libabseil-20240116.2-cxx17_h00cdb27_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libaec-1.1.3-hebf3989_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libarchive-3.7.4-h83d404f_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libasprintf-0.22.5-h8fbad5d_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libasprintf-devel-0.22.5-h8fbad5d_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libasprintf-0.22.5-h8414b35_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libasprintf-devel-0.22.5-h8414b35_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libass-0.17.1-hf7da4fe_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libblas-3.9.0-23_osxarm64_openblas.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libboost-1.84.0-h17eb2be_3.conda
@@ -1542,7 +1550,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libclang13-18.1.8-default_hfc66aa2_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcrc32c-1.1.2-hbdafb3b_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcurl-8.9.1-hfd8ffcc_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcxx-18.1.8-h5a72898_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcxx-18.1.8-h5a72898_4.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libdeflate-1.20-h93a5062_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libedit-3.1.20191231-hc8eb9b7_2.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libev-4.33-h93a5062_2.conda
@@ -1551,8 +1559,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libflac-1.4.3-hb765f3a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgd-2.3.3-hfdf3952_9.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-3.8.4-h7181668_5.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgettextpo-0.22.5-h8fbad5d_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgettextpo-devel-0.22.5-h8fbad5d_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgettextpo-0.22.5-h8414b35_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgettextpo-devel-0.22.5-h8414b35_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgfortran-5.0.0-13_2_0_hd922786_3.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/libgfortran-devel_osx-arm64-12.3.0-hc62be1c_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgfortran5-13.2.0-hf226fd6_3.conda
@@ -1584,8 +1592,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libignition-msgs5-5.11.0-h79388a1_9.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libignition-tools1-1.5.0-h203d471_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libignition-transport8-8.4.0-h1726a66_11.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libintl-0.22.5-h8fbad5d_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libintl-devel-0.22.5-h8fbad5d_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libintl-0.22.5-h8414b35_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libintl-devel-0.22.5-h8414b35_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libjpeg-turbo-3.0.0-hb547adb_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libkml-1.3.0-h00ed6cc_1020.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/liblapack-3.9.0-23_osxarm64_openblas.conda
@@ -1644,15 +1652,15 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libxml2-2.12.7-h9a80f22_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libzip-1.10.1-ha0bc3c6_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libzlib-1.3.1-hfb2fe0b_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/llvm-openmp-18.1.8-hde57baf_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/llvm-openmp-18.1.8-hde57baf_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/llvm-tools-16.0.6-haab561b_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/loguru-0.7.2-py312h81bd7bf_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/lua-5.4.6-hfd2a410_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/lz4-c-1.9.4-hb7217d7_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/lzo-2.10-h93a5062_1001.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/make-4.3-he57ea6c_1.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/matplotlib-3.9.1-py312h1f38498_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/matplotlib-base-3.9.1-py312h32d6e5a_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/matplotlib-3.9.2-py312h1f38498_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/matplotlib-base-3.9.2-py312h32d6e5a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/matplotlib-inline-0.1.7-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/metis-5.1.0-h13dd4ca_1007.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/minizip-4.0.7-h27ee973_0.conda
@@ -1669,13 +1677,13 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ncurses-6.5-hb89a1cb_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/nettle-3.9.1-h40ed0f5_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ninja-1.12.1-h420ef59_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/nlohmann_json-3.11.3-hebf3989_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/nlohmann_json-3.11.3-h00cdb27_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/nspr-4.35-hb7217d7_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/nss-3.103-hc42bcbf_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/numpy-1.26.4-py312h8442bc7_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/octomap-1.9.8-hffc8910_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ogre-1.10.12.1-h5f4fb40_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ogre-next-2.3.3-h01a85d9_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ogre-next-2.3.3-h167f6a0_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/onnxruntime-cpp-1.18.1-h590478b_0_cpu.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/openal-soft-1.23.1-h2ffa867_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/opencv-4.10.0-headless_py312hf580477_1.conda
@@ -1707,9 +1715,9 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pugixml-1.14-h13dd4ca_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pure_eval-0.2.3-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/py-opencv-4.10.0-headless_py312hd31a7ba_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pybind11-2.13.1-py312h157fec4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pybind11-2.13.4-py312h157fec4_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pybind11-abi-4-hd8ed1ab_3.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pybind11-global-2.13.1-py312h157fec4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pybind11-global-2.13.4-py312h157fec4_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.18.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.1.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyqt-5.15.9-py312h550cae4_5.conda
@@ -1717,9 +1725,9 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyqtwebengine-5.15.9-py312h14105d7_5.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/python-3.12.5-h30c5eda_0_cpython.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/python_abi-3.12-4_cp312.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/python_abi-3.12-5_cp312.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyyaml-6.0.2-py312h7e5086c_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyzmq-26.1.0-py312hfa13136_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyzmq-26.1.1-py312hfa13136_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/qhull-2020.2-h420ef59_5.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/qt-main-5.15.8-hf679f28_21.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/qt-webengine-5.15.8-h850e111_4.conda
@@ -1732,7 +1740,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ruby-3.3.3-h57ff7e8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/sdl-1.2.68-hfc12253_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/sdl2-2.30.5-h00cdb27_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-72.1.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-72.2.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/sigtool-0.1.3-h44b9a77_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/simbody-3.7-h4b178c3_3.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/sip-6.8.3-py312h20a0b95_0.conda
@@ -1800,13 +1808,14 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zziplib-0.13.69-h57f5043_2.conda
       win-64:
       - conda: https://conda.anaconda.org/conda-forge/win-64/ace-8.0.1-he0c23c2_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/aiohappyeyeballs-2.3.5-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/aiohttp-3.10.3-py312h4389bb4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/aiohappyeyeballs-2.4.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/aiohttp-3.10.5-py310ha8f682b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/aiosignal-1.3.1-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/win-64/aom-3.9.1-he0c23c2_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/asio-1.29.0-h63175ca_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/assimp-5.3.1-h0dbab56_3.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/asttokens-2.4.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/async-timeout-4.0.3-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/attrs-24.2.0-pyh71513ae_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-auth-0.7.20-h6823eb1_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-cal-0.6.12-hc83774a_0.conda
@@ -1825,12 +1834,12 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/azure-storage-blobs-cpp-12.10.0-h91493d7_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/azure-storage-common-cpp-12.5.0-h91493d7_4.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/blosc-1.21.6-h85f69ea_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/boost-1.84.0-h7e22eef_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/boost-1.84.0-h05ea346_5.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/brotli-1.1.0-hcfcfb64_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/brotli-bin-1.1.0-hcfcfb64_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/bullet-cpp-3.25-h2ab9e98_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/bullet-cpp-3.25-hecd3228_2.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/bzip2-1.0.8-h2466b09_7.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/c-ares-1.32.3-h2466b09_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/c-ares-1.33.0-h2466b09_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/c-compiler-1.7.0-hcfcfb64_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/ca-certificates-2024.7.4-h56e8100_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/cached-property-1.5.2-hd8ed1ab_1.tar.bz2
@@ -1844,7 +1853,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/win-64/compilers-1.7.0-h57928b3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/console_bridge-1.0.2-h5362a0b_1.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/win-64/contourpy-1.2.1-py312h0d7def4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/contourpy-1.2.1-py310h232114e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/cppzmq-4.10.0-h42135b4_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/cxx-compiler-1.7.0-h91493d7_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/cycler-0.12.1-pyhd8ed1ab_0.conda
@@ -1860,7 +1869,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/executing-2.0.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/expat-2.6.2-h63175ca_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/fcl-0.7.0-he22821c_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/ffmpeg-6.1.2-gpl_h97ca3ef_100.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/ffmpeg-6.1.2-gpl_h97ca3ef_101.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/flang-5.0.0-he025d50_20180525.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/win-64/flang_win-64-5.0.0-h13ae965_20180526.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/win-64/flann-1.9.2-h23e6bae_0.conda
@@ -1872,20 +1881,20 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/fontconfig-2.14.2-hbde0cde_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-ecosystem-1-0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-forge-1-0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/win-64/fonttools-4.53.1-py312h4389bb4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/fonttools-4.53.1-py310ha8f682b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/fortran-compiler-1.7.0-h9655429_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/freeglut-3.2.2-he0c23c2_3.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/freeimage-3.18.0-h2b56e36_20.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/freetype-2.12.1-hdaf720e_2.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/freexl-2.0.0-h8276f4a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/fribidi-1.0.10-h8d14728_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/win-64/frozenlist-1.4.1-py312he70551f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/frozenlist-1.4.1-py310h8d17308_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/gazebo-11.14.0-hb27d4c6_10.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/geos-3.12.1-h1537add_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/geotiff-1.7.1-hbf5ca3a_15.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/getopt-win32-0.1-hcfcfb64_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/gettext-0.22.5-h5728263_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/gettext-tools-0.22.5-h7d00a51_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/gettext-0.22.5-h5728263_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/gettext-tools-0.22.5-h5a7288d_3.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/gl2ps-1.4.2-had7236b_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/glew-2.1.0-h39d44d4_2.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/win-64/glfw-3.4-hcfcfb64_0.conda
@@ -1901,26 +1910,26 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/gst-plugins-good-1.24.4-h3b23867_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/gstreamer-1.24.4-h5006eae_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/gts-0.7.6-h6b5321d_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/gz-sim8-8.1.0-h57928b3_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/gz-sim8-python-8.1.0-py312hd0fd4dc_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/h5py-3.11.0-nompi_py312ha036244_102.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/gz-sim8-8.3.0-h57928b3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/gz-sim8-python-8.3.0-py310h595d6f7_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/h5py-3.11.0-nompi_py310h2b0be38_102.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/harfbuzz-9.0.0-h81778c3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/hdf4-4.2.15-h5557f11_7.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/hdf5-1.14.3-nompi_h2b43c12_105.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/icu-73.2-h63175ca_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/idna-3.7-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/imath-3.1.11-h12be248_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/intel-openmp-2024.2.0-h57928b3_980.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/intel-openmp-2024.2.1-h57928b3_1083.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/ipopt-3.14.16-ha3daec3_4.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ipython-8.26.0-pyh7428d3b_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/irrlicht-1.8.5-h65f4d7e_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/irrlicht-1.8.5-h20dfb44_5.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/jasper-4.2.4-hcb1a123_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jedi-0.19.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/jsoncpp-1.9.5-h2d74725_1.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/win-64/jxrlib-1.1-hcfcfb64_3.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/kealib-1.5.3-h6c43f9b_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/khronos-opencl-icd-loader-2023.04.17-h64bf75a_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/kiwisolver-1.4.5-py312h0d7def4_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/kiwisolver-1.4.5-py310h232114e_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/krb5-1.21.3-hdf4eb48_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/lame-3.100-hcfcfb64_1003.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/win-64/lcms2-2.16-h67d730c_0.conda
@@ -1928,14 +1937,14 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/libabseil-20240116.2-cxx17_he0c23c2_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libaec-1.1.3-h63175ca_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libarchive-3.7.4-haf234dc_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libasprintf-0.22.5-h5728263_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libasprintf-devel-0.22.5-h5728263_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libasprintf-0.22.5-h5728263_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libasprintf-devel-0.22.5-h5728263_3.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libblas-3.9.0-23_win64_mkl.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libboost-1.84.0-h444863b_5.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libboost-devel-1.84.0-h91493d7_5.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libboost-headers-1.84.0-h57928b3_5.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libboost-python-1.84.0-py312hbaa7e33_5.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libboost-python-devel-1.84.0-py312h7e22eef_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libboost-python-1.84.0-py310h3e8ed56_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libboost-python-devel-1.84.0-py310h05ea346_5.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libbrotlicommon-1.1.0-hcfcfb64_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libbrotlidec-1.1.0-hcfcfb64_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libbrotlienc-1.1.0-hcfcfb64_1.conda
@@ -1951,8 +1960,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/libflang-5.0.0-h6538335_20180525.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/win-64/libgd-2.3.3-h312136b_9.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-3.8.4-hf83a0e2_5.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libgettextpo-0.22.5-h5728263_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libgettextpo-devel-0.22.5-h5728263_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgettextpo-0.22.5-h5728263_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgettextpo-devel-0.22.5-h5728263_3.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libglib-2.80.2-h0df6a38_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libgoogle-cloud-2.23.0-h68df31e_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libgoogle-cloud-storage-2.23.0-hb581fae_1.conda
@@ -1963,16 +1972,12 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/libgz-gui8-8.0.0-h68669f0_6.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libgz-math7-7.5.0-he0c23c2_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libgz-msgs10-10.2.0-hf246b6b_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libgz-msgs9-9.5.0-h76d1f87_8.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libgz-physics7-7.2.0-h5433f92_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libgz-plugin2-2.0.3-h63175ca_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libgz-rendering7-7.4.2-h63175ca_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libgz-rendering8-8.1.1-h63175ca_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libgz-sensors7-7.3.0-h89268de_6.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libgz-sensors8-8.0.0-h89268de_5.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libgz-sim8-8.1.0-hea5eaeb_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgz-sim8-8.3.0-h6914e37_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libgz-tools2-2.0.0-hf5993cb_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libgz-transport12-12.2.1-h0e3e44e_8.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libgz-transport13-13.4.0-ha6d6571_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libgz-utils2-2.1.0-h63175ca_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libhwloc-2.11.1-default_h8125262_1000.conda
@@ -1980,12 +1985,12 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/libignition-cmake2-2.17.2-he0c23c2_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libignition-common3-3.15.1-hef572a9_4.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libignition-fuel-tools4-4.6.0-h7d73f36_9.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libignition-math6-6.15.1-py312haf63811_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libignition-math6-6.15.1-py310h595d6f7_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libignition-msgs5-5.11.0-h76d1f87_9.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libignition-tools1-1.5.0-hf5993cb_3.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libignition-transport8-8.4.0-h401e20c_11.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libintl-0.22.5-h5728263_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libintl-devel-0.22.5-h5728263_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libintl-0.22.5-h5728263_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libintl-devel-0.22.5-h5728263_3.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libjpeg-turbo-3.0.0-hcfcfb64_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libkml-1.3.0-h538826c_1020.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/liblapack-3.9.0-23_win64_mkl.conda
@@ -1993,10 +1998,10 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/libmatio-1.5.27-h0a2718b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libnetcdf-4.9.2-nompi_h92078aa_114.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libnghttp2-1.58.0-h63175ca_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libode-0.16.2-h53d5487_14.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libode-0.16.2-h00ffb61_14.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libogg-1.3.5-h2466b09_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libopenblas-0.3.27-pthreads_hf0a32cb_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libopencv-4.10.0-qt6_py312h00ae949_602.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libopenblas-0.3.28-pthreads_hf0a32cb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libopencv-4.10.0-qt6_py310hb73b763_602.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libopenvino-2024.2.0-hfe1841e_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libopenvino-auto-batch-plugin-2024.2.0-h04f32e0_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libopenvino-auto-plugin-2024.2.0-h04f32e0_1.conda
@@ -2018,7 +2023,6 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/libre2-11-2023.09.01-hf8d8778_2.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/librttopo-1.1.0-h94c4f80_15.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libsdformat-9.8.0-hbbad600_6.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libsdformat13-13.6.0-h76d8a3d_4.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libsdformat14-14.5.0-hf143461_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libsndfile-1.2.2-h81429f1_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libsodium-1.0.18-h8d14728_1.tar.bz2
@@ -2039,7 +2043,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/libzip-1.10.1-h1d365fa_3.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libzlib-1.3.1-h2466b09_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/llvm-meta-5.0.0-0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/win-64/loguru-0.7.2-py312h2e8e312_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/loguru-0.7.2-py310h5588dad_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/lua-5.4.6-h2466b09_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/lz4-c-1.9.4-hcfcfb64_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/lzo-2.10-hcfcfb64_1001.conda
@@ -2049,28 +2053,28 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/m2w64-gmp-6.1.0-2.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/win-64/m2w64-libwinpthread-git-5.0.0.4634.697f757-2.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/win-64/make-4.3-h3d2af85_1.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/win-64/matplotlib-3.9.1-py312h2e8e312_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/matplotlib-base-3.9.1-py312h90004f6_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/matplotlib-3.9.2-py310h5588dad_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/matplotlib-base-3.9.2-py310h37e0a56_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/matplotlib-inline-0.1.7-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/metis-5.1.0-h63175ca_1007.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/minizip-4.0.6-hb638d1e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/mkl-2024.1.0-h66d3029_694.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/mpg123-1.32.6-h63175ca_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/msgpack-python-1.0.8-py312hd5eb7cc_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/msgpack-python-1.0.8-py310hc19bc0b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/msys2-conda-epoch-20160418-1.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/win-64/multidict-6.0.5-py312he70551f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/multidict-6.0.5-py310h8d17308_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/mumps-seq-5.7.2-h7c2359a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/munkres-1.1.4-pyh9f0ad1d_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/win-64/ninja-1.12.1-hc790b64_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/nlohmann_json-3.11.3-h1537add_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/numpy-1.26.4-py312h8753938_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/nlohmann_json-3.11.3-he0c23c2_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/numpy-1.26.4-py310hf667824_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/octomap-1.9.8-h91493d7_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/win-64/ogre-1.10.12.1-hc646683_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/ogre-next-2.3.3-h606bb5d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/ogre-next-2.3.3-hb2de451_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/onnxruntime-cpp-1.18.1-h50ebc8d_0_cpu.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/openal-soft-1.23.1-h91493d7_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/openblas-0.3.27-pthreads_h29161c6_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/opencv-4.10.0-qt6_py312hfab33ed_602.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/openblas-0.3.28-pthreads_h29161c6_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/opencv-4.10.0-qt6_py310h36cc372_602.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/openexr-3.2.2-h72640d8_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/openh264-2.4.1-h63175ca_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/openjpeg-2.5.2-h3d672ee_0.conda
@@ -2082,7 +2086,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/pcl-1.14.1-hb5fe040_3.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/pcre2-10.43-h17e33f8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pickleshare-0.7.5-py_1003.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/win-64/pillow-10.4.0-py312h381445a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pillow-10.4.0-py310h3e38d90_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pip-24.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/pixman-0.43.4-h63175ca_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/pkg-config-0.29.2-h2bf4dc2_1008.tar.bz2
@@ -2097,21 +2101,21 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/pthreads-win32-2.9.1-hfa6e2cd_3.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/win-64/pugixml-1.14-h63175ca_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pure_eval-0.2.3-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/py-opencv-4.10.0-qt6_py312h8df5404_602.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/pybind11-2.13.1-py312hd5eb7cc_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/py-opencv-4.10.0-qt6_py310h7364d9e_602.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pybind11-2.13.4-py310hc19bc0b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pybind11-abi-4-hd8ed1ab_3.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/win-64/pybind11-global-2.13.1-py312hd5eb7cc_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pybind11-global-2.13.4-py310hc19bc0b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.18.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.1.2-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/pyqt-5.15.9-py312he09f080_5.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/pyqt5-sip-12.12.2-py312h53d5487_5.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/pyqtwebengine-5.15.9-py312hca0710b_5.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/pyside6-6.7.2-py312h2ee7485_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/python-3.12.5-h889d299_0_cpython.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pyqt-5.15.9-py310h1fd54f2_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pyqt5-sip-12.12.2-py310h00ffb61_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pyqtwebengine-5.15.9-py310he49db7d_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pyside6-6.7.2-py310h60c6385_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/python-3.10.14-h4de0772_0_cpython.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/python_abi-3.12-4_cp312.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/pyyaml-6.0.2-py312h4389bb4_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/pyzmq-26.1.0-py312hd7027bb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/python_abi-3.10-5_cp310.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pyyaml-6.0.2-py310ha8f682b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pyzmq-26.1.1-py310h656833d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/qhull-2020.2-hc790b64_5.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/qt-main-5.15.8-hcef0176_21.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/qt-webengine-5.15.8-h4bf5c4e_4.tar.bz2
@@ -2122,9 +2126,9 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/ruby-3.3.3-hfb80623_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/sdl-1.2.68-h21dd15a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/sdl2-2.30.5-he0c23c2_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-72.1.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-72.2.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/simbody-3.7-hade3207_3.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/win-64/sip-6.7.12-py312h53d5487_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/sip-6.7.12-py310h00ffb61_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.16.0-pyh6c4a22f_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/win-64/snappy-1.2.1-h23299a8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/soxr-0.1.3-hcfcfb64_3.conda
@@ -2143,12 +2147,14 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/toml-0.10.2-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.0.1-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/win-64/tomlplusplus-3.3.0-h63175ca_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/tornado-6.4.1-py312h4389bb4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/tornado-6.4.1-py310ha8f682b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/traitlets-5.14.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.12.2-hd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.12.2-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2024a-h0c530f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/u-msgpack-python-2.8.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/ucrt-10.0.22621.0-h57928b3_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/unicodedata2-15.1.0-py310h8d17308_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/urdfdom-4.0.0-h0b06ded_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/urdfdom_headers-1.1.1-h91493d7_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/uriparser-0.9.8-h5a68840_0.conda
@@ -2158,8 +2164,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/vs2015_runtime-14.40.33810-h3bf8584_20.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/vs2019_win-64-19.29.30139-he1865b1_20.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/vswhere-3.1.7-h57928b3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/vtk-9.3.0-qt_py312h1234567_200.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/vtk-base-9.3.0-qt_py312h1234567_200.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/vtk-9.3.0-qt_py310h1234567_200.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/vtk-base-9.3.0-qt_py310h1234567_200.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.2.13-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/wheel-0.44.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/win32_setctime-1.1.0-pyhd8ed1ab_0.tar.bz2
@@ -2180,7 +2186,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/xorg-xproto-7.0.31-hcd874cb_1007.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/win-64/xz-5.2.6-h8d14728_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/win-64/yaml-0.2.5-h8ffe710_2.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/win-64/yarl-1.9.4-py312he70551f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/yarl-1.9.4-py310h8d17308_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/zeromq-4.3.5-he1f189c_4.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/zlib-1.3.1-h2466b09_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/zstd-1.5.6-h0ea2cb4_0.conda
@@ -2334,26 +2340,27 @@ packages:
   timestamp: 1722626386604
 - kind: conda
   name: aiohappyeyeballs
-  version: 2.3.5
+  version: 2.4.0
   build: pyhd8ed1ab_0
   subdir: noarch
   noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/aiohappyeyeballs-2.3.5-pyhd8ed1ab_0.conda
-  sha256: 37ac19a57d429670dcd2c716232e6f842b7f357cecd0977b1d4fd30b8446a30a
-  md5: d904abda207d2dba054fd820d34bbaee
+  url: https://conda.anaconda.org/conda-forge/noarch/aiohappyeyeballs-2.4.0-pyhd8ed1ab_0.conda
+  sha256: 5d318408a7ad62c1dbff90060795287f1fd3bdbec13b733bc82f1fadb2c9244e
+  md5: 0482cd2217e27b3ce47676d570ac3d45
   depends:
   - python >=3.8.0
   license: PSF-2.0
-  size: 16990
-  timestamp: 1723050994330
+  license_family: PSF
+  size: 17032
+  timestamp: 1724167966661
 - kind: conda
   name: aiohttp
-  version: 3.10.3
+  version: 3.10.5
   build: py310h5b4e0ec_0
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/aiohttp-3.10.3-py310h5b4e0ec_0.conda
-  sha256: c7705884b1cb3811f5ab6c5ff0f1b0e08b9f4854d979f037745e7e85cfa90ad0
-  md5: dbdc5a34d9a4796ab695512d6b9c2313
+  url: https://conda.anaconda.org/conda-forge/linux-64/aiohttp-3.10.5-py310h5b4e0ec_0.conda
+  sha256: 5007bf1c6dd9371f44547177e9812beca8006b633cfb6b65fa4b82ef82432367
+  md5: 975d45aba678d0564cd5bb3fc0f883f7
   depends:
   - __glibc >=2.17,<3.0.a0
   - aiohappyeyeballs >=2.3.0
@@ -2368,16 +2375,41 @@ packages:
   - yarl >=1.0,<2.0
   license: MIT AND Apache-2.0
   license_family: Apache
-  size: 714129
-  timestamp: 1723330988196
+  size: 714502
+  timestamp: 1724171316330
 - kind: conda
   name: aiohttp
-  version: 3.10.3
+  version: 3.10.5
+  build: py310ha8f682b_0
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/aiohttp-3.10.5-py310ha8f682b_0.conda
+  sha256: 5212403cf4f06238df22aa72a5128afa802111ad26d365e9e4624be61b2dc5d1
+  md5: 71309490ab5b89b02ce4926d92855542
+  depends:
+  - aiohappyeyeballs >=2.3.0
+  - aiosignal >=1.1.2
+  - async-timeout >=4.0,<5.0
+  - attrs >=17.3.0
+  - frozenlist >=1.1.1
+  - multidict >=4.5,<7.0
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  - yarl >=1.0,<2.0
+  license: MIT AND Apache-2.0
+  license_family: Apache
+  size: 673634
+  timestamp: 1724171903497
+- kind: conda
+  name: aiohttp
+  version: 3.10.5
   build: py310hb52b2da_0
   subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/aiohttp-3.10.3-py310hb52b2da_0.conda
-  sha256: 346dc40106fa8d379d23f3eae2bffda904de2d72785381a1d5f443502f1f8ebd
-  md5: 5f0405ba376e8a465b7b5539d648ae81
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/aiohttp-3.10.5-py310hb52b2da_0.conda
+  sha256: faddf084d6ef610187c010e3a43461de1a748c679af8769b850d9e20205b1fd4
+  md5: 69cf80deee8778bda4fe9a05ce9b0098
   depends:
   - aiohappyeyeballs >=2.3.0
   - aiosignal >=1.1.2
@@ -2392,16 +2424,16 @@ packages:
   - yarl >=1.0,<2.0
   license: MIT AND Apache-2.0
   license_family: Apache
-  size: 708038
-  timestamp: 1723331066624
+  size: 711729
+  timestamp: 1724171505234
 - kind: conda
   name: aiohttp
-  version: 3.10.3
+  version: 3.10.5
   build: py311h72ae277_0
   subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/aiohttp-3.10.3-py311h72ae277_0.conda
-  sha256: 135f448e05018d9b169e4a30c735f79874c16a59aa6a85fd7d4dfe543b0077df
-  md5: dce4b894108d68bb984a1a40846c282c
+  url: https://conda.anaconda.org/conda-forge/osx-64/aiohttp-3.10.5-py311h72ae277_0.conda
+  sha256: 39afc1de1723f6810a0f55ca97c68b4d506a464bd2e6b802e943fdd43439c1cc
+  md5: f982299c7289d13f1ee1f2bc3b0822aa
   depends:
   - __osx >=10.13
   - aiohappyeyeballs >=2.3.0
@@ -2414,40 +2446,16 @@ packages:
   - yarl >=1.0,<2.0
   license: MIT AND Apache-2.0
   license_family: Apache
-  size: 799708
-  timestamp: 1723331093578
+  size: 799866
+  timestamp: 1724171615774
 - kind: conda
   name: aiohttp
-  version: 3.10.3
-  build: py312h4389bb4_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/aiohttp-3.10.3-py312h4389bb4_0.conda
-  sha256: 826e2aecf24e49245dd9fb41289a394641b0466356e0010bbb9046d45f9f2f12
-  md5: b7e68806c5b2fb264516c0d04c6a3379
-  depends:
-  - aiohappyeyeballs >=2.3.0
-  - aiosignal >=1.1.2
-  - attrs >=17.3.0
-  - frozenlist >=1.1.1
-  - multidict >=4.5,<7.0
-  - python >=3.12,<3.13.0a0
-  - python_abi 3.12.* *_cp312
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  - yarl >=1.0,<2.0
-  license: MIT AND Apache-2.0
-  license_family: Apache
-  size: 781977
-  timestamp: 1723331441999
-- kind: conda
-  name: aiohttp
-  version: 3.10.3
+  version: 3.10.5
   build: py312h7e5086c_0
   subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/aiohttp-3.10.3-py312h7e5086c_0.conda
-  sha256: 0ea31d8781a39bbd766a48aa2f336a34dbd26d050223b88d9447fdaad49f74c9
-  md5: cc0d1381170ac5f052ec11a318fa0756
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/aiohttp-3.10.5-py312h7e5086c_0.conda
+  sha256: 21ffc1709ff00528b3b3a1dc961284f364aa36a97a51bdf18124e8c5a164feae
+  md5: 48b9f475c6eddf9dbbedb865f702aed5
   depends:
   - __osx >=11.0
   - aiohappyeyeballs >=2.3.0
@@ -2461,8 +2469,8 @@ packages:
   - yarl >=1.0,<2.0
   license: MIT AND Apache-2.0
   license_family: Apache
-  size: 797451
-  timestamp: 1723331121547
+  size: 800154
+  timestamp: 1724171548900
 - kind: conda
   name: aiosignal
   version: 1.3.1
@@ -4665,6 +4673,22 @@ packages:
 - kind: conda
   name: boost
   version: 1.84.0
+  build: h05ea346_5
+  build_number: 5
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/boost-1.84.0-h05ea346_5.conda
+  sha256: d331937bf0aaadd13c17acfececae9e5f9362f6ce096b6ba1c1685d385f16744
+  md5: e595185bc75c4b010e47e9b44eaad5ec
+  depends:
+  - libboost-python-devel 1.84.0 py310h05ea346_5
+  - numpy >=1.19,<3
+  - python_abi 3.10.* *_cp310
+  license: BSL-1.0
+  size: 17478
+  timestamp: 1722293372818
+- kind: conda
+  name: boost
+  version: 1.84.0
   build: h36e1b2c_3
   build_number: 3
   subdir: linux-aarch64
@@ -4678,22 +4702,6 @@ packages:
   license: BSL-1.0
   size: 16656
   timestamp: 1715809161965
-- kind: conda
-  name: boost
-  version: 1.84.0
-  build: h7e22eef_5
-  build_number: 5
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/boost-1.84.0-h7e22eef_5.conda
-  sha256: 72a372fc13417e10507d238f885bd9022f84925ca8c6d704ceeaf2ab34f087a8
-  md5: 7291ade4d04c563f8ef3609dacb397a5
-  depends:
-  - libboost-python-devel 1.84.0 py312h7e22eef_5
-  - numpy >=1.19,<3
-  - python_abi 3.12.* *_cp312
-  license: BSL-1.0
-  size: 17505
-  timestamp: 1722293290389
 - kind: conda
   name: boost
   version: 1.84.0
@@ -4920,24 +4928,6 @@ packages:
 - kind: conda
   name: bullet-cpp
   version: '3.25'
-  build: h2ab9e98_2
-  build_number: 2
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/bullet-cpp-3.25-h2ab9e98_2.conda
-  sha256: 1ab7d9943ef1177892dbf101842e9ea5e2d508933686e14208bc6991a1671cc0
-  md5: d8fbf5874e2d5dd6e2d9358b40ef545d
-  depends:
-  - numpy >=1.26.0,<2.0a0
-  - python_abi 3.12.* *_cp312
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  license: Zlib
-  size: 15974310
-  timestamp: 1697298479323
-- kind: conda
-  name: bullet-cpp
-  version: '3.25'
   build: h7be5568_2
   build_number: 2
   subdir: osx-64
@@ -4973,6 +4963,24 @@ packages:
   license: Zlib
   size: 42832835
   timestamp: 1697298033683
+- kind: conda
+  name: bullet-cpp
+  version: '3.25'
+  build: hecd3228_2
+  build_number: 2
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/bullet-cpp-3.25-hecd3228_2.conda
+  sha256: 94981307bd16348cbbfb58c0860cbd7eccd1984a43d1f4ba54b2de85e8078ab0
+  md5: c62bc33a0804e88cb2fc5344c351a9d2
+  depends:
+  - numpy >=1.22.4,<2.0a0
+  - python_abi 3.10.* *_cp310
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Zlib
+  size: 15845701
+  timestamp: 1697298509856
 - kind: conda
   name: bullet-cpp
   version: '3.25'
@@ -5093,77 +5101,78 @@ packages:
   timestamp: 1720974491916
 - kind: conda
   name: c-ares
-  version: 1.32.3
+  version: 1.33.0
   build: h2466b09_0
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/c-ares-1.32.3-h2466b09_0.conda
-  sha256: 91e3568f5708916b28863d672120e67f85f86d3d9d892aabe6012153702aa045
-  md5: eb6bcf1d4a0bb3ab98d4bbd402534b80
+  url: https://conda.anaconda.org/conda-forge/win-64/c-ares-1.33.0-h2466b09_0.conda
+  sha256: b3f07bc0134a921fee0d3b1306751051da3c1d19eb82b1ae6e14c1f15bcda9c3
+  md5: 0864e040b671709d2838790522a8b976
   depends:
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
   license: MIT
   license_family: MIT
-  size: 165093
-  timestamp: 1721835227167
+  size: 166933
+  timestamp: 1723535152991
 - kind: conda
   name: c-ares
-  version: 1.32.3
-  build: h4bc722e_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/c-ares-1.32.3-h4bc722e_0.conda
-  sha256: 3c5a844bb60b0d52d89c3f1bd828c9856417fe33a6102fd8bbd5c13c3351704a
-  md5: 7624e34ee6baebfc80d67bac76cc9d9d
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc-ng >=12
-  license: MIT
-  license_family: MIT
-  size: 179736
-  timestamp: 1721834714515
-- kind: conda
-  name: c-ares
-  version: 1.32.3
+  version: 1.33.0
   build: h51dda26_0
   subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/c-ares-1.32.3-h51dda26_0.conda
-  sha256: 2454287fa7d32b2cd089ad2bb46c8f8634b6f409d6fa8892c37ccc66134ec076
-  md5: 5487b45a597e142da7839941ab2494a9
+  url: https://conda.anaconda.org/conda-forge/osx-64/c-ares-1.33.0-h51dda26_0.conda
+  sha256: d1f2429bf3d5d1c7e1a0ce5bf6216b563024169293731a130f7d8a64230b9302
+  md5: 3355b2350a1de63943bcd053a4fccd6d
   depends:
   - __osx >=10.13
   license: MIT
   license_family: MIT
-  size: 160304
-  timestamp: 1721834876236
+  size: 163061
+  timestamp: 1723534676956
 - kind: conda
   name: c-ares
-  version: 1.32.3
-  build: h68df207_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/c-ares-1.32.3-h68df207_0.conda
-  sha256: 9c0505e6e8a23c85f10e4b5c8924c4f9d51cccb89b81b59369b167adf2448fd1
-  md5: 13d442f0a28e5a71073328a9b2140cb8
-  depends:
-  - libgcc-ng >=12
-  license: MIT
-  license_family: MIT
-  size: 187241
-  timestamp: 1721834713576
-- kind: conda
-  name: c-ares
-  version: 1.32.3
+  version: 1.33.0
   build: h99b78c6_0
   subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/c-ares-1.32.3-h99b78c6_0.conda
-  sha256: dc8e2c2508295595675fb829345a156b0bb42b164271c2fcafb7fb193449bcf8
-  md5: c27bebc62991ab075b773f86ba64aa9b
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/c-ares-1.33.0-h99b78c6_0.conda
+  sha256: cc80521ffcc27ddf1362a85acee440bea4aa669f367463cd7d28cb46b497ec55
+  md5: 47874589be833bd706221ce6897374df
   depends:
   - __osx >=11.0
   license: MIT
   license_family: MIT
-  size: 157977
-  timestamp: 1721834921671
+  size: 160570
+  timestamp: 1723534815224
+- kind: conda
+  name: c-ares
+  version: 1.33.0
+  build: ha66036c_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/c-ares-1.33.0-ha66036c_0.conda
+  sha256: 3dec5fdb5d1e1758510af0ca163d82ea10109fec8af7d0cd7af38f01068c365b
+  md5: b6927f788e85267beef6cbb292aaebdd
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libgcc-ng >=12
+  license: MIT
+  license_family: MIT
+  size: 181873
+  timestamp: 1723534591118
+- kind: conda
+  name: c-ares
+  version: 1.33.0
+  build: hfcffcd1_0
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/c-ares-1.33.0-hfcffcd1_0.conda
+  sha256: aec8f52249ab157d160725970420a3ef95ee608bb43c285c145f6d832518d256
+  md5: 25a9aacee964ea10f6f272931f4c1433
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libgcc-ng >=12
+  license: MIT
+  license_family: MIT
+  size: 191846
+  timestamp: 1723534638037
 - kind: conda
   name: c-compiler
   version: 1.7.0
@@ -6372,6 +6381,25 @@ packages:
 - kind: conda
   name: contourpy
   version: 1.2.1
+  build: py310h232114e_0
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/contourpy-1.2.1-py310h232114e_0.conda
+  sha256: 9a53e5c28fc4348743beee9e2700a64e2378cdc8a383653da0501f05df677600
+  md5: 69968a52474279f0c44c08c87752096f
+  depends:
+  - numpy >=1.20
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 189962
+  timestamp: 1712430301862
+- kind: conda
+  name: contourpy
+  version: 1.2.1
   build: py310h586407a_0
   subdir: linux-aarch64
   url: https://conda.anaconda.org/conda-forge/linux-aarch64/contourpy-1.2.1-py310h586407a_0.conda
@@ -6423,25 +6451,6 @@ packages:
   license_family: BSD
   size: 249875
   timestamp: 1712430222440
-- kind: conda
-  name: contourpy
-  version: 1.2.1
-  build: py312h0d7def4_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/contourpy-1.2.1-py312h0d7def4_0.conda
-  sha256: 3af3de9a099d9ab88d24d0956c3acb838a774b64e52afa25abeed7b31c1174ef
-  md5: bc0160f16ae02e18de578eaddadd4f61
-  depends:
-  - numpy >=1.20
-  - python >=3.12,<3.13.0a0
-  - python_abi 3.12.* *_cp312
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 206433
-  timestamp: 1712430299728
 - kind: conda
   name: contourpy
   version: 1.2.1
@@ -7545,12 +7554,12 @@ packages:
 - kind: conda
   name: ffmpeg
   version: 6.1.2
-  build: gpl_h97ca3ef_100
-  build_number: 100
+  build: gpl_h97ca3ef_101
+  build_number: 101
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/ffmpeg-6.1.2-gpl_h97ca3ef_100.conda
-  sha256: a3b3baa0553f5378c13642e1fbd095412fb62543c0149dc76f2b952c251b4a24
-  md5: 149e39b215bf13b1352b377cbaf4d985
+  url: https://conda.anaconda.org/conda-forge/win-64/ffmpeg-6.1.2-gpl_h97ca3ef_101.conda
+  sha256: c6a36e3f86d890db7381c191f880aedd74d299e0fbab8d41cd9174b02d07e074
+  md5: 5f4dd4f6353d2582f4d6461b9b59afa3
   depends:
   - aom >=3.9.1,<3.10.0a0
   - bzip2 >=1.0.8,<2.0a0
@@ -7573,8 +7582,8 @@ packages:
   - xz >=5.2.6,<6.0a0
   license: GPL-2.0-or-later
   license_family: GPL
-  size: 9659934
-  timestamp: 1722711491862
+  size: 9631223
+  timestamp: 1723848325911
 - kind: conda
   name: flang
   version: 5.0.0
@@ -7970,6 +7979,27 @@ packages:
 - kind: conda
   name: fonttools
   version: 4.53.1
+  build: py310ha8f682b_0
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/fonttools-4.53.1-py310ha8f682b_0.conda
+  sha256: 71940803ccc516c06363badfc4d83b3f730f5916dbacbf6d1f42457785db9525
+  md5: 2cc3108eee7252ac8dcf22060a97be8d
+  depends:
+  - brotli
+  - munkres
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  - ucrt >=10.0.20348.0
+  - unicodedata2 >=14.0.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 1942539
+  timestamp: 1720359509701
+- kind: conda
+  name: fonttools
+  version: 4.53.1
   build: py310hb52b2da_0
   subdir: linux-aarch64
   url: https://conda.anaconda.org/conda-forge/linux-aarch64/fonttools-4.53.1-py310hb52b2da_0.conda
@@ -8005,26 +8035,6 @@ packages:
   license_family: MIT
   size: 2826047
   timestamp: 1720359212068
-- kind: conda
-  name: fonttools
-  version: 4.53.1
-  build: py312h4389bb4_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/fonttools-4.53.1-py312h4389bb4_0.conda
-  sha256: 508b8443a382eec4a6c389e0ab43543797a99172982d9999df8972bfa42e2829
-  md5: d1d90dc02033f12ab8020dbb653a9fc8
-  depends:
-  - brotli
-  - munkres
-  - python >=3.12,<3.13.0a0
-  - python_abi 3.12.* *_cp312
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  license: MIT
-  license_family: MIT
-  size: 2412400
-  timestamp: 1720359443784
 - kind: conda
   name: fonttools
   version: 4.53.1
@@ -8564,6 +8574,24 @@ packages:
 - kind: conda
   name: frozenlist
   version: 1.4.1
+  build: py310h8d17308_0
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/frozenlist-1.4.1-py310h8d17308_0.conda
+  sha256: 5c2969ab2c266d509f86697712ff1f47c0358bcbba992dca2a7b8b169f3f520b
+  md5: 7c80af4c3275a59af51d84896b0b7d9f
+  depends:
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Apache-2.0
+  license_family: APACHE
+  size: 53649
+  timestamp: 1702646171442
+- kind: conda
+  name: frozenlist
+  version: 1.4.1
   build: py310hb299538_0
   subdir: linux-aarch64
   url: https://conda.anaconda.org/conda-forge/linux-aarch64/frozenlist-1.4.1-py310hb299538_0.conda
@@ -8609,24 +8637,6 @@ packages:
   license_family: APACHE
   size: 52950
   timestamp: 1702645976558
-- kind: conda
-  name: frozenlist
-  version: 1.4.1
-  build: py312he70551f_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/frozenlist-1.4.1-py312he70551f_0.conda
-  sha256: 1bd946a7b2d33955d6a9c01f48903d9d6c173d176278390e6bea1cd49fce4804
-  md5: 76c4af78fdeaa3a6a2e8ac1d16c97ba2
-  depends:
-  - python >=3.12,<3.13.0a0
-  - python_abi 3.12.* *_cp312
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  license: Apache-2.0
-  license_family: APACHE
-  size: 53711
-  timestamp: 1702646171104
 - kind: conda
   name: gazebo
   version: 11.14.0
@@ -9348,189 +9358,195 @@ packages:
 - kind: conda
   name: gettext
   version: 0.22.5
-  build: h2f0025b_2
-  build_number: 2
+  build: h0a1ffab_3
+  build_number: 3
   subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/gettext-0.22.5-h2f0025b_2.conda
-  sha256: 2a55989e078485473cd6963ec094a2e51c66693a2112079a45ebc6fafe067277
-  md5: 2cb8df031115b66a564f2eb225fb4c48
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/gettext-0.22.5-h0a1ffab_3.conda
+  sha256: 25b0b40329537f374a7394474376b01fd226e31f3ff3aa9254e8d328b23c2145
+  md5: be78ccdd273e43e27e66fc1629df6576
   depends:
-  - gettext-tools 0.22.5 h2f0025b_2
-  - libasprintf 0.22.5 h7b6a552_2
-  - libasprintf-devel 0.22.5 h7b6a552_2
+  - gettext-tools 0.22.5 h0a1ffab_3
+  - libasprintf 0.22.5 h87f4aca_3
+  - libasprintf-devel 0.22.5 h87f4aca_3
   - libgcc-ng >=12
-  - libgettextpo 0.22.5 h2f0025b_2
-  - libgettextpo-devel 0.22.5 h2f0025b_2
+  - libgettextpo 0.22.5 h0a1ffab_3
+  - libgettextpo-devel 0.22.5 h0a1ffab_3
   - libstdcxx-ng >=12
   license: LGPL-2.1-or-later AND GPL-3.0-or-later
-  size: 475799
-  timestamp: 1712512430871
+  size: 481962
+  timestamp: 1723626297896
 - kind: conda
   name: gettext
   version: 0.22.5
-  build: h5728263_2
-  build_number: 2
+  build: h5728263_3
+  build_number: 3
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/gettext-0.22.5-h5728263_2.conda
-  sha256: cd4ef93fd052a4fe89a4db963c9d69e60c8a434d41968fc9dc8726db67191582
-  md5: da84216f88a8c89eb943c683ceb34d7d
+  url: https://conda.anaconda.org/conda-forge/win-64/gettext-0.22.5-h5728263_3.conda
+  sha256: 8cbfe8fc9421438fcfd06e08ace5587dcceb544ce46f773e116e414a51d6b3ff
+  md5: 85bbe942c8b188fa70f6ffb88a80ae2e
   depends:
-  - gettext-tools 0.22.5 h7d00a51_2
-  - libasprintf 0.22.5 h5728263_2
-  - libasprintf-devel 0.22.5 h5728263_2
-  - libgettextpo 0.22.5 h5728263_2
-  - libgettextpo-devel 0.22.5 h5728263_2
+  - gettext-tools 0.22.5 h5a7288d_3
+  - libasprintf 0.22.5 h5728263_3
+  - libasprintf-devel 0.22.5 h5728263_3
+  - libgettextpo 0.22.5 h5728263_3
+  - libgettextpo-devel 0.22.5 h5728263_3
   - libiconv >=1.17,<2.0a0
-  - libintl 0.22.5 h5728263_2
-  - libintl-devel 0.22.5 h5728263_2
+  - libintl 0.22.5 h5728263_3
+  - libintl-devel 0.22.5 h5728263_3
   license: LGPL-2.1-or-later AND GPL-3.0-or-later
-  size: 34028
-  timestamp: 1712517225377
+  size: 34015
+  timestamp: 1723630597857
 - kind: conda
   name: gettext
   version: 0.22.5
-  build: h59595ed_2
-  build_number: 2
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/gettext-0.22.5-h59595ed_2.conda
-  sha256: 386181254ddd2aed1fccdfc217da5b6545f6df4e9979ad8e08f5e91e22eaf7dc
-  md5: 219ba82e95d7614cf7140d2a4afc0926
-  depends:
-  - gettext-tools 0.22.5 h59595ed_2
-  - libasprintf 0.22.5 h661eb56_2
-  - libasprintf-devel 0.22.5 h661eb56_2
-  - libgcc-ng >=12
-  - libgettextpo 0.22.5 h59595ed_2
-  - libgettextpo-devel 0.22.5 h59595ed_2
-  - libstdcxx-ng >=12
-  license: LGPL-2.1-or-later AND GPL-3.0-or-later
-  size: 475058
-  timestamp: 1712512357949
-- kind: conda
-  name: gettext
-  version: 0.22.5
-  build: h5ff76d1_2
-  build_number: 2
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/gettext-0.22.5-h5ff76d1_2.conda
-  sha256: ba9a4680b018a4ca517ec20beb25b09c97e293ecd16b931075e689db10291712
-  md5: c09b3dcf2adc5a2a32d11ab90289b8fa
-  depends:
-  - gettext-tools 0.22.5 h5ff76d1_2
-  - libasprintf 0.22.5 h5ff76d1_2
-  - libasprintf-devel 0.22.5 h5ff76d1_2
-  - libcxx >=16
-  - libgettextpo 0.22.5 h5ff76d1_2
-  - libgettextpo-devel 0.22.5 h5ff76d1_2
-  - libiconv >=1.17,<2.0a0
-  - libintl 0.22.5 h5ff76d1_2
-  - libintl-devel 0.22.5 h5ff76d1_2
-  license: LGPL-2.1-or-later AND GPL-3.0-or-later
-  size: 481687
-  timestamp: 1712513003915
-- kind: conda
-  name: gettext
-  version: 0.22.5
-  build: h8fbad5d_2
-  build_number: 2
+  build: h8414b35_3
+  build_number: 3
   subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/gettext-0.22.5-h8fbad5d_2.conda
-  sha256: 7188b466071698759b125aaed9b4d78940e72e6299b0c6dbad6f35c85cf3d27b
-  md5: 404e2894e9cb2835246cef47317ff763
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/gettext-0.22.5-h8414b35_3.conda
+  sha256: 634e11f6e6560568ede805f823a2be8634c6a0a2fa6743880ec403d925923138
+  md5: 89b31a91b3ac2b7b3b0e5bc4eb99c39d
   depends:
-  - gettext-tools 0.22.5 h8fbad5d_2
-  - libasprintf 0.22.5 h8fbad5d_2
-  - libasprintf-devel 0.22.5 h8fbad5d_2
+  - __osx >=11.0
+  - gettext-tools 0.22.5 h8414b35_3
+  - libasprintf 0.22.5 h8414b35_3
+  - libasprintf-devel 0.22.5 h8414b35_3
   - libcxx >=16
-  - libgettextpo 0.22.5 h8fbad5d_2
-  - libgettextpo-devel 0.22.5 h8fbad5d_2
+  - libgettextpo 0.22.5 h8414b35_3
+  - libgettextpo-devel 0.22.5 h8414b35_3
   - libiconv >=1.17,<2.0a0
-  - libintl 0.22.5 h8fbad5d_2
-  - libintl-devel 0.22.5 h8fbad5d_2
+  - libintl 0.22.5 h8414b35_3
+  - libintl-devel 0.22.5 h8414b35_3
   license: LGPL-2.1-or-later AND GPL-3.0-or-later
-  size: 482649
-  timestamp: 1712512963023
+  size: 483255
+  timestamp: 1723627203687
 - kind: conda
-  name: gettext-tools
+  name: gettext
   version: 0.22.5
-  build: h2f0025b_2
-  build_number: 2
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/gettext-tools-0.22.5-h2f0025b_2.conda
-  sha256: a2fe02e43b7e0c042e01c83873da8c6c179d2cb1af04ecaf8a8c0d47d2390168
-  md5: dba96ed6fd0a19c5e52000b12221a726
-  depends:
-  - libgcc-ng >=12
-  license: GPL-3.0-or-later
-  license_family: GPL
-  size: 2993665
-  timestamp: 1712512399997
-- kind: conda
-  name: gettext-tools
-  version: 0.22.5
-  build: h59595ed_2
-  build_number: 2
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/gettext-tools-0.22.5-h59595ed_2.conda
-  sha256: 67d7b1d6fe4f1c516df2000640ec7dcfebf3ff6ea0785f0276870e730c403d33
-  md5: 985f2f453fb72408d6b6f1be0f324033
-  depends:
-  - libgcc-ng >=12
-  license: GPL-3.0-or-later
-  license_family: GPL
-  size: 2728420
-  timestamp: 1712512328692
-- kind: conda
-  name: gettext-tools
-  version: 0.22.5
-  build: h5ff76d1_2
-  build_number: 2
+  build: hdfe23c8_3
+  build_number: 3
   subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/gettext-tools-0.22.5-h5ff76d1_2.conda
-  sha256: 4db71a66340d068c57e16c574c356db6df54ac0147b5b26d3313093f7854ee6d
-  md5: 37e1cb0efeff4d4623a6357e37e0105d
+  url: https://conda.anaconda.org/conda-forge/osx-64/gettext-0.22.5-hdfe23c8_3.conda
+  sha256: f68cd35c98394dc322f2695a720b31b77a9cdfe7d5c08ce53bc68c9e3fe4c6ec
+  md5: 4e53e0f241c09fcdf674e4a37c0c70e6
   depends:
+  - __osx >=10.13
+  - gettext-tools 0.22.5 hdfe23c8_3
+  - libasprintf 0.22.5 hdfe23c8_3
+  - libasprintf-devel 0.22.5 hdfe23c8_3
+  - libcxx >=16
+  - libgettextpo 0.22.5 hdfe23c8_3
+  - libgettextpo-devel 0.22.5 hdfe23c8_3
   - libiconv >=1.17,<2.0a0
-  - libintl 0.22.5 h5ff76d1_2
-  license: GPL-3.0-or-later
-  license_family: GPL
-  size: 2501207
-  timestamp: 1712512940076
+  - libintl 0.22.5 hdfe23c8_3
+  - libintl-devel 0.22.5 hdfe23c8_3
+  license: LGPL-2.1-or-later AND GPL-3.0-or-later
+  size: 480155
+  timestamp: 1723627002489
+- kind: conda
+  name: gettext
+  version: 0.22.5
+  build: he02047a_3
+  build_number: 3
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/gettext-0.22.5-he02047a_3.conda
+  sha256: c3d9a453f523acbf2b3e1c82a42edfc7c7111b4686a2180ab48cb9b51a274218
+  md5: c7f243bbaea97cd6ea1edd693270100e
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - gettext-tools 0.22.5 he02047a_3
+  - libasprintf 0.22.5 he8f35ee_3
+  - libasprintf-devel 0.22.5 he8f35ee_3
+  - libgcc-ng >=12
+  - libgettextpo 0.22.5 he02047a_3
+  - libgettextpo-devel 0.22.5 he02047a_3
+  - libstdcxx-ng >=12
+  license: LGPL-2.1-or-later AND GPL-3.0-or-later
+  size: 479452
+  timestamp: 1723626088190
 - kind: conda
   name: gettext-tools
   version: 0.22.5
-  build: h7d00a51_2
-  build_number: 2
+  build: h0a1ffab_3
+  build_number: 3
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/gettext-tools-0.22.5-h0a1ffab_3.conda
+  sha256: 9846b9d2e3d081cc8cb9ac7800c7e02a7b63bceea8619e0c51cfa271f89afdb2
+  md5: 5fc8dfe3163ead62e0af82d97ce6b486
+  depends:
+  - libgcc-ng >=12
+  license: GPL-3.0-or-later
+  license_family: GPL
+  size: 2954814
+  timestamp: 1723626262722
+- kind: conda
+  name: gettext-tools
+  version: 0.22.5
+  build: h5a7288d_3
+  build_number: 3
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/gettext-tools-0.22.5-h7d00a51_2.conda
-  sha256: e3621dc3d48399c89bf0dd512a6a398d354429b3b84219473d674aa56e0feef2
-  md5: ef1c3bb48c013099c4872640a5f2096c
+  url: https://conda.anaconda.org/conda-forge/win-64/gettext-tools-0.22.5-h5a7288d_3.conda
+  sha256: 363dcc414ece1d82d5b031afea67901ad03edea6b5f1051bea985e699c090f13
+  md5: 7c631c844abcba0d855c7b6204d42e9d
   depends:
   - libiconv >=1.17,<2.0a0
-  - libintl 0.22.5 h5728263_2
+  - libintl 0.22.5 h5728263_3
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
   license: GPL-3.0-or-later
   license_family: GPL
-  size: 3415835
-  timestamp: 1712516856107
+  size: 3411654
+  timestamp: 1723630236515
 - kind: conda
   name: gettext-tools
   version: 0.22.5
-  build: h8fbad5d_2
-  build_number: 2
+  build: h8414b35_3
+  build_number: 3
   subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/gettext-tools-0.22.5-h8fbad5d_2.conda
-  sha256: f60d1671e30ac60598396c11fcec4426f7ddb281bf9e37af2262016b4d812cce
-  md5: 31117a80d73f4fac856ab09fd9f3c6b5
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/gettext-tools-0.22.5-h8414b35_3.conda
+  sha256: 50b530cf2326938b80330f78cf4056492fa8c6a5c7e313d92069ebbbb2f4d264
+  md5: 47071f4b2915032e1d47119f779f9d9c
   depends:
+  - __osx >=11.0
   - libiconv >=1.17,<2.0a0
-  - libintl 0.22.5 h8fbad5d_2
+  - libintl 0.22.5 h8414b35_3
   license: GPL-3.0-or-later
   license_family: GPL
-  size: 2482262
-  timestamp: 1712512901194
+  size: 2467439
+  timestamp: 1723627140130
+- kind: conda
+  name: gettext-tools
+  version: 0.22.5
+  build: hdfe23c8_3
+  build_number: 3
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/gettext-tools-0.22.5-hdfe23c8_3.conda
+  sha256: 7fe97828eae5e067b68dd012811e614e057854ed51116bbd2fd2e8d05439ad63
+  md5: 70a5bb1505016ebdba1214ba10de0503
+  depends:
+  - __osx >=10.13
+  - libiconv >=1.17,<2.0a0
+  - libintl 0.22.5 hdfe23c8_3
+  license: GPL-3.0-or-later
+  license_family: GPL
+  size: 2513986
+  timestamp: 1723626957941
+- kind: conda
+  name: gettext-tools
+  version: 0.22.5
+  build: he02047a_3
+  build_number: 3
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/gettext-tools-0.22.5-he02047a_3.conda
+  sha256: 0fd003953ce1ce9f4569458aab9ffaa397e3be2bc069250e2f05fd93b0ad2976
+  md5: fcd2016d1d299f654f81021e27496818
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc-ng >=12
+  license: GPL-3.0-or-later
+  license_family: GPL
+  size: 2750908
+  timestamp: 1723626056740
 - kind: conda
   name: gfortran
   version: 12.3.0
@@ -11623,20 +11639,19 @@ packages:
   timestamp: 1721141565277
 - kind: conda
   name: gz-sim8
-  version: 8.1.0
-  build: h57928b3_2
-  build_number: 2
+  version: 8.3.0
+  build: h57928b3_0
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/gz-sim8-8.1.0-h57928b3_2.conda
-  sha256: f201b49de6d769fc2d23759742657289e68812ece28195f773d36e412d06076e
-  md5: a8892e8d0ca04f7350690d0f74a0960b
+  url: https://conda.anaconda.org/conda-forge/win-64/gz-sim8-8.3.0-h57928b3_0.conda
+  sha256: 34f566a6cb3d8e0d8f52fb04bcfc80afb2d4610c1081675fdd4415e0030cba8d
+  md5: 292a482cc578a27c0bc187a62b125a2f
   depends:
-  - gz-sim8-python >=8.1.0,<8.1.1.0a0
-  - libgz-sim8 8.1.0 hea5eaeb_2
+  - gz-sim8-python >=8.3.0,<8.3.1.0a0
+  - libgz-sim8 8.3.0 h6914e37_0
   license: Apache-2.0
   license_family: APACHE
-  size: 12657
-  timestamp: 1709967977347
+  size: 13048
+  timestamp: 1713971647125
 - kind: conda
   name: gz-sim8
   version: 8.3.0
@@ -11699,34 +11714,6 @@ packages:
   timestamp: 1713972441777
 - kind: conda
   name: gz-sim8-python
-  version: 8.1.0
-  build: py312hd0fd4dc_2
-  build_number: 2
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/gz-sim8-python-8.1.0-py312hd0fd4dc_2.conda
-  sha256: cbf19b7f3f7f3d4abe5ed778ee4fb323d09fa61678ca30f6c935351ac3ebf554
-  md5: d97a8ab8f7fd11f6dc1179f3185151ae
-  depends:
-  - libabseil * cxx17*
-  - libabseil >=20240116.1,<20240117.0a0
-  - libgz-common5 >=5.5.0,<6.0a0
-  - libgz-physics7 >=7.0.0,<8.0a0
-  - libgz-sensors7 >=7.3.0,<8.0a0
-  - libgz-sim8 8.1.0 hea5eaeb_2
-  - libprotobuf >=4.25.3,<4.25.4.0a0
-  - pybind11-abi 4
-  - python >=3.12,<3.13.0a0
-  - python_abi 3.12.* *_cp312
-  - qt-main >=5.15.8,<5.16.0a0
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  license: Apache-2.0
-  license_family: APACHE
-  size: 147029
-  timestamp: 1709967966512
-- kind: conda
-  name: gz-sim8-python
   version: 8.3.0
   build: py310h0f8fcc8_0
   subdir: linux-aarch64
@@ -11746,6 +11733,27 @@ packages:
   license_family: APACHE
   size: 175467
   timestamp: 1713970212351
+- kind: conda
+  name: gz-sim8-python
+  version: 8.3.0
+  build: py310h595d6f7_0
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/gz-sim8-python-8.3.0-py310h595d6f7_0.conda
+  sha256: 3cd31454ad212491ffdf434f5023c2e02c0a8183038465e8cf15a0dbcf5065b5
+  md5: 12d1f45e546bcb729892cec8fed6f0c7
+  depends:
+  - libgz-common5 >=5.5.1,<6.0a0
+  - libgz-sim8 8.3.0 h6914e37_0
+  - pybind11-abi 4
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Apache-2.0
+  license_family: APACHE
+  size: 147437
+  timestamp: 1713971636279
 - kind: conda
   name: gz-sim8-python
   version: 8.3.0
@@ -11805,6 +11813,28 @@ packages:
   license_family: APACHE
   size: 166686
   timestamp: 1713972421398
+- kind: conda
+  name: h5py
+  version: 3.11.0
+  build: nompi_py310h2b0be38_102
+  build_number: 102
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/h5py-3.11.0-nompi_py310h2b0be38_102.conda
+  sha256: 7d1753e538fafea74e36c2da8c0e10d47b057a2623dbb96959395ce5b1dfc80c
+  md5: 6ea1515f0984ae6e916cc1f124e6b664
+  depends:
+  - cached-property
+  - hdf5 >=1.14.3,<1.14.4.0a0
+  - numpy >=1.19,<3
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 884907
+  timestamp: 1717665361036
 - kind: conda
   name: h5py
   version: 3.11.0
@@ -11887,28 +11917,6 @@ packages:
   license_family: BSD
   size: 1070462
   timestamp: 1717666091052
-- kind: conda
-  name: h5py
-  version: 3.11.0
-  build: nompi_py312ha036244_102
-  build_number: 102
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/h5py-3.11.0-nompi_py312ha036244_102.conda
-  sha256: 23df4d96a9eee3a3650717dd31d30b431e46dfe01f90d0e0d3ec9fc9cdc0897a
-  md5: e01e327cd56fb4a4d17743b0ddb5bceb
-  depends:
-  - cached-property
-  - hdf5 >=1.14.3,<1.14.4.0a0
-  - numpy >=1.19,<3
-  - python >=3.12,<3.13.0a0
-  - python_abi 3.12.* *_cp312
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 939154
-  timestamp: 1717666505818
 - kind: conda
   name: harfbuzz
   version: 8.5.0
@@ -12376,17 +12384,17 @@ packages:
   timestamp: 1709194196768
 - kind: conda
   name: intel-openmp
-  version: 2024.2.0
-  build: h57928b3_980
-  build_number: 980
+  version: 2024.2.1
+  build: h57928b3_1083
+  build_number: 1083
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/intel-openmp-2024.2.0-h57928b3_980.conda
-  sha256: e3ddfb67e0a922868e68f83d0b56755ff1c280ffa959a0c5ee6a922aaf7022b0
-  md5: 9c28c39e64871a0adef7d1195bd58655
+  url: https://conda.anaconda.org/conda-forge/win-64/intel-openmp-2024.2.1-h57928b3_1083.conda
+  sha256: 0fd2b0b84c854029041b0ede8f4c2369242ee92acc0092f8407b1fe9238a8209
+  md5: 2d89243bfb53652c182a7c73182cce4f
   license: LicenseRef-IntelSimplifiedSoftwareOct2022
   license_family: Proprietary
-  size: 1860328
-  timestamp: 1721088141110
+  size: 1852356
+  timestamp: 1723739573141
 - kind: conda
   name: ipopt
   version: 3.14.16
@@ -12557,24 +12565,24 @@ packages:
 - kind: conda
   name: irrlicht
   version: 1.8.5
-  build: h1344824_4
-  build_number: 4
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/irrlicht-1.8.5-h1344824_4.conda
-  sha256: 9ed28603eb7d0531923b742d75559507630ad96e534533a75a5f089edecdb086
-  md5: 65a53e41b87cffb99035952d370d6791
+  build: h20dfb44_5
+  build_number: 5
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/irrlicht-1.8.5-h20dfb44_5.conda
+  sha256: aa2de7c7d1e924437438e57b5141a407bfd6a7c69ebedeb4d9f6cd07e683f724
+  md5: 662cf5b69d72c77dc16f6e30df616cc2
   depends:
   - bzip2 >=1.0.8,<2.0a0
-  - libcxx >=15.0.7
   - libjpeg-turbo >=3.0.0,<4.0a0
-  - libpng >=1.6.39,<1.7.0a0
-  - libzlib >=1.2.13,<2.0.0a0
-  - sdl >=1.2.64,<1.3.0a0
-  - xorg-libx11 >=1.8.6,<2.0a0
-  - xorg-libxext >=1.3.4,<2.0a0
+  - libpng >=1.6.43,<1.7.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - sdl >=1.2.68,<1.3.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
   license: Zlib
-  size: 1192357
-  timestamp: 1695760649404
+  size: 1142127
+  timestamp: 1724165302309
 - kind: conda
   name: irrlicht
   version: 1.8.5
@@ -12601,48 +12609,6 @@ packages:
 - kind: conda
   name: irrlicht
   version: 1.8.5
-  build: h5bfa9a0_4
-  build_number: 4
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/irrlicht-1.8.5-h5bfa9a0_4.conda
-  sha256: d7101e0426f4a42a97adebeab203113f67ff5ab219ed7b9f71168328d338efc7
-  md5: bb0152817299dab5fe6fdd731379bad4
-  depends:
-  - bzip2 >=1.0.8,<2.0a0
-  - libcxx >=15.0.7
-  - libjpeg-turbo >=3.0.0,<4.0a0
-  - libpng >=1.6.39,<1.7.0a0
-  - libzlib >=1.2.13,<2.0.0a0
-  - sdl >=1.2.64,<1.3.0a0
-  - xorg-libx11 >=1.8.6,<2.0a0
-  - xorg-libxext >=1.3.4,<2.0a0
-  license: Zlib
-  size: 1361017
-  timestamp: 1695760594533
-- kind: conda
-  name: irrlicht
-  version: 1.8.5
-  build: h65f4d7e_4
-  build_number: 4
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/irrlicht-1.8.5-h65f4d7e_4.conda
-  sha256: 9c92bda25dcb6da671b8bc76bfdf1a36900a314f923aa4c0aa46fda653cde1e1
-  md5: 25c1d32ba2975b713f3cbab6f99c6776
-  depends:
-  - bzip2 >=1.0.8,<2.0a0
-  - libjpeg-turbo >=3.0.0,<4.0a0
-  - libpng >=1.6.39,<1.7.0a0
-  - libzlib >=1.2.13,<2.0.0a0
-  - sdl >=1.2.64,<1.3.0a0
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  license: Zlib
-  size: 1141034
-  timestamp: 1695760782225
-- kind: conda
-  name: irrlicht
-  version: 1.8.5
   build: h962fdfd_4
   build_number: 4
   subdir: linux-aarch64
@@ -12663,6 +12629,50 @@ packages:
   license: Zlib
   size: 1907558
   timestamp: 1695760464370
+- kind: conda
+  name: irrlicht
+  version: 1.8.5
+  build: hc01355b_5
+  build_number: 5
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/irrlicht-1.8.5-hc01355b_5.conda
+  sha256: 0c8e947236cb988f3c8216bc8d90f8af56a4b02ce68dbd3b9c51393e629e8efa
+  md5: 6dbd611bb92296e1c103d6cd07dddc8a
+  depends:
+  - __osx >=10.13
+  - bzip2 >=1.0.8,<2.0a0
+  - libcxx >=16
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libpng >=1.6.43,<1.7.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - sdl >=1.2.68,<1.3.0a0
+  - xorg-libx11 >=1.8.9,<2.0a0
+  - xorg-libxext >=1.3.4,<2.0a0
+  license: Zlib
+  size: 1351009
+  timestamp: 1724165176986
+- kind: conda
+  name: irrlicht
+  version: 1.8.5
+  build: hdfd4c6d_5
+  build_number: 5
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/irrlicht-1.8.5-hdfd4c6d_5.conda
+  sha256: f13abda30c917f95b012a4552f84f505ce662ddcff0a563e39f0e60b9bc131ea
+  md5: 2011bfec6849090eef9ca0e9b75abc66
+  depends:
+  - __osx >=11.0
+  - bzip2 >=1.0.8,<2.0a0
+  - libcxx >=16
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libpng >=1.6.43,<1.7.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - sdl >=1.2.68,<1.3.0a0
+  - xorg-libx11 >=1.8.9,<2.0a0
+  - xorg-libxext >=1.3.4,<2.0a0
+  license: Zlib
+  size: 1202474
+  timestamp: 1724165134357
 - kind: conda
   name: isl
   version: '0.26'
@@ -13184,6 +13194,25 @@ packages:
 - kind: conda
   name: kiwisolver
   version: 1.4.5
+  build: py310h232114e_1
+  build_number: 1
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/kiwisolver-1.4.5-py310h232114e_1.conda
+  sha256: 8969469887a0b72f732ec9250fd25982499270bda473a5db4c04ee252db96d89
+  md5: a340ed8a9c513e2782cb7feb3cfe665d
+  depends:
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 55587
+  timestamp: 1695380469062
+- kind: conda
+  name: kiwisolver
+  version: 1.4.5
   build: py310hd41b1e2_1
   build_number: 1
   subdir: linux-64
@@ -13234,25 +13263,6 @@ packages:
   license_family: BSD
   size: 60694
   timestamp: 1695380246398
-- kind: conda
-  name: kiwisolver
-  version: 1.4.5
-  build: py312h0d7def4_1
-  build_number: 1
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/kiwisolver-1.4.5-py312h0d7def4_1.conda
-  sha256: 07021ffc3bbf42922694c23634e028950547d088717b448b46296b3ca5a26068
-  md5: 77c9d46fc8680bb08f4e1ebb6669e44e
-  depends:
-  - python >=3.12.0rc3,<3.13.0a0
-  - python_abi 3.12.* *_cp312
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 55576
-  timestamp: 1695380565733
 - kind: conda
   name: kiwisolver
   version: 1.4.5
@@ -13992,141 +14002,151 @@ packages:
 - kind: conda
   name: libasprintf
   version: 0.22.5
-  build: h5728263_2
-  build_number: 2
+  build: h5728263_3
+  build_number: 3
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libasprintf-0.22.5-h5728263_2.conda
-  sha256: 5722a4a260355c9233680a3424a977433f25826ca0a1c05af403d62b805681bc
-  md5: 75a6982b9ff0a8db0f53303527b07af8
+  url: https://conda.anaconda.org/conda-forge/win-64/libasprintf-0.22.5-h5728263_3.conda
+  sha256: 8e41136b7e4ec44c1c0bae0ff51cdb0d04e026d0b44eaaf5a9ff8b4e1b6b019b
+  md5: 9f661052be1d477dcf61ee3cd77ce5ee
   license: LGPL-2.1-or-later
-  size: 49778
-  timestamp: 1712515968238
+  size: 49776
+  timestamp: 1723629333404
 - kind: conda
   name: libasprintf
   version: 0.22.5
-  build: h5ff76d1_2
-  build_number: 2
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/libasprintf-0.22.5-h5ff76d1_2.conda
-  sha256: 4babb29b8d39ae8b341c094c134a1917c595846e5f974c9d0cb64d3f734b46b1
-  md5: ad803793d7168331f1395685cbdae212
+  build: h8414b35_3
+  build_number: 3
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libasprintf-0.22.5-h8414b35_3.conda
+  sha256: 819bf95543470658f48db53a267a3fabe1616797c4031cf88e63f451c5029e6f
+  md5: 472b673c083175195965a48f2f4808f8
+  depends:
+  - __osx >=11.0
+  - libcxx >=16
   license: LGPL-2.1-or-later
-  size: 40438
-  timestamp: 1712512749697
+  size: 40657
+  timestamp: 1723626937704
 - kind: conda
   name: libasprintf
   version: 0.22.5
-  build: h661eb56_2
-  build_number: 2
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libasprintf-0.22.5-h661eb56_2.conda
-  sha256: 31d58af7eb54e2938123200239277f14893c5fa4b5d0280c8cf55ae10000638b
-  md5: dd197c968bf9760bba0031888d431ede
+  build: h87f4aca_3
+  build_number: 3
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libasprintf-0.22.5-h87f4aca_3.conda
+  sha256: b438814a7190a541950da68d3cde8ecbcc55629ce677eb65afbb01cfa1e4e651
+  md5: 332ce64c2dec75dc0849e7ffcdf7a3a4
   depends:
   - libgcc-ng >=12
   - libstdcxx-ng >=12
   license: LGPL-2.1-or-later
-  size: 43226
-  timestamp: 1712512265295
+  size: 42627
+  timestamp: 1723626204541
 - kind: conda
   name: libasprintf
   version: 0.22.5
-  build: h7b6a552_2
-  build_number: 2
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libasprintf-0.22.5-h7b6a552_2.conda
-  sha256: 8c2b54f0d9fd4331feb995f04eb9d5819de11fa8f33e5c5c392e7ff326106331
-  md5: 1c027a1a3c07fe94729870c85ef44cfd
+  build: hdfe23c8_3
+  build_number: 3
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/libasprintf-0.22.5-hdfe23c8_3.conda
+  sha256: 9c6f3e2558e098dbbc63c9884b4af368ea6cc4185ea027563ac4f5ee8571b143
+  md5: 55363e1d53635b3497cdf753ab0690c1
   depends:
+  - __osx >=10.13
+  - libcxx >=16
+  license: LGPL-2.1-or-later
+  size: 40442
+  timestamp: 1723626787726
+- kind: conda
+  name: libasprintf
+  version: 0.22.5
+  build: he8f35ee_3
+  build_number: 3
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libasprintf-0.22.5-he8f35ee_3.conda
+  sha256: 2da5c735811cbf38c7f7844ab457ff8b25046bbf5fe5ebd5dc1c2fafdf4fbe1c
+  md5: 4fab9799da9571266d05ca5503330655
+  depends:
+  - __glibc >=2.17,<3.0.a0
   - libgcc-ng >=12
   - libstdcxx-ng >=12
   license: LGPL-2.1-or-later
-  size: 42533
-  timestamp: 1712512336201
-- kind: conda
-  name: libasprintf
-  version: 0.22.5
-  build: h8fbad5d_2
-  build_number: 2
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libasprintf-0.22.5-h8fbad5d_2.conda
-  sha256: 04bbe4374719906cd08b639a3f34828030f405c33b47c757b47fd55aa7310179
-  md5: 1b27402397a76115679c4855ab2ece41
-  license: LGPL-2.1-or-later
-  size: 40630
-  timestamp: 1712512727388
+  size: 42817
+  timestamp: 1723626012203
 - kind: conda
   name: libasprintf-devel
   version: 0.22.5
-  build: h5728263_2
-  build_number: 2
+  build: h5728263_3
+  build_number: 3
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libasprintf-devel-0.22.5-h5728263_2.conda
-  sha256: d5c711d9da4e35d29f4f2191664075c64cbf8cd481a35bf7ef3a527018eb0184
-  md5: 8377da2cc31200d7181d2e48d60e4c7b
+  url: https://conda.anaconda.org/conda-forge/win-64/libasprintf-devel-0.22.5-h5728263_3.conda
+  sha256: bc04e8255b7f2edea6eb74fe0ee2eba7ce58d002de4f9bc57946f2b89bada062
+  md5: 524de7ba10ea8a2d85286beac4654119
   depends:
-  - libasprintf 0.22.5 h5728263_2
+  - libasprintf 0.22.5 h5728263_3
   license: LGPL-2.1-or-later
-  size: 36272
-  timestamp: 1712516175913
+  size: 36244
+  timestamp: 1723629552895
 - kind: conda
   name: libasprintf-devel
   version: 0.22.5
-  build: h5ff76d1_2
-  build_number: 2
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/libasprintf-devel-0.22.5-h5ff76d1_2.conda
-  sha256: 39fa757378b49993142013c1f69dd56248cc3703c2f04c5bcf4cc4acdc644ae3
-  md5: c7182eda3bc727384e2f98f4d680fa7d
-  depends:
-  - libasprintf 0.22.5 h5ff76d1_2
-  license: LGPL-2.1-or-later
-  size: 34702
-  timestamp: 1712512806211
-- kind: conda
-  name: libasprintf-devel
-  version: 0.22.5
-  build: h661eb56_2
-  build_number: 2
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libasprintf-devel-0.22.5-h661eb56_2.conda
-  sha256: 99d26d272a8203d30b3efbe734a99c823499884d7759b4291674438137c4b5ca
-  md5: 02e41ab5834dcdcc8590cf29d9526f50
-  depends:
-  - libasprintf 0.22.5 h661eb56_2
-  - libgcc-ng >=12
-  license: LGPL-2.1-or-later
-  size: 34225
-  timestamp: 1712512295117
-- kind: conda
-  name: libasprintf-devel
-  version: 0.22.5
-  build: h7b6a552_2
-  build_number: 2
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libasprintf-devel-0.22.5-h7b6a552_2.conda
-  sha256: 36610080b9dd4022783a9cd47e1028df7ee4f4a541145f6f71ddc66c5a1e021b
-  md5: 47aeae64e19437c16e1c2afdad154cd8
-  depends:
-  - libasprintf 0.22.5 h7b6a552_2
-  - libgcc-ng >=12
-  license: LGPL-2.1-or-later
-  size: 34395
-  timestamp: 1712512362335
-- kind: conda
-  name: libasprintf-devel
-  version: 0.22.5
-  build: h8fbad5d_2
-  build_number: 2
+  build: h8414b35_3
+  build_number: 3
   subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libasprintf-devel-0.22.5-h8fbad5d_2.conda
-  sha256: f5331486854a5fe80bb837891efb28a28623f762327372cb4cbc264c9c4bf9e2
-  md5: 480c106e87d4c4791e6b55a6d1678866
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libasprintf-devel-0.22.5-h8414b35_3.conda
+  sha256: ca7322f7c3f1a68cb36630eaa88a44c774261150d42d70a4be3d77bc9ed28d5d
+  md5: a03ca97f9fabf5626660697c2e0b8850
   depends:
-  - libasprintf 0.22.5 h8fbad5d_2
+  - __osx >=11.0
+  - libasprintf 0.22.5 h8414b35_3
   license: LGPL-2.1-or-later
-  size: 34625
-  timestamp: 1712512769736
+  size: 34648
+  timestamp: 1723626983419
+- kind: conda
+  name: libasprintf-devel
+  version: 0.22.5
+  build: h87f4aca_3
+  build_number: 3
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libasprintf-devel-0.22.5-h87f4aca_3.conda
+  sha256: c9eda86140a5a023b72a8997f82629f4b071df17d57d00ba75a66b65a0525a5e
+  md5: dbaa9d8c0030bda3e3d22d325ea48191
+  depends:
+  - libasprintf 0.22.5 h87f4aca_3
+  - libgcc-ng >=12
+  license: LGPL-2.1-or-later
+  size: 34359
+  timestamp: 1723626223953
+- kind: conda
+  name: libasprintf-devel
+  version: 0.22.5
+  build: hdfe23c8_3
+  build_number: 3
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/libasprintf-devel-0.22.5-hdfe23c8_3.conda
+  sha256: 408e59cc215b654b292f503d37552d319e71180d33798867975377c28fd3c6b3
+  md5: e2ae0568825e62d439a921fdc7f6db64
+  depends:
+  - __osx >=10.13
+  - libasprintf 0.22.5 hdfe23c8_3
+  license: LGPL-2.1-or-later
+  size: 34522
+  timestamp: 1723626838677
+- kind: conda
+  name: libasprintf-devel
+  version: 0.22.5
+  build: he8f35ee_3
+  build_number: 3
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libasprintf-devel-0.22.5-he8f35ee_3.conda
+  sha256: ccc7967e298ddf3124c8ad9741c7180dc6f778ae4135ec87978214f7b3c64dc2
+  md5: 1091193789bb830127ed067a9e01ac57
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libasprintf 0.22.5 he8f35ee_3
+  - libgcc-ng >=12
+  license: LGPL-2.1-or-later
+  size: 34172
+  timestamp: 1723626026096
 - kind: conda
   name: libass
   version: 0.17.1
@@ -14586,6 +14606,28 @@ packages:
 - kind: conda
   name: libboost-python
   version: 1.84.0
+  build: py310h3e8ed56_5
+  build_number: 5
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/libboost-python-1.84.0-py310h3e8ed56_5.conda
+  sha256: 330218440bbc2edab72b7254216c146460e2b92bb0a4007bbf36c6fd4e0516f7
+  md5: 21806c2c0a308b07bc744ac33fcd2cc8
+  depends:
+  - numpy >=1.19,<3
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  constrains:
+  - py-boost <0.0a0
+  - boost =1.84.0
+  license: BSL-1.0
+  size: 114259
+  timestamp: 1722291848177
+- kind: conda
+  name: libboost-python
+  version: 1.84.0
   build: py310hdc2ec55_3
   build_number: 3
   subdir: linux-aarch64
@@ -14650,28 +14692,6 @@ packages:
 - kind: conda
   name: libboost-python
   version: 1.84.0
-  build: py312hbaa7e33_5
-  build_number: 5
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libboost-python-1.84.0-py312hbaa7e33_5.conda
-  sha256: 907dfba63f9e8e3fbfb3c6b5b018c327b26bed13db8537ad2ee73c9b4319dfd4
-  md5: 85ce716981c6f23948c7aa21db336e54
-  depends:
-  - numpy >=1.19,<3
-  - python >=3.12,<3.13.0a0
-  - python_abi 3.12.* *_cp312
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  constrains:
-  - py-boost <0.0a0
-  - boost =1.84.0
-  license: BSL-1.0
-  size: 114638
-  timestamp: 1722291673733
-- kind: conda
-  name: libboost-python
-  version: 1.84.0
   build: py312hffe1f2a_3
   build_number: 3
   subdir: osx-arm64
@@ -14691,6 +14711,27 @@ packages:
   license: BSL-1.0
   size: 107933
   timestamp: 1715811895637
+- kind: conda
+  name: libboost-python-devel
+  version: 1.84.0
+  build: py310h05ea346_5
+  build_number: 5
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/libboost-python-devel-1.84.0-py310h05ea346_5.conda
+  sha256: 3756b48903905ae0e57af14e36cce744487703f8d5ca955c8a1cdb98bac5af25
+  md5: 4b27152a33696aae5bd65fc98fd27718
+  depends:
+  - libboost-devel 1.84.0 h91493d7_5
+  - libboost-python 1.84.0 py310h3e8ed56_5
+  - numpy >=1.19,<3
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  constrains:
+  - py-boost <0.0a0
+  - boost =1.84.0
+  license: BSL-1.0
+  size: 20901
+  timestamp: 1722292789918
 - kind: conda
   name: libboost-python-devel
   version: 1.84.0
@@ -14754,27 +14795,6 @@ packages:
   license: BSL-1.0
   size: 20293
   timestamp: 1715809749586
-- kind: conda
-  name: libboost-python-devel
-  version: 1.84.0
-  build: py312h7e22eef_5
-  build_number: 5
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libboost-python-devel-1.84.0-py312h7e22eef_5.conda
-  sha256: e3aa8224a5518d5924f554cf1af61b4a7a71351eeaf51989fd25fb7ed9a3620b
-  md5: d27bd7afac3b2aa64f7cfaf2585e626b
-  depends:
-  - libboost-devel 1.84.0 h91493d7_5
-  - libboost-python 1.84.0 py312hbaa7e33_5
-  - numpy >=1.19,<3
-  - python >=3.12,<3.13.0a0
-  - python_abi 3.12.* *_cp312
-  constrains:
-  - py-boost <0.0a0
-  - boost =1.84.0
-  license: BSL-1.0
-  size: 20890
-  timestamp: 1722292684311
 - kind: conda
   name: libboost-python-devel
   version: 1.84.0
@@ -15675,33 +15695,33 @@ packages:
 - kind: conda
   name: libcxx
   version: 18.1.8
-  build: h5a72898_2
-  build_number: 2
+  build: h5a72898_4
+  build_number: 4
   subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libcxx-18.1.8-h5a72898_2.conda
-  sha256: ed8d2977f87ca6221d17eb1b9272db5766d86d51c7fcb6135e5cf81aee516c8f
-  md5: 2d8d36fada9497ebc35894189fb52b7a
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libcxx-18.1.8-h5a72898_4.conda
+  sha256: 997e68bea725ade25ba71bc1a9fce5d7e5c37cccec6bc7656124d0d31743584d
+  md5: 8c71928e2e5c78129e4ccd752ef33e12
   depends:
   - __osx >=11.0
   license: Apache-2.0 WITH LLVM-exception
   license_family: Apache
-  size: 1217224
-  timestamp: 1722895989109
+  size: 1216058
+  timestamp: 1723637781569
 - kind: conda
   name: libcxx
   version: 18.1.8
-  build: heced48a_2
-  build_number: 2
+  build: heced48a_4
+  build_number: 4
   subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/libcxx-18.1.8-heced48a_2.conda
-  sha256: e4df0dfd5fcc1e4ece36fb6b09f44436584df961c5cdbf328581522ff8d033b6
-  md5: 8c8198f9e93fcc0fd359ff37b4a8cd2d
+  url: https://conda.anaconda.org/conda-forge/osx-64/libcxx-18.1.8-heced48a_4.conda
+  sha256: e6ad2e71bc9f2ee8fdcce7596baf5041941f69be5ffef478aaffd673f0691daf
+  md5: 7e13da1296840905452340fca10a625b
   depends:
   - __osx >=10.13
   license: Apache-2.0 WITH LLVM-exception
   license_family: Apache
-  size: 1221836
-  timestamp: 1722895766052
+  size: 1268903
+  timestamp: 1723637719063
 - kind: conda
   name: libdb
   version: 6.2.32
@@ -15941,6 +15961,33 @@ packages:
   license_family: BSD
   size: 134104
   timestamp: 1597617110769
+- kind: conda
+  name: libegl
+  version: 1.7.0
+  build: ha4b6fd6_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libegl-1.7.0-ha4b6fd6_0.conda
+  sha256: d577ab061760e631c2980eb88d6970e43391c461a89fc7cd6f98e2999d626d44
+  md5: 35e52d19547cb3265a09c49de146a5ae
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libglvnd 1.7.0 ha4b6fd6_0
+  license: LicenseRef-libglvnd
+  size: 44492
+  timestamp: 1723473193819
+- kind: conda
+  name: libegl
+  version: 1.7.0
+  build: hd24410f_0
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libegl-1.7.0-hd24410f_0.conda
+  sha256: 6906ca8d9e868a88150b4e2cf4821acb5a46cd31724b2da67aced65d6720c443
+  md5: 5f0828a40c82e542e3235e02f6c2dffd
+  depends:
+  - libglvnd 1.7.0 hd24410f_0
+  license: LicenseRef-libglvnd
+  size: 53467
+  timestamp: 1723474989555
 - kind: conda
   name: libev
   version: '4.33'
@@ -16800,164 +16847,170 @@ packages:
 - kind: conda
   name: libgettextpo
   version: 0.22.5
-  build: h2f0025b_2
-  build_number: 2
+  build: h0a1ffab_3
+  build_number: 3
   subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libgettextpo-0.22.5-h2f0025b_2.conda
-  sha256: 591e448ca1bdc4c77d694ec76178fc693c394813a68149a5d83799e45c89c4c3
-  md5: 0e5887b1c0a764c098102729ed80afee
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libgettextpo-0.22.5-h0a1ffab_3.conda
+  sha256: f816747b63432def4bfe2bfa517057149b2b94a48101fe13e7fcc2c223ec2042
+  md5: 263a0b8af4b3fcdb35acc4038bb5bff5
   depends:
   - libgcc-ng >=12
   license: GPL-3.0-or-later
   license_family: GPL
-  size: 200431
-  timestamp: 1712512353023
+  size: 199824
+  timestamp: 1723626215655
 - kind: conda
   name: libgettextpo
   version: 0.22.5
-  build: h5728263_2
-  build_number: 2
+  build: h5728263_3
+  build_number: 3
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libgettextpo-0.22.5-h5728263_2.conda
-  sha256: 445ecfc4bf5b474c2ac79f716dcb8459a08a532ab13a785744665f086ef94c95
-  md5: f4c826b19bf1ccee2a63a2c685039728
+  url: https://conda.anaconda.org/conda-forge/win-64/libgettextpo-0.22.5-h5728263_3.conda
+  sha256: 6747bd29a0896b21ee1fe07bd212210475655354a3e8033c25b797e054ddd821
+  md5: e46c142e2d2d9ccef31ad3d176b10fab
   depends:
   - libiconv >=1.17,<2.0a0
-  - libintl 0.22.5 h5728263_2
+  - libintl 0.22.5 h5728263_3
   license: GPL-3.0-or-later
   license_family: GPL
-  size: 171210
-  timestamp: 1712516290149
+  size: 171120
+  timestamp: 1723629671164
 - kind: conda
   name: libgettextpo
   version: 0.22.5
-  build: h59595ed_2
-  build_number: 2
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libgettextpo-0.22.5-h59595ed_2.conda
-  sha256: e2f784564a2bdc6f753f00f63cc77c97601eb03bc89dccc4413336ec6d95490b
-  md5: 172bcc51059416e7ce99e7b528cede83
+  build: h8414b35_3
+  build_number: 3
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libgettextpo-0.22.5-h8414b35_3.conda
+  sha256: bc446fad58155e96a01b28e99254415c2151bdddf57f9a2c00c44e6f0298bb62
+  md5: c8cd7295cfb7bda5cbabea4fef904349
   depends:
+  - __osx >=11.0
+  - libiconv >=1.17,<2.0a0
+  - libintl 0.22.5 h8414b35_3
+  license: GPL-3.0-or-later
+  license_family: GPL
+  size: 159800
+  timestamp: 1723627007035
+- kind: conda
+  name: libgettextpo
+  version: 0.22.5
+  build: hdfe23c8_3
+  build_number: 3
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/libgettextpo-0.22.5-hdfe23c8_3.conda
+  sha256: 8f7631d03a093272a5a8423181ac2c66514503e082e5494a2e942737af8a34ad
+  md5: ba6eeccaee150e24a544be8ae71aeca1
+  depends:
+  - __osx >=10.13
+  - libiconv >=1.17,<2.0a0
+  - libintl 0.22.5 hdfe23c8_3
+  license: GPL-3.0-or-later
+  license_family: GPL
+  size: 172305
+  timestamp: 1723626852373
+- kind: conda
+  name: libgettextpo
+  version: 0.22.5
+  build: he02047a_3
+  build_number: 3
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgettextpo-0.22.5-he02047a_3.conda
+  sha256: 7f2d1f4d69973e2c3c3d2b6420d5eb989982baba97d63ab2d7a2b25a92d886b4
+  md5: efab66b82ec976930b96d62a976de8e7
+  depends:
+  - __glibc >=2.17,<3.0.a0
   - libgcc-ng >=12
   license: GPL-3.0-or-later
   license_family: GPL
-  size: 170582
-  timestamp: 1712512286907
-- kind: conda
-  name: libgettextpo
-  version: 0.22.5
-  build: h5ff76d1_2
-  build_number: 2
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/libgettextpo-0.22.5-h5ff76d1_2.conda
-  sha256: 139d1861e21c41b950ebf9e395db2492839337a3b481ad2901a4a6800c555e37
-  md5: 54cc9d12c29c2f0516f2ef4987de53ae
-  depends:
-  - libiconv >=1.17,<2.0a0
-  - libintl 0.22.5 h5ff76d1_2
-  license: GPL-3.0-or-later
-  license_family: GPL
-  size: 172506
-  timestamp: 1712512827340
-- kind: conda
-  name: libgettextpo
-  version: 0.22.5
-  build: h8fbad5d_2
-  build_number: 2
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libgettextpo-0.22.5-h8fbad5d_2.conda
-  sha256: c3f5580e172c3fc03d33e8994024f08b709a239bd599792e51435fa7a06beb64
-  md5: a66fad933e22d22599a6dd149d359d25
-  depends:
-  - libiconv >=1.17,<2.0a0
-  - libintl 0.22.5 h8fbad5d_2
-  license: GPL-3.0-or-later
-  license_family: GPL
-  size: 159856
-  timestamp: 1712512788407
+  size: 170646
+  timestamp: 1723626019265
 - kind: conda
   name: libgettextpo-devel
   version: 0.22.5
-  build: h2f0025b_2
-  build_number: 2
+  build: h0a1ffab_3
+  build_number: 3
   subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libgettextpo-devel-0.22.5-h2f0025b_2.conda
-  sha256: 83c9e0ab845176a9b1738c0415a007f2b9bcc2f23e5520f9e17d8454b0f92676
-  md5: 63e625fa42d34b50b8814447a17771bd
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libgettextpo-devel-0.22.5-h0a1ffab_3.conda
+  sha256: 677df7af241b36c6b06dff52528c2a8e4f42f8cf40d962e693caa707b563c86c
+  md5: 5c1498c4da030824d57072f05220aad8
   depends:
   - libgcc-ng >=12
-  - libgettextpo 0.22.5 h2f0025b_2
+  - libgettextpo 0.22.5 h0a1ffab_3
   license: GPL-3.0-or-later
   license_family: GPL
-  size: 36999
-  timestamp: 1712512372984
+  size: 36989
+  timestamp: 1723626232155
 - kind: conda
   name: libgettextpo-devel
   version: 0.22.5
-  build: h5728263_2
-  build_number: 2
+  build: h5728263_3
+  build_number: 3
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libgettextpo-devel-0.22.5-h5728263_2.conda
-  sha256: bcee730b2be23ba9aa5de3471b78c4644d3b17d5a71e7fdc59bb40e252edb2f7
-  md5: 6f42ec61abc6d52a4079800a640319c5
+  url: https://conda.anaconda.org/conda-forge/win-64/libgettextpo-devel-0.22.5-h5728263_3.conda
+  sha256: 5039a89ebb9751408a2f507afb344241afe47a4e1b06c281af2decf5b734f79a
+  md5: e618841b85fefbb8b76d2caa163baaec
   depends:
-  - libgettextpo 0.22.5 h5728263_2
+  - libgettextpo 0.22.5 h5728263_3
   - libiconv >=1.17,<2.0a0
-  - libintl 0.22.5 h5728263_2
+  - libintl 0.22.5 h5728263_3
   license: GPL-3.0-or-later
   license_family: GPL
-  size: 40312
-  timestamp: 1712516436925
+  size: 40036
+  timestamp: 1723629819549
 - kind: conda
   name: libgettextpo-devel
   version: 0.22.5
-  build: h59595ed_2
-  build_number: 2
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libgettextpo-devel-0.22.5-h59595ed_2.conda
-  sha256: 695eb2439ad4a89e4205dd675cc52fba5cef6b5d41b83f07cdbf4770a336cc15
-  md5: b63d9b6da3653179a278077f0de20014
-  depends:
-  - libgcc-ng >=12
-  - libgettextpo 0.22.5 h59595ed_2
-  license: GPL-3.0-or-later
-  license_family: GPL
-  size: 36758
-  timestamp: 1712512303244
-- kind: conda
-  name: libgettextpo-devel
-  version: 0.22.5
-  build: h5ff76d1_2
-  build_number: 2
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/libgettextpo-devel-0.22.5-h5ff76d1_2.conda
-  sha256: 57940f6a872ffcf5a3406e96bdbd9d25854943e4dd84acee56178ffb728a9671
-  md5: 1e0384c52cd8b54812912e7234e66056
-  depends:
-  - libgettextpo 0.22.5 h5ff76d1_2
-  - libiconv >=1.17,<2.0a0
-  - libintl 0.22.5 h5ff76d1_2
-  license: GPL-3.0-or-later
-  license_family: GPL
-  size: 37189
-  timestamp: 1712512859854
-- kind: conda
-  name: libgettextpo-devel
-  version: 0.22.5
-  build: h8fbad5d_2
-  build_number: 2
+  build: h8414b35_3
+  build_number: 3
   subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libgettextpo-devel-0.22.5-h8fbad5d_2.conda
-  sha256: b1be0bb8a726e2c47a025ff348e6ba8b51ef668f6ace06694657025d84ae66e2
-  md5: 1113aa220b042b7ce8d077ea8f696f98
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libgettextpo-devel-0.22.5-h8414b35_3.conda
+  sha256: ea3ca757bf11ed25965b39466b50411c7c2a43f3b90ab4a36fc0ef43f7ab98ac
+  md5: 7074dc1c9aae1bb5d7bccb4ff03746ca
   depends:
-  - libgettextpo 0.22.5 h8fbad5d_2
+  - __osx >=11.0
+  - libgettextpo 0.22.5 h8414b35_3
   - libiconv >=1.17,<2.0a0
-  - libintl 0.22.5 h8fbad5d_2
+  - libintl 0.22.5 h8414b35_3
   license: GPL-3.0-or-later
   license_family: GPL
-  size: 37221
-  timestamp: 1712512820461
+  size: 37153
+  timestamp: 1723627048279
+- kind: conda
+  name: libgettextpo-devel
+  version: 0.22.5
+  build: hdfe23c8_3
+  build_number: 3
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/libgettextpo-devel-0.22.5-hdfe23c8_3.conda
+  sha256: 8ea6bcba8c002f547edfd51e27e1e81465c8838033877c56439d20bcbc8f32a3
+  md5: efbba22e1657ef214c9ce9105b2ca562
+  depends:
+  - __osx >=10.13
+  - libgettextpo 0.22.5 hdfe23c8_3
+  - libiconv >=1.17,<2.0a0
+  - libintl 0.22.5 hdfe23c8_3
+  license: GPL-3.0-or-later
+  license_family: GPL
+  size: 36977
+  timestamp: 1723626874373
+- kind: conda
+  name: libgettextpo-devel
+  version: 0.22.5
+  build: he02047a_3
+  build_number: 3
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgettextpo-devel-0.22.5-he02047a_3.conda
+  sha256: 0a66cdd46d1cd5201061252535cd91905b3222328a9294c1a5bcd32e85531545
+  md5: 9aba7960731e6b4547b3a52f812ed801
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc-ng >=12
+  - libgettextpo 0.22.5 he02047a_3
+  license: GPL-3.0-or-later
+  license_family: GPL
+  size: 36790
+  timestamp: 1723626032786
 - kind: conda
   name: libgfortran
   version: 5.0.0
@@ -17111,6 +17164,35 @@ packages:
   size: 1457561
   timestamp: 1719538909168
 - kind: conda
+  name: libgl
+  version: 1.7.0
+  build: ha4b6fd6_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgl-1.7.0-ha4b6fd6_0.conda
+  sha256: 993f3bfe04e16c58fceab108bf54f1522ff93a657a22a4ced8c56658001d55fa
+  md5: 3deca8c25851196c28d1c84dd4ae9149
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libglvnd 1.7.0 ha4b6fd6_0
+  - libglx 1.7.0 ha4b6fd6_0
+  license: LicenseRef-libglvnd
+  size: 132746
+  timestamp: 1723473216625
+- kind: conda
+  name: libgl
+  version: 1.7.0
+  build: hd24410f_0
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libgl-1.7.0-hd24410f_0.conda
+  sha256: 4899e7f5013fe316480de1582e0803bcb7c6f24124ff92ad711d2f23c8573f9d
+  md5: 4a07dfe441cea9331f7117e1d28b4af3
+  depends:
+  - libglvnd 1.7.0 hd24410f_0
+  - libglx 1.7.0 hd24410f_0
+  license: LicenseRef-libglvnd
+  size: 145952
+  timestamp: 1723475015909
+- kind: conda
   name: libglib
   version: 2.80.2
   build: h0df6a38_0
@@ -17250,6 +17332,30 @@ packages:
   size: 317590
   timestamp: 1694431968293
 - kind: conda
+  name: libglvnd
+  version: 1.7.0
+  build: ha4b6fd6_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libglvnd-1.7.0-ha4b6fd6_0.conda
+  sha256: ce35ceca19110ba9d27cb0058e55c62ea0489b3dfad76d016df2d0bf4f027998
+  md5: e46b5ae31282252e0525713e34ffbe2b
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  license: LicenseRef-libglvnd
+  size: 129500
+  timestamp: 1723473188457
+- kind: conda
+  name: libglvnd
+  version: 1.7.0
+  build: hd24410f_0
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libglvnd-1.7.0-hd24410f_0.conda
+  sha256: cd3c02630dbeeda08dd5fa6c06628b6a4ca38d6ed1c2471ade769a0fdba36873
+  md5: 302d86324040dad17ef3c71a9171a1fb
+  license: LicenseRef-libglvnd
+  size: 135960
+  timestamp: 1723474980802
+- kind: conda
   name: libglvnd-cos7-aarch64
   version: 1.0.1
   build: h9b0a68f_1105
@@ -17315,6 +17421,35 @@ packages:
   license_family: MIT
   size: 180318
   timestamp: 1627502249243
+- kind: conda
+  name: libglx
+  version: 1.7.0
+  build: ha4b6fd6_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libglx-1.7.0-ha4b6fd6_0.conda
+  sha256: 72ba2a55de3d8902b40359433bbc51f50574067eaf2ae4081a2347d3735e30bb
+  md5: b470cc353c5b852e0d830e8d5d23e952
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libglvnd 1.7.0 ha4b6fd6_0
+  - xorg-libx11 >=1.8.9,<2.0a0
+  license: LicenseRef-libglvnd
+  size: 79343
+  timestamp: 1723473207891
+- kind: conda
+  name: libglx
+  version: 1.7.0
+  build: hd24410f_0
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libglx-1.7.0-hd24410f_0.conda
+  sha256: 1317e6f4f80f786f059c6076a800b0835f02209e3aaea6539564d58ccc76a127
+  md5: 391ac90a070791bc5182f93de5c46f1c
+  depends:
+  - libglvnd 1.7.0 hd24410f_0
+  - xorg-libx11 >=1.8.9,<2.0a0
+  license: LicenseRef-libglvnd
+  size: 78114
+  timestamp: 1723475005041
 - kind: conda
   name: libgomp
   version: 14.1.0
@@ -18421,29 +18556,6 @@ packages:
   size: 1821444
   timestamp: 1716340061241
 - kind: conda
-  name: libgz-msgs9
-  version: 9.5.0
-  build: h76d1f87_8
-  build_number: 8
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libgz-msgs9-9.5.0-h76d1f87_8.conda
-  sha256: 67d2aad0dc70ede9eeeedd2352e15c6b4bf84c8e1d94ed6a80aeb8aba7fd59b8
-  md5: 5ce1dba7736f77ba7e755d174f4e5191
-  depends:
-  - libabseil * cxx17*
-  - libabseil >=20240116.1,<20240117.0a0
-  - libgz-math7 >=7.3.0,<8.0a0
-  - libgz-tools2 >=2.0.0,<3.0a0
-  - libprotobuf >=4.25.3,<4.25.4.0a0
-  - tinyxml2 >=10.0.0,<11.0a0
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  license: Apache-2.0
-  license_family: APACHE
-  size: 1921413
-  timestamp: 1709785749044
-- kind: conda
   name: libgz-physics7
   version: 7.2.0
   build: h198f548_1
@@ -18663,29 +18775,6 @@ packages:
   size: 209406
   timestamp: 1712618256072
 - kind: conda
-  name: libgz-rendering7
-  version: 7.4.2
-  build: h63175ca_1
-  build_number: 1
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libgz-rendering7-7.4.2-h63175ca_1.conda
-  sha256: b7d2f15a02471366f0b2bf23c52012f03d7b69151da5e4330c408406b17f39bb
-  md5: 40b0621d390b902997080fbc04ed557f
-  depends:
-  - libgz-common5 >=5.5.1,<6.0a0
-  - libgz-math7 >=7.3.0,<8.0a0
-  - libgz-plugin2 >=2.0.3,<3.0a0
-  - libgz-utils2 >=2.1.0,<3.0a0
-  - ogre >=1.10.12.1,<1.11.0a0
-  - ogre-next >=2.3.3,<2.3.4.0a0
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  license: Apache-2.0
-  license_family: APACHE
-  size: 3147462
-  timestamp: 1714686094167
-- kind: conda
   name: libgz-rendering8
   version: 8.1.1
   build: h2f0025b_1
@@ -18805,35 +18894,6 @@ packages:
   license_family: APACHE
   size: 3629950
   timestamp: 1713964243979
-- kind: conda
-  name: libgz-sensors7
-  version: 7.3.0
-  build: h89268de_6
-  build_number: 6
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libgz-sensors7-7.3.0-h89268de_6.conda
-  sha256: e7dbeda9b9a8002692f0e9c411ff7ce23c96cf490bdc46709406a585645c8fae
-  md5: 1efca3a3eacd9c3340cdea6027f84202
-  depends:
-  - libabseil * cxx17*
-  - libabseil >=20240116.1,<20240117.0a0
-  - libgz-cmake3 >=3.4.1,<4.0a0
-  - libgz-common5 >=5.5.0,<6.0a0
-  - libgz-math7 >=7.3.0,<8.0a0
-  - libgz-msgs9 >=9.5.0,<10.0a0
-  - libgz-plugin2 >=2.0.2,<3.0a0
-  - libgz-rendering7 >=7.4.2,<8.0a0
-  - libgz-transport12 >=12.2.1,<13.0a0
-  - libprotobuf >=4.25.3,<4.25.4.0a0
-  - libsdformat13 >=13.6.0,<14.0a0
-  - ogre >=1.10.12.1,<1.11.0a0
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  license: Apache-2.0
-  license_family: APACHE
-  size: 301565
-  timestamp: 1709930332625
 - kind: conda
   name: libgz-sensors8
   version: 8.0.0
@@ -18978,44 +19038,6 @@ packages:
   timestamp: 1709925205123
 - kind: conda
   name: libgz-sim8
-  version: 8.1.0
-  build: hea5eaeb_2
-  build_number: 2
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libgz-sim8-8.1.0-hea5eaeb_2.conda
-  sha256: 8216dc86bab27690c22017f7887a1eb77568ebda3cca360b622c1bd12ef33530
-  md5: 1af216d21d62e6ff8a18167e9d7dba02
-  depends:
-  - libabseil * cxx17*
-  - libabseil >=20240116.1,<20240117.0a0
-  - libgz-cmake3 >=3.4.1,<4.0a0
-  - libgz-common5 >=5.5.0,<6.0a0
-  - libgz-fuel-tools9 >=9.0.0,<10.0a0
-  - libgz-gui8 >=8.0.0,<9.0a0
-  - libgz-math7 >=7.3.0,<8.0a0
-  - libgz-msgs10 >=10.1.0,<11.0a0
-  - libgz-physics7 >=7.0.0,<8.0a0
-  - libgz-plugin2 >=2.0.2,<3.0a0
-  - libgz-rendering8 >=8.0.0,<9.0a0
-  - libgz-sensors8 >=8.0.0,<9.0a0
-  - libgz-tools2 >=2.0.0,<3.0a0
-  - libgz-transport13 >=13.0.0,<14.0a0
-  - libgz-utils2 >=2.1.0,<3.0a0
-  - libprotobuf >=4.25.3,<4.25.4.0a0
-  - libsdformat14 >=14.0.0,<15.0a0
-  - pybind11-abi 4
-  - python_abi 3.12.* *_cp312
-  - qt-main >=5.15.8,<5.16.0a0
-  - tinyxml2 >=10.0.0,<11.0a0
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  license: Apache-2.0
-  license_family: APACHE
-  size: 10990196
-  timestamp: 1709967342919
-- kind: conda
-  name: libgz-sim8
   version: 8.3.0
   build: h5fd5377_0
   subdir: linux-64
@@ -19050,6 +19072,43 @@ packages:
   license_family: APACHE
   size: 11543196
   timestamp: 1713969902434
+- kind: conda
+  name: libgz-sim8
+  version: 8.3.0
+  build: h6914e37_0
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/libgz-sim8-8.3.0-h6914e37_0.conda
+  sha256: ae86904c3803b48efeb5f605a216c8cc9ec6f77e308a0033275e818abbfa18b6
+  md5: ee0ffb5b0728dda8515c404620867673
+  depends:
+  - libabseil * cxx17*
+  - libabseil >=20240116.1,<20240117.0a0
+  - libgz-cmake3 >=3.5.2,<4.0a0
+  - libgz-common5 >=5.5.1,<6.0a0
+  - libgz-fuel-tools9 >=9.0.3,<10.0a0
+  - libgz-gui8 >=8.0.0,<9.0a0
+  - libgz-math7 >=7.3.0,<8.0a0
+  - libgz-msgs10 >=10.1.2,<11.0a0
+  - libgz-physics7 >=7.1.0,<8.0a0
+  - libgz-plugin2 >=2.0.3,<3.0a0
+  - libgz-rendering8 >=8.1.1,<9.0a0
+  - libgz-sensors8 >=8.0.0,<9.0a0
+  - libgz-tools2 >=2.0.0,<3.0a0
+  - libgz-transport13 >=13.2.0,<14.0a0
+  - libgz-utils2 >=2.1.0,<3.0a0
+  - libprotobuf >=4.25.3,<4.25.4.0a0
+  - libsdformat14 >=14.0.0,<15.0a0
+  - pybind11-abi 4
+  - python_abi 3.10.* *_cp310
+  - qt-main >=5.15.8,<5.16.0a0
+  - tinyxml2 >=10.0.0,<11.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Apache-2.0
+  license_family: APACHE
+  size: 10834955
+  timestamp: 1713971085161
 - kind: conda
   name: libgz-sim8
   version: 8.3.0
@@ -19250,31 +19309,6 @@ packages:
   license_family: APACHE
   size: 41895
   timestamp: 1677955087049
-- kind: conda
-  name: libgz-transport12
-  version: 12.2.1
-  build: h0e3e44e_8
-  build_number: 8
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libgz-transport12-12.2.1-h0e3e44e_8.conda
-  sha256: e3fc6d461809055116621007e569923a755e93db4102e0a98279841e57893532
-  md5: 640f5d96336eb1f6f9f08bb9e62e7122
-  depends:
-  - cppzmq
-  - libgz-cmake3 >=3.4.1,<4.0a0
-  - libgz-msgs9 >=9.5.0,<10.0a0
-  - libgz-tools2 >=2.0.0,<3.0a0
-  - libgz-utils2 >=2.1.0,<3.0a0
-  - libprotobuf >=4.25.3,<4.25.4.0a0
-  - libsqlite >=3.45.1,<4.0a0
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  - zeromq >=4.3.5,<4.3.6.0a0
-  license: Apache-2.0
-  license_family: APACHE
-  size: 485743
-  timestamp: 1709800979133
 - kind: conda
   name: libgz-transport13
   version: 13.4.0
@@ -20081,6 +20115,28 @@ packages:
 - kind: conda
   name: libignition-math6
   version: 6.15.1
+  build: py310h595d6f7_1
+  build_number: 1
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/libignition-math6-6.15.1-py310h595d6f7_1.conda
+  sha256: bf84f808ad7974f2b55a217772c5ee5a26477be898c680281a532c58d890a9c2
+  md5: 326c8667a1a63fbd29f3b37015be59e9
+  depends:
+  - eigen
+  - libignition-cmake2 >=2.16.0,<3.0a0
+  - pybind11-abi 4
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Apache-2.0
+  license_family: APACHE
+  size: 732079
+  timestamp: 1704580773590
+- kind: conda
+  name: libignition-math6
+  version: 6.15.1
   build: py310h64a2142_1
   build_number: 1
   subdir: linux-64
@@ -20119,28 +20175,6 @@ packages:
   license_family: APACHE
   size: 1081670
   timestamp: 1704581982663
-- kind: conda
-  name: libignition-math6
-  version: 6.15.1
-  build: py312haf63811_1
-  build_number: 1
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libignition-math6-6.15.1-py312haf63811_1.conda
-  sha256: 49c636b6a31aeedf89b68cb0a8c7c241c59daf3ca153bedb44966a070b88a445
-  md5: 72280d94bd5229bce5683550272175a7
-  depends:
-  - eigen
-  - libignition-cmake2 >=2.16.0,<3.0a0
-  - pybind11-abi 4
-  - python >=3.12,<3.13.0a0
-  - python_abi 3.12.* *_cp312
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  license: Apache-2.0
-  license_family: APACHE
-  size: 722039
-  timestamp: 1704580736770
 - kind: conda
   name: libignition-math6
   version: 6.15.1
@@ -20483,90 +20517,94 @@ packages:
 - kind: conda
   name: libintl
   version: 0.22.5
-  build: h5728263_2
-  build_number: 2
+  build: h5728263_3
+  build_number: 3
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libintl-0.22.5-h5728263_2.conda
-  sha256: 1b95335af0a3e278b31e16667fa4e51d1c3f5e22d394d982539dfd5d34c5ae19
-  md5: aa622c938af057adc119f8b8eecada01
+  url: https://conda.anaconda.org/conda-forge/win-64/libintl-0.22.5-h5728263_3.conda
+  sha256: c7e4600f28bcada8ea81456a6530c2329312519efcf0c886030ada38976b0511
+  md5: 2cf0cf76cc15d360dfa2f17fd6cf9772
   depends:
   - libiconv >=1.17,<2.0a0
   license: LGPL-2.1-or-later
-  size: 95745
-  timestamp: 1712516102666
+  size: 95568
+  timestamp: 1723629479451
 - kind: conda
   name: libintl
   version: 0.22.5
-  build: h5ff76d1_2
-  build_number: 2
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/libintl-0.22.5-h5ff76d1_2.conda
-  sha256: 280aaef0ed84637ee869012ad9ad9ed208e068dd9b8cf010dafeea717dad7203
-  md5: 3fb6774cb8cdbb93a6013b67bcf9716d
+  build: h8414b35_3
+  build_number: 3
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libintl-0.22.5-h8414b35_3.conda
+  sha256: 7c1d238d4333af385e594c89ebcb520caad7ed83a735c901099ec0970a87a891
+  md5: 3b98ec32e91b3b59ad53dbb9c96dd334
   depends:
+  - __osx >=11.0
   - libiconv >=1.17,<2.0a0
   license: LGPL-2.1-or-later
-  size: 74307
-  timestamp: 1712512790983
+  size: 81171
+  timestamp: 1723626968270
 - kind: conda
   name: libintl
   version: 0.22.5
-  build: h8fbad5d_2
-  build_number: 2
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libintl-0.22.5-h8fbad5d_2.conda
-  sha256: 21bc79bdf34ffd20cb84d2a8bd82d7d0e2a1b94b9e72773f0fb207e5b4f1ff63
-  md5: 3d216d0add050129007de3342be7b8c5
-  depends:
-  - libiconv >=1.17,<2.0a0
-  license: LGPL-2.1-or-later
-  size: 81206
-  timestamp: 1712512755390
-- kind: conda
-  name: libintl-devel
-  version: 0.22.5
-  build: h5728263_2
-  build_number: 2
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libintl-devel-0.22.5-h5728263_2.conda
-  sha256: 6164fd51abfc7294477c58da77ee1ff9ebc63b9a33404b646407f7fbc3cc7d0d
-  md5: a2ad82fae23975e4ccbfab2847d31d48
-  depends:
-  - libiconv >=1.17,<2.0a0
-  - libintl 0.22.5 h5728263_2
-  license: LGPL-2.1-or-later
-  size: 40772
-  timestamp: 1712516363413
-- kind: conda
-  name: libintl-devel
-  version: 0.22.5
-  build: h5ff76d1_2
-  build_number: 2
+  build: hdfe23c8_3
+  build_number: 3
   subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/libintl-devel-0.22.5-h5ff76d1_2.conda
-  sha256: e3f15a85c6e63633a5ff503d56366bab31cd2e07ea21559889bc7eb19564106d
-  md5: ea0a07e556d6b238db685cae6e3585d0
+  url: https://conda.anaconda.org/conda-forge/osx-64/libintl-0.22.5-hdfe23c8_3.conda
+  sha256: 0dbb662440a73e20742f12d88e51785a5a5117b8b150783a032b8818a8c043af
+  md5: 52d4d643ed26c07599736326c46bf12f
   depends:
+  - __osx >=10.13
   - libiconv >=1.17,<2.0a0
-  - libintl 0.22.5 h5ff76d1_2
   license: LGPL-2.1-or-later
-  size: 38422
-  timestamp: 1712512843420
+  size: 88086
+  timestamp: 1723626826235
 - kind: conda
   name: libintl-devel
   version: 0.22.5
-  build: h8fbad5d_2
-  build_number: 2
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libintl-devel-0.22.5-h8fbad5d_2.conda
-  sha256: e52b2d0c5711f64b523756ccd9b800ee6f10a6317432b20a417dc3792e0a794a
-  md5: 962b3348c68efd25da253e94590ea9a2
+  build: h5728263_3
+  build_number: 3
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/libintl-devel-0.22.5-h5728263_3.conda
+  sha256: be1f3c48bc750bca7e68955d57180dfd826d6f9fa7eb32994f6cb61b813f9a6a
+  md5: 7537784e9e35399234d4007f45cdb744
   depends:
   - libiconv >=1.17,<2.0a0
-  - libintl 0.22.5 h8fbad5d_2
+  - libintl 0.22.5 h5728263_3
   license: LGPL-2.1-or-later
-  size: 38616
-  timestamp: 1712512805567
+  size: 40746
+  timestamp: 1723629745649
+- kind: conda
+  name: libintl-devel
+  version: 0.22.5
+  build: h8414b35_3
+  build_number: 3
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libintl-devel-0.22.5-h8414b35_3.conda
+  sha256: c9d1d4fdfb5775828e54bc9fb443b1a6de9319a04b81d1bac52c26114a763154
+  md5: 271646de11b018c66e81eb4c4717b291
+  depends:
+  - __osx >=11.0
+  - libiconv >=1.17,<2.0a0
+  - libintl 0.22.5 h8414b35_3
+  license: LGPL-2.1-or-later
+  size: 38584
+  timestamp: 1723627022409
+- kind: conda
+  name: libintl-devel
+  version: 0.22.5
+  build: hdfe23c8_3
+  build_number: 3
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/libintl-devel-0.22.5-hdfe23c8_3.conda
+  sha256: 4913a20244520d6fae14452910613b652752982193a401482b7d699ee70bb13a
+  md5: aeb045f400ec2b068c6c142b16f87c7e
+  depends:
+  - __osx >=10.13
+  - libiconv >=1.17,<2.0a0
+  - libintl 0.22.5 hdfe23c8_3
+  license: LGPL-2.1-or-later
+  size: 38249
+  timestamp: 1723626863306
 - kind: conda
   name: libjpeg-turbo
   version: 3.0.0
@@ -21506,22 +21544,22 @@ packages:
 - kind: conda
   name: libode
   version: 0.16.2
-  build: h53d5487_14
+  build: h00ffb61_14
   build_number: 14
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libode-0.16.2-h53d5487_14.conda
-  sha256: 2998b838f5ca50e591905e1d8c12a13e89b53244e15731f9ed1bca5b179a698a
-  md5: 9700da78cfcaf77bd7b68d523e5fbc18
+  url: https://conda.anaconda.org/conda-forge/win-64/libode-0.16.2-h00ffb61_14.conda
+  sha256: 50468f3162af4fd8b5406e1d1bf50dd236aa165d416db1b8568b901134d54b58
+  md5: 0dfbb77ce69faa435c1a279116137797
   depends:
   - libccd-double >=2.1,<2.2.0a0
-  - python_abi 3.12.* *_cp312
+  - python_abi 3.10.* *_cp310
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
   - vs2015_runtime
   license: LGPL-2.1-or-later OR BSD-4-Clause
-  size: 367320
-  timestamp: 1710842384440
+  size: 366618
+  timestamp: 1710841987111
 - kind: conda
   name: libode
   version: 0.16.2
@@ -21746,24 +21784,23 @@ packages:
   timestamp: 1720426334043
 - kind: conda
   name: libopenblas
-  version: 0.3.27
-  build: pthreads_hf0a32cb_1
-  build_number: 1
+  version: 0.3.28
+  build: pthreads_hf0a32cb_0
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libopenblas-0.3.27-pthreads_hf0a32cb_1.conda
-  sha256: 4e66ab8a83ac2464aa32c8886c7507b8c4ae030c3eedbb5833710dcaf5249713
-  md5: 52610e910dd5f1ab578abae44fa19ca3
+  url: https://conda.anaconda.org/conda-forge/win-64/libopenblas-0.3.28-pthreads_hf0a32cb_0.conda
+  sha256: 4574b0f99afb72e248df016443ac5ee4b2b59c22fe73c3cf63540ddda28885bd
+  md5: 3a27ab073561e48706ba93ffe1552697
   depends:
   - libflang >=5.0.0,<6.0.0.a0
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
   constrains:
-  - openblas >=0.3.27,<0.3.28.0a0
+  - openblas >=0.3.28,<0.3.29.0a0
   license: BSD-3-Clause
   license_family: BSD
-  size: 3967835
-  timestamp: 1720443575226
+  size: 3975623
+  timestamp: 1723935076109
 - kind: conda
   name: libopencv
   version: 4.10.0
@@ -21913,6 +21950,56 @@ packages:
 - kind: conda
   name: libopencv
   version: 4.10.0
+  build: qt6_py310hb73b763_602
+  build_number: 602
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/libopencv-4.10.0-qt6_py310hb73b763_602.conda
+  sha256: 4309fccd6941ed595bd9a7aef2643d66317740eeacc54f5ab32ca25dd660a243
+  md5: 3ee8ca57b436f6185c7ca8244d6f1516
+  depends:
+  - ffmpeg >=6.1.1,<7.0a0
+  - freetype >=2.12.1,<3.0a0
+  - harfbuzz >=9.0.0,<10.0a0
+  - hdf5 >=1.14.3,<1.14.4.0a0
+  - jasper >=4.2.4,<5.0a0
+  - libasprintf >=0.22.5,<1.0a0
+  - libcblas >=3.9.0,<4.0a0
+  - libgettextpo >=0.22.5,<1.0a0
+  - libglib >=2.80.2,<3.0a0
+  - libintl >=0.22.5,<1.0a0
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - liblapack >=3.9.0,<4.0a0
+  - liblapacke >=3.9.0,<4.0a0
+  - libopenvino >=2024.2.0,<2024.2.1.0a0
+  - libopenvino-auto-batch-plugin >=2024.2.0,<2024.2.1.0a0
+  - libopenvino-auto-plugin >=2024.2.0,<2024.2.1.0a0
+  - libopenvino-hetero-plugin >=2024.2.0,<2024.2.1.0a0
+  - libopenvino-intel-cpu-plugin >=2024.2.0,<2024.2.1.0a0
+  - libopenvino-intel-gpu-plugin >=2024.2.0,<2024.2.1.0a0
+  - libopenvino-ir-frontend >=2024.2.0,<2024.2.1.0a0
+  - libopenvino-onnx-frontend >=2024.2.0,<2024.2.1.0a0
+  - libopenvino-paddle-frontend >=2024.2.0,<2024.2.1.0a0
+  - libopenvino-pytorch-frontend >=2024.2.0,<2024.2.1.0a0
+  - libopenvino-tensorflow-frontend >=2024.2.0,<2024.2.1.0a0
+  - libopenvino-tensorflow-lite-frontend >=2024.2.0,<2024.2.1.0a0
+  - libpng >=1.6.43,<1.7.0a0
+  - libprotobuf >=4.25.3,<4.25.4.0a0
+  - libtiff >=4.6.0,<4.7.0a0
+  - libwebp-base >=1.4.0,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - numpy >=1.19,<3
+  - openexr >=3.2.2,<3.3.0a0
+  - qt6-main >=6.7.2,<6.8.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Apache-2.0
+  license_family: Apache
+  size: 33122404
+  timestamp: 1721306263407
+- kind: conda
+  name: libopencv
+  version: 4.10.0
   build: qt6_py310hbbd9133_600
   build_number: 600
   subdir: linux-64
@@ -21962,56 +22049,6 @@ packages:
   license_family: Apache
   size: 30484320
   timestamp: 1717732168712
-- kind: conda
-  name: libopencv
-  version: 4.10.0
-  build: qt6_py312h00ae949_602
-  build_number: 602
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libopencv-4.10.0-qt6_py312h00ae949_602.conda
-  sha256: ec249b81422ce340d75430e85b3dd09e1f58bc2aff12ddf296c609bcb82df4ac
-  md5: 14bccb309089686c913d4bcd29bdf976
-  depends:
-  - ffmpeg >=6.1.1,<7.0a0
-  - freetype >=2.12.1,<3.0a0
-  - harfbuzz >=9.0.0,<10.0a0
-  - hdf5 >=1.14.3,<1.14.4.0a0
-  - jasper >=4.2.4,<5.0a0
-  - libasprintf >=0.22.5,<1.0a0
-  - libcblas >=3.9.0,<4.0a0
-  - libgettextpo >=0.22.5,<1.0a0
-  - libglib >=2.80.2,<3.0a0
-  - libintl >=0.22.5,<1.0a0
-  - libjpeg-turbo >=3.0.0,<4.0a0
-  - liblapack >=3.9.0,<4.0a0
-  - liblapacke >=3.9.0,<4.0a0
-  - libopenvino >=2024.2.0,<2024.2.1.0a0
-  - libopenvino-auto-batch-plugin >=2024.2.0,<2024.2.1.0a0
-  - libopenvino-auto-plugin >=2024.2.0,<2024.2.1.0a0
-  - libopenvino-hetero-plugin >=2024.2.0,<2024.2.1.0a0
-  - libopenvino-intel-cpu-plugin >=2024.2.0,<2024.2.1.0a0
-  - libopenvino-intel-gpu-plugin >=2024.2.0,<2024.2.1.0a0
-  - libopenvino-ir-frontend >=2024.2.0,<2024.2.1.0a0
-  - libopenvino-onnx-frontend >=2024.2.0,<2024.2.1.0a0
-  - libopenvino-paddle-frontend >=2024.2.0,<2024.2.1.0a0
-  - libopenvino-pytorch-frontend >=2024.2.0,<2024.2.1.0a0
-  - libopenvino-tensorflow-frontend >=2024.2.0,<2024.2.1.0a0
-  - libopenvino-tensorflow-lite-frontend >=2024.2.0,<2024.2.1.0a0
-  - libpng >=1.6.43,<1.7.0a0
-  - libprotobuf >=4.25.3,<4.25.4.0a0
-  - libtiff >=4.6.0,<4.7.0a0
-  - libwebp-base >=1.4.0,<2.0a0
-  - libzlib >=1.3.1,<2.0a0
-  - numpy >=1.19,<3
-  - openexr >=3.2.2,<3.3.0a0
-  - qt6-main >=6.7.2,<6.8.0a0
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  license: Apache-2.0
-  license_family: Apache
-  size: 33158586
-  timestamp: 1721307291430
 - kind: conda
   name: libopenvino
   version: 2024.1.0
@@ -23976,29 +24013,6 @@ packages:
   license_family: APACHE
   size: 521836
   timestamp: 1704587224113
-- kind: conda
-  name: libsdformat13
-  version: 13.6.0
-  build: h76d8a3d_4
-  build_number: 4
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libsdformat13-13.6.0-h76d8a3d_4.conda
-  sha256: 18b9bfff535db56edc5ddd7b93205c5497d03a47f528b5c554f123c8107026e3
-  md5: a997fd80540a2128b5df0151a64331a9
-  depends:
-  - libgz-cmake3 >=3.4.1,<4.0a0
-  - libgz-math7 >=7.3.0,<8.0a0
-  - libgz-tools2 >=2.0.0,<3.0a0
-  - libgz-utils2 >=2.1.0,<3.0a0
-  - tinyxml2 >=10.0.0,<11.0a0
-  - ucrt >=10.0.20348.0
-  - urdfdom >=4.0.0,<4.1.0a0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  license: Apache-2.0
-  license_family: APACHE
-  size: 771654
-  timestamp: 1704657781015
 - kind: conda
   name: libsdformat14
   version: 14.5.0
@@ -26220,35 +26234,37 @@ packages:
 - kind: conda
   name: llvm-openmp
   version: 18.1.8
-  build: h15ab845_0
+  build: h15ab845_1
+  build_number: 1
   subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/llvm-openmp-18.1.8-h15ab845_0.conda
-  sha256: 0fd74128806bd839c7a9aa343faf265b94aece84f75f67f14b6246936138e61e
-  md5: 2c3c6c8aaf8728f87326964a82fdc7d8
+  url: https://conda.anaconda.org/conda-forge/osx-64/llvm-openmp-18.1.8-h15ab845_1.conda
+  sha256: 06a245abb6e6d8d6662a35ad162eacb39f431349edf7cea9b1ff73b2da213c58
+  md5: ad0afa524866cc1c08b436865d0ae484
   depends:
   - __osx >=10.13
   constrains:
   - openmp 18.1.8|18.1.8.*
   license: Apache-2.0 WITH LLVM-exception
   license_family: APACHE
-  size: 300682
-  timestamp: 1718887195436
+  size: 300358
+  timestamp: 1723605369115
 - kind: conda
   name: llvm-openmp
   version: 18.1.8
-  build: hde57baf_0
+  build: hde57baf_1
+  build_number: 1
   subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/llvm-openmp-18.1.8-hde57baf_0.conda
-  sha256: 42bc913b3c91934a1ce7ff635e87ee48e2e252632f0cbf607c5a3e4409d9f9dd
-  md5: 82393fdbe38448d878a8848b6fcbcefb
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/llvm-openmp-18.1.8-hde57baf_1.conda
+  sha256: 7a76e2932ac77e6314bfa1c4ff83f617c8260313bfed1b8401b508ed3e9d70ba
+  md5: fe89757e3cd14bb1c6ebd68dac591363
   depends:
   - __osx >=11.0
   constrains:
   - openmp 18.1.8|18.1.8.*
   license: Apache-2.0 WITH LLVM-exception
   license_family: APACHE
-  size: 276438
-  timestamp: 1718911793488
+  size: 276263
+  timestamp: 1723605341828
 - kind: conda
   name: llvm-tools
   version: 16.0.6
@@ -26298,6 +26314,24 @@ packages:
 - kind: conda
   name: loguru
   version: 0.7.2
+  build: py310h5588dad_1
+  build_number: 1
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/loguru-0.7.2-py310h5588dad_1.conda
+  sha256: f3db7a198439b1d6f3943a4dba416e06406e6090fa6afe4b0d06441c3d5a2923
+  md5: 2b73ddd2ad9984b09aafccabd8d0fac2
+  depends:
+  - colorama >=0.3.4
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  - win32_setctime >=1.0.0
+  license: MIT
+  license_family: MIT
+  size: 98664
+  timestamp: 1695547777075
+- kind: conda
+  name: loguru
+  version: 0.7.2
   build: py310hbbe02a8_1
   build_number: 1
   subdir: linux-aarch64
@@ -26343,24 +26377,6 @@ packages:
   license_family: MIT
   size: 125723
   timestamp: 1695547737548
-- kind: conda
-  name: loguru
-  version: 0.7.2
-  build: py312h2e8e312_1
-  build_number: 1
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/loguru-0.7.2-py312h2e8e312_1.conda
-  sha256: ec36ae07a8b465965f8a91e1357af7f51049fbbadd57d6580da7935e16036c6e
-  md5: abed90ae66f8c890b36af7ad16e43697
-  depends:
-  - colorama >=0.3.4
-  - python >=3.12.0rc3,<3.13.0a0
-  - python_abi 3.12.* *_cp312
-  - win32_setctime >=1.0.0
-  license: MIT
-  license_family: MIT
-  size: 122681
-  timestamp: 1695547648062
 - kind: conda
   name: loguru
   version: 0.7.2
@@ -26760,106 +26776,131 @@ packages:
   timestamp: 1602706492919
 - kind: conda
   name: matplotlib
-  version: 3.9.1
-  build: py310hbbe02a8_2
-  build_number: 2
+  version: 3.9.2
+  build: py310h5588dad_0
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/matplotlib-3.9.2-py310h5588dad_0.conda
+  sha256: 4c9570a4bede542879b6b7e29355843a521cc0c44707ac3c87e3c5156a224d8a
+  md5: 21a87b9b459d72304b3da851b9e7550f
+  depends:
+  - matplotlib-base >=3.9.2,<3.9.3.0a0
+  - pyside6 >=6.7.2
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  - tornado >=5
+  license: PSF-2.0
+  license_family: PSF
+  size: 9155
+  timestamp: 1723760787466
+- kind: conda
+  name: matplotlib
+  version: 3.9.2
+  build: py310hbbe02a8_0
   subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/matplotlib-3.9.1-py310hbbe02a8_2.conda
-  sha256: f12bd8e757b11e8bf93e898b774bbc928506d2ae97912bf40202e8e8fc1d705f
-  md5: 54a9e01409d332f4e7eb3ce1720f79f4
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/matplotlib-3.9.2-py310hbbe02a8_0.conda
+  sha256: 9cf894ba9174a3ae75267953f1eca9c86426924a2d8f03ab11232ab2ad205da6
+  md5: ea70fee36d2fed78b58d069f20216c83
   depends:
-  - matplotlib-base >=3.9.1,<3.9.2.0a0
+  - matplotlib-base >=3.9.2,<3.9.3.0a0
   - pyside6 >=6.7.2
   - python >=3.10,<3.11.0a0
   - python_abi 3.10.* *_cp310
   - tornado >=5
   license: PSF-2.0
   license_family: PSF
-  size: 8889
-  timestamp: 1722733069799
+  size: 8892
+  timestamp: 1723759756563
 - kind: conda
   name: matplotlib
-  version: 3.9.1
-  build: py310hff52083_2
-  build_number: 2
+  version: 3.9.2
+  build: py310hff52083_0
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/matplotlib-3.9.1-py310hff52083_2.conda
-  sha256: 8aad6b08beb30b2b67673b99527d61a64d53e8dfaefc40bd9f8585de518dbbae
-  md5: 443c2d893a524bc9bef132a498f8913e
+  url: https://conda.anaconda.org/conda-forge/linux-64/matplotlib-3.9.2-py310hff52083_0.conda
+  sha256: 8161302ebffe670b40f5f126be39ea9be4e0c6ecf75d1e73430eeb8c52775468
+  md5: c242f10aff2f3691c09eef916f6b82d8
   depends:
-  - matplotlib-base >=3.9.1,<3.9.2.0a0
+  - matplotlib-base >=3.9.2,<3.9.3.0a0
   - pyside6 >=6.7.2
   - python >=3.10,<3.11.0a0
   - python_abi 3.10.* *_cp310
   - tornado >=5
   license: PSF-2.0
   license_family: PSF
-  size: 8740
-  timestamp: 1722732896137
+  size: 8718
+  timestamp: 1723759686625
 - kind: conda
   name: matplotlib
-  version: 3.9.1
-  build: py311h6eed73b_2
-  build_number: 2
+  version: 3.9.2
+  build: py311h6eed73b_0
   subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/matplotlib-3.9.1-py311h6eed73b_2.conda
-  sha256: c3ddb1c8eb3890e0115ccf344b23a11c7e20202d336372c96653751045f92b3f
-  md5: c04fd48f5aebb396edbdcdff805318f8
+  url: https://conda.anaconda.org/conda-forge/osx-64/matplotlib-3.9.2-py311h6eed73b_0.conda
+  sha256: 73221500ff3884a611b4bd57c589f349b1505b57ab973aa98b475067d760f615
+  md5: 1ed72889fe9deeaeb78c3b8fc1c8d56c
   depends:
-  - matplotlib-base >=3.9.1,<3.9.2.0a0
+  - matplotlib-base >=3.9.2,<3.9.3.0a0
   - python >=3.11,<3.12.0a0
   - python_abi 3.11.* *_cp311
   - tornado >=5
   license: PSF-2.0
   license_family: PSF
-  size: 8820
-  timestamp: 1722732946943
+  size: 8830
+  timestamp: 1723759719134
 - kind: conda
   name: matplotlib
-  version: 3.9.1
-  build: py312h1f38498_2
-  build_number: 2
+  version: 3.9.2
+  build: py312h1f38498_0
   subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/matplotlib-3.9.1-py312h1f38498_2.conda
-  sha256: 2e2ed8364ff212bfa8e09fc1b278b6c3e55e513e78a61f83a7266c964202f13f
-  md5: 40480415d535db3985429cef5c1c8f79
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/matplotlib-3.9.2-py312h1f38498_0.conda
+  sha256: d5d332f2bb301eec1e43d4702f5332d8c32953ab7974e74da99a3fef94c00d86
+  md5: dddd7fd8834329a4436deea957022433
   depends:
-  - matplotlib-base >=3.9.1,<3.9.2.0a0
+  - matplotlib-base >=3.9.2,<3.9.3.0a0
   - python >=3.12,<3.13.0a0
   - python_abi 3.12.* *_cp312
   - tornado >=5
   license: PSF-2.0
   license_family: PSF
-  size: 8836
-  timestamp: 1722733010482
-- kind: conda
-  name: matplotlib
-  version: 3.9.1
-  build: py312h2e8e312_2
-  build_number: 2
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/matplotlib-3.9.1-py312h2e8e312_2.conda
-  sha256: 1f0954a769507fe01fad59bbb47c18ecaa6419aae7ce8fb9b2a684b6c8b16174
-  md5: 62ea4aefc82a31be9c99f39b63fae7d1
-  depends:
-  - matplotlib-base >=3.9.1,<3.9.2.0a0
-  - pyside6 >=6.7.2
-  - python >=3.12,<3.13.0a0
-  - python_abi 3.12.* *_cp312
-  - tornado >=5
-  license: PSF-2.0
-  license_family: PSF
-  size: 9238
-  timestamp: 1722733859811
+  size: 8884
+  timestamp: 1723759792668
 - kind: conda
   name: matplotlib-base
-  version: 3.9.1
-  build: py310hf02ac8c_2
-  build_number: 2
+  version: 3.9.2
+  build: py310h37e0a56_0
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/matplotlib-base-3.9.2-py310h37e0a56_0.conda
+  sha256: 833b4ce97091c2cd6bb328cd5da8f17204ebc7991b61c96c5d14d8f64bc3b539
+  md5: 572f63aacc91b6ce473ad677350a3ca2
+  depends:
+  - certifi >=2020.06.20
+  - contourpy >=1.0.1
+  - cycler >=0.10
+  - fonttools >=4.22.0
+  - freetype >=2.12.1,<3.0a0
+  - kiwisolver >=1.3.1
+  - numpy >=1.19,<3
+  - numpy >=1.23
+  - packaging >=20.0
+  - pillow >=8
+  - pyparsing >=2.3.1
+  - python >=3.10,<3.11.0a0
+  - python-dateutil >=2.7
+  - python_abi 3.10.* *_cp310
+  - qhull >=2020.2,<2020.3.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: PSF-2.0
+  license_family: PSF
+  size: 6696325
+  timestamp: 1723760715383
+- kind: conda
+  name: matplotlib-base
+  version: 3.9.2
+  build: py310hf02ac8c_0
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/matplotlib-base-3.9.1-py310hf02ac8c_2.conda
-  sha256: ee29885abf90e9c59459346dd5aa19026f02f66e0e586a95b2c442e7f913c67b
-  md5: 123acef757eb89e8dd6eb37af3f65821
+  url: https://conda.anaconda.org/conda-forge/linux-64/matplotlib-base-3.9.2-py310hf02ac8c_0.conda
+  sha256: 8c7e155111290531e352c731f42b57f9047bd283029aaffac8c9aa975100b588
+  md5: 394fef7267dfc5bc139ba72b05560b75
   depends:
   - __glibc >=2.17,<3.0.a0
   - certifi >=2020.06.20
@@ -26882,17 +26923,16 @@ packages:
   - tk >=8.6.13,<8.7.0a0
   license: PSF-2.0
   license_family: PSF
-  size: 7018180
-  timestamp: 1722732874975
+  size: 6884522
+  timestamp: 1723759666002
 - kind: conda
   name: matplotlib-base
-  version: 3.9.1
-  build: py310hf9f654d_2
-  build_number: 2
+  version: 3.9.2
+  build: py310hf9f654d_0
   subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/matplotlib-base-3.9.1-py310hf9f654d_2.conda
-  sha256: 21c09328112b354064e0bddfde25e4773ac59bbdb9b45e562b58cde7b5b542e6
-  md5: 02f1d280fac982ecbd3f7eafd86718a2
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/matplotlib-base-3.9.2-py310hf9f654d_0.conda
+  sha256: fde820dc8c4fb35a275812124f3811d09132f9856a052693f771e72075bf58f3
+  md5: 5c6b6ec7697558251760178d6e8df7f9
   depends:
   - certifi >=2020.06.20
   - contourpy >=1.0.1
@@ -26915,17 +26955,16 @@ packages:
   - tk >=8.6.13,<8.7.0a0
   license: PSF-2.0
   license_family: PSF
-  size: 6919840
-  timestamp: 1722733050479
+  size: 6911227
+  timestamp: 1723759739679
 - kind: conda
   name: matplotlib-base
-  version: 3.9.1
-  build: py311hf31e254_2
-  build_number: 2
+  version: 3.9.2
+  build: py311hf31e254_0
   subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/matplotlib-base-3.9.1-py311hf31e254_2.conda
-  sha256: e47bcd835c87df9ca1bf082b67de3f458323ffd168cad2b82d6bd26004142351
-  md5: 749acc259bdea66ca858de097b29fb56
+  url: https://conda.anaconda.org/conda-forge/osx-64/matplotlib-base-3.9.2-py311hf31e254_0.conda
+  sha256: 6d8729fa58420fbb9f00b32bbbd015675635b62a463be1cbe56b76748355603c
+  md5: c23f5862543ee6e36f7001a535ef11a1
   depends:
   - __osx >=10.13
   - certifi >=2020.06.20
@@ -26946,17 +26985,16 @@ packages:
   - qhull >=2020.2,<2020.3.0a0
   license: PSF-2.0
   license_family: PSF
-  size: 7921565
-  timestamp: 1722732901432
+  size: 7942947
+  timestamp: 1723759675474
 - kind: conda
   name: matplotlib-base
-  version: 3.9.1
-  build: py312h32d6e5a_2
-  build_number: 2
+  version: 3.9.2
+  build: py312h32d6e5a_0
   subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/matplotlib-base-3.9.1-py312h32d6e5a_2.conda
-  sha256: 92e2ddd6cac1adce930686ca7d741f81051b791845206b56e779351ea1d1e78f
-  md5: 0eb9a1cf6567b2ca4ec63674ba97d7e1
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/matplotlib-base-3.9.2-py312h32d6e5a_0.conda
+  sha256: 508798a3d84d6cb2d17f8025ff3be5949351b3ab680e7a5acebc1166abb2d157
+  md5: 2649a9158eb3183c8de0116b9fd6aada
   depends:
   - __osx >=11.0
   - certifi >=2020.06.20
@@ -26978,40 +27016,8 @@ packages:
   - qhull >=2020.2,<2020.3.0a0
   license: PSF-2.0
   license_family: PSF
-  size: 7908720
-  timestamp: 1722732967629
-- kind: conda
-  name: matplotlib-base
-  version: 3.9.1
-  build: py312h90004f6_2
-  build_number: 2
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/matplotlib-base-3.9.1-py312h90004f6_2.conda
-  sha256: e48a47f274ee3ce4b7922bb41ef5368cf78dedff44666bc44676faa8eb5f325f
-  md5: b887827aaf3c5019d6802eeab07b9697
-  depends:
-  - certifi >=2020.06.20
-  - contourpy >=1.0.1
-  - cycler >=0.10
-  - fonttools >=4.22.0
-  - freetype >=2.12.1,<3.0a0
-  - kiwisolver >=1.3.1
-  - numpy >=1.19,<3
-  - numpy >=1.23
-  - packaging >=20.0
-  - pillow >=8
-  - pyparsing >=2.3.1
-  - python >=3.12,<3.13.0a0
-  - python-dateutil >=2.7
-  - python_abi 3.12.* *_cp312
-  - qhull >=2020.2,<2020.3.0a0
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  license: PSF-2.0
-  license_family: PSF
-  size: 7770509
-  timestamp: 1722733792441
+  size: 7864592
+  timestamp: 1723759750829
 - kind: conda
   name: matplotlib-inline
   version: 0.1.7
@@ -27499,6 +27505,24 @@ packages:
 - kind: conda
   name: msgpack-python
   version: 1.0.8
+  build: py310hc19bc0b_0
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/msgpack-python-1.0.8-py310hc19bc0b_0.conda
+  sha256: f880861554e8dc98dec30ae039bcd8d491ce1b411a01e5b1e50270840eb57a8d
+  md5: f1188194dd35d19b490d8d13f6380f19
+  depends:
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Apache-2.0
+  license_family: Apache
+  size: 83204
+  timestamp: 1715671168114
+- kind: conda
+  name: msgpack-python
+  version: 1.0.8
   build: py311h46c8309_0
   subdir: osx-64
   url: https://conda.anaconda.org/conda-forge/osx-64/msgpack-python-1.0.8-py311h46c8309_0.conda
@@ -27532,24 +27556,6 @@ packages:
   size: 91912
   timestamp: 1715670824147
 - kind: conda
-  name: msgpack-python
-  version: 1.0.8
-  build: py312hd5eb7cc_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/msgpack-python-1.0.8-py312hd5eb7cc_0.conda
-  sha256: 080fad891281a38ff05d417ed4aa59b093d7c5fbb232cd3498dc100baacd8e44
-  md5: 83bdd6554fb4bf25195c0dacabeeebf3
-  depends:
-  - python >=3.12,<3.13.0a0
-  - python_abi 3.12.* *_cp312
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  license: Apache-2.0
-  license_family: Apache
-  size: 88758
-  timestamp: 1715671314905
-- kind: conda
   name: msys2-conda-epoch
   version: '20160418'
   build: '1'
@@ -27576,6 +27582,24 @@ packages:
   license_family: APACHE
   size: 57322
   timestamp: 1707040852167
+- kind: conda
+  name: multidict
+  version: 6.0.5
+  build: py310h8d17308_0
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/multidict-6.0.5-py310h8d17308_0.conda
+  sha256: d8fd51c489b939e7980acf26a37856ffc2ade10d7b288bf78df79cb96bc24486
+  md5: 55f85e475f92bc646829731fba4fa203
+  depends:
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Apache-2.0
+  license_family: APACHE
+  size: 52263
+  timestamp: 1707041257388
 - kind: conda
   name: multidict
   version: 6.0.5
@@ -27624,24 +27648,6 @@ packages:
   license_family: APACHE
   size: 55186
   timestamp: 1707041093658
-- kind: conda
-  name: multidict
-  version: 6.0.5
-  build: py312he70551f_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/multidict-6.0.5-py312he70551f_0.conda
-  sha256: df1066ce4014fd6ff2fb3c7a767e6d073d2c0deb30230d6f2f4981e4ed007f57
-  md5: 9db8fc5a5cc88db18dadbc2401dfa90a
-  depends:
-  - python >=3.12,<3.13.0a0
-  - python_abi 3.12.* *_cp312
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  license: Apache-2.0
-  license_family: APACHE
-  size: 55956
-  timestamp: 1707041448541
 - kind: conda
   name: mumps-include
   version: 5.7.2
@@ -28130,66 +28136,85 @@ packages:
 - kind: conda
   name: nlohmann_json
   version: 3.11.3
-  build: h1537add_0
+  build: h00cdb27_1
+  build_number: 1
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/nlohmann_json-3.11.3-h00cdb27_1.conda
+  sha256: 3f4e6a4fa074bb297855f8111ab974dab6d9f98b7d4317d4dd46f8687ee2363b
+  md5: d2dee849c806430eee64d3acc98ce090
+  depends:
+  - __osx >=11.0
+  - libcxx >=16
+  license: MIT
+  license_family: MIT
+  size: 123250
+  timestamp: 1723652704997
+- kind: conda
+  name: nlohmann_json
+  version: 3.11.3
+  build: h0a1ffab_1
+  build_number: 1
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/nlohmann_json-3.11.3-h0a1ffab_1.conda
+  sha256: c90b1f11fc337d90a9e4c5aeeacac1418c5ba6a195097086566d38bb2ecf0f24
+  md5: f2bd10ff23ab5c87327439c4499b3f3e
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  license: MIT
+  license_family: MIT
+  size: 122755
+  timestamp: 1723652622631
+- kind: conda
+  name: nlohmann_json
+  version: 3.11.3
+  build: he02047a_1
+  build_number: 1
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/nlohmann_json-3.11.3-he02047a_1.conda
+  sha256: ce4bcced4f8eea71b7cac8bc3daac097abf7a5792f278cd811dedada199500c1
+  md5: e46f7ac4917215b49df2ea09a694a3fa
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  license: MIT
+  license_family: MIT
+  size: 122743
+  timestamp: 1723652407663
+- kind: conda
+  name: nlohmann_json
+  version: 3.11.3
+  build: he0c23c2_1
+  build_number: 1
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/nlohmann_json-3.11.3-h1537add_0.conda
-  sha256: 62d47c5411e3870cb766a9dfcccf095203454894121f68798c122b4b19a83c7d
-  md5: 9e7f685b4ef5d4685249571bde5cf6a2
+  url: https://conda.anaconda.org/conda-forge/win-64/nlohmann_json-3.11.3-he0c23c2_1.conda
+  sha256: 106af14431772a6bc659e8d5a3bb1930cf1010b85e0e7eca99ecd3e556e91470
+  md5: 340cbb4ab78c90cd9d08f826ad22aed2
   depends:
   - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
   license: MIT
   license_family: MIT
-  size: 124457
-  timestamp: 1710904523077
+  size: 124255
+  timestamp: 1723652081336
 - kind: conda
   name: nlohmann_json
   version: 3.11.3
-  build: h2f0025b_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/nlohmann_json-3.11.3-h2f0025b_0.conda
-  sha256: a762ce6a30e2872019cee8e10781940ad6f3c2703987f835f12f3ffc8a0c895c
-  md5: b8f7cb7c8a6ca3589cbd09afd2329e5d
-  license: MIT
-  license_family: MIT
-  size: 123252
-  timestamp: 1710905136783
-- kind: conda
-  name: nlohmann_json
-  version: 3.11.3
-  build: h59595ed_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/nlohmann_json-3.11.3-h59595ed_0.conda
-  sha256: cb6ac3e7ea49c07348384ce55766282bb2f665be1d5cdbd8396128d6eb34ddd4
-  md5: df9ae69b85e0cab9bde23eff1e87f183
-  license: MIT
-  license_family: MIT
-  size: 123069
-  timestamp: 1710905127322
-- kind: conda
-  name: nlohmann_json
-  version: 3.11.3
-  build: h73e2aa4_0
+  build: hf036a51_1
+  build_number: 1
   subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/nlohmann_json-3.11.3-h73e2aa4_0.conda
-  sha256: d7f60d7a5a2ede0d8e634f3b414f93cff3d8b8f832bd45d755316e7377182163
-  md5: 7e82f8ccb0f18ad05ef405369263937d
+  url: https://conda.anaconda.org/conda-forge/osx-64/nlohmann_json-3.11.3-hf036a51_1.conda
+  sha256: 41b1aa2a67654917c9c32a5f0111970b11cfce49ed57cf44bba4aefdcd59e54b
+  md5: 00c3efa95b3a010ee85bc36aac6ab2f6
+  depends:
+  - __osx >=10.13
+  - libcxx >=16
   license: MIT
   license_family: MIT
-  size: 122967
-  timestamp: 1710905156326
-- kind: conda
-  name: nlohmann_json
-  version: 3.11.3
-  build: hebf3989_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/nlohmann_json-3.11.3-hebf3989_0.conda
-  sha256: ffe576b0ffa8af934e281985e335c699e222d1ebf3956f1b6b533be77134ce23
-  md5: 880fb1dfe72c96423a9c0e6aa7812089
-  license: MIT
-  license_family: MIT
-  size: 122856
-  timestamp: 1710905243663
+  size: 122773
+  timestamp: 1723652497933
 - kind: conda
   name: nspr
   version: '4.35'
@@ -28369,6 +28394,29 @@ packages:
 - kind: conda
   name: numpy
   version: 1.26.4
+  build: py310hf667824_0
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/numpy-1.26.4-py310hf667824_0.conda
+  sha256: 20ca447a8f840c01961f2bdf0847fc7b7785a62968e867d7aa4ca8a66d70f9ad
+  md5: 93e881c391880df90e74e43a4b67c16d
+  depends:
+  - libblas >=3.9.0,<4.0a0
+  - libcblas >=3.9.0,<4.0a0
+  - liblapack >=3.9.0,<4.0a0
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  constrains:
+  - numpy-base <0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 5977469
+  timestamp: 1707226445438
+- kind: conda
+  name: numpy
+  version: 1.26.4
   build: py311hc43a94b_0
   subdir: osx-64
   url: https://conda.anaconda.org/conda-forge/osx-64/numpy-1.26.4-py311hc43a94b_0.conda
@@ -28409,29 +28457,6 @@ packages:
   license_family: BSD
   size: 6073136
   timestamp: 1707226249608
-- kind: conda
-  name: numpy
-  version: 1.26.4
-  build: py312h8753938_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/numpy-1.26.4-py312h8753938_0.conda
-  sha256: 73570817a5109d396b4ebbe5124a89525959269fd33fa33fd413700289fbe0ef
-  md5: f9ac74c3b07c396014434aca1e58d362
-  depends:
-  - libblas >=3.9.0,<4.0a0
-  - libcblas >=3.9.0,<4.0a0
-  - liblapack >=3.9.0,<4.0a0
-  - python >=3.12,<3.13.0a0
-  - python_abi 3.12.* *_cp312
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  constrains:
-  - numpy-base <0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 6495445
-  timestamp: 1707226412944
 - kind: conda
   name: ocl-icd
   version: 2.3.2
@@ -28658,35 +28683,61 @@ packages:
 - kind: conda
   name: ogre-next
   version: 2.3.3
-  build: h01a85d9_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/ogre-next-2.3.3-h01a85d9_0.conda
-  sha256: 5a452a107e5d709cea9fcc113740ad0fb6ca129fd75e6fde1ac406ca99106612
-  md5: 6c1e0d7fe61c67643dd74e21f76191a8
+  build: h0aac46b_1
+  build_number: 1
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/ogre-next-2.3.3-h0aac46b_1.conda
+  sha256: 29bbad7ef2b1d573fe417abbfe11b211c828032b8333796973f3aa8a66a66c3e
+  md5: 47ebbe13d3ff3c48587f7dcb9e015fa6
   depends:
+  - __osx >=10.13
   - freeimage >=3.18.0,<3.19.0a0
   - freetype >=2.12.1,<3.0a0
   - libcxx >=16
-  - libzlib >=1.2.13,<2.0.0a0
+  - libzlib >=1.3.1,<2.0a0
   - zziplib >=0.13.69,<0.14.0a0
   license: MIT
   license_family: MIT
-  size: 3364459
-  timestamp: 1712612584188
+  size: 3525876
+  timestamp: 1724200251130
 - kind: conda
   name: ogre-next
   version: 2.3.3
-  build: h1b25c05_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/ogre-next-2.3.3-h1b25c05_0.conda
-  sha256: be4b06e743c77c6ddf8b5e72d50bc4bff86760f2f166c7798dc64c4aee3f5f12
-  md5: ecbc12b505bc11b52668cf75640fd0af
+  build: h167f6a0_1
+  build_number: 1
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/ogre-next-2.3.3-h167f6a0_1.conda
+  sha256: 2b0264c083bd8aca296fe65fd2807963338d87109cd9e658d653f122bb5b7130
+  md5: 5313eaed70cf1967014a87dcae099667
   depends:
+  - __osx >=11.0
   - freeimage >=3.18.0,<3.19.0a0
   - freetype >=2.12.1,<3.0a0
+  - libcxx >=16
+  - libzlib >=1.3.1,<2.0a0
+  - zziplib >=0.13.69,<0.14.0a0
+  license: MIT
+  license_family: MIT
+  size: 3341212
+  timestamp: 1724199958165
+- kind: conda
+  name: ogre-next
+  version: 2.3.3
+  build: ha916a4f_1
+  build_number: 1
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/ogre-next-2.3.3-ha916a4f_1.conda
+  sha256: 795663f6f85c955e4736cb4852a61e4b43a9cc19e3079bec2892aa89de38dbca
+  md5: 1ac0ff2de586986bdfd19347321df8c9
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - freeimage >=3.18.0,<3.19.0a0
+  - freetype >=2.12.1,<3.0a0
+  - libegl >=1.7.0,<2.0a0
   - libgcc-ng >=12
+  - libgl >=1.7.0,<2.0a0
   - libstdcxx-ng >=12
-  - libzlib >=1.2.13,<2.0.0a0
+  - libzlib >=1.3.1,<2.0a0
   - xorg-libx11 >=1.8.9,<2.0a0
   - xorg-libxaw
   - xorg-libxfixes
@@ -28695,42 +28746,46 @@ packages:
   - zziplib >=0.13.69,<0.14.0a0
   license: MIT
   license_family: MIT
-  size: 4193167
-  timestamp: 1712610834597
+  size: 4154553
+  timestamp: 1724199474548
 - kind: conda
   name: ogre-next
   version: 2.3.3
-  build: h606bb5d_0
+  build: hb2de451_1
+  build_number: 1
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/ogre-next-2.3.3-h606bb5d_0.conda
-  sha256: 6e389230722183cada2541d37769530c9072dc996725abce39186ef7c424e80a
-  md5: 05d64d4762a6743952ed2d1f54a83212
+  url: https://conda.anaconda.org/conda-forge/win-64/ogre-next-2.3.3-hb2de451_1.conda
+  sha256: 0be36e72175d6ab75f5feca44996c800b9ace4938b8e4ab9759a7209f7e44c69
+  md5: 8be3b40af5768961e80d9f2871c0e069
   depends:
   - freeimage >=3.18.0,<3.19.0a0
   - freetype >=2.12.1,<3.0a0
-  - libzlib >=1.2.13,<2.0.0a0
+  - libzlib >=1.3.1,<2.0a0
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
   - zziplib >=0.13.69,<0.14.0a0
   license: MIT
   license_family: MIT
-  size: 4002319
-  timestamp: 1712612438810
+  size: 3984990
+  timestamp: 1724201435856
 - kind: conda
   name: ogre-next
   version: 2.3.3
-  build: h736244c_0
+  build: hdfe6764_1
+  build_number: 1
   subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/ogre-next-2.3.3-h736244c_0.conda
-  sha256: e9cb6be74edb5551e5b91bdd3ef178185e1835feb5df4e48b63200acceecb557
-  md5: df239e5adb6eb8f682373cdf1020bbad
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/ogre-next-2.3.3-hdfe6764_1.conda
+  sha256: f9f3d25cdaec6ca72280e449f068501fbc26c9aaa6faf50d518a9b97825a5621
+  md5: 333bed3202b218579942b5c32a09759c
   depends:
   - freeimage >=3.18.0,<3.19.0a0
   - freetype >=2.12.1,<3.0a0
+  - libegl >=1.7.0,<2.0a0
   - libgcc-ng >=12
+  - libgl >=1.7.0,<2.0a0
   - libstdcxx-ng >=12
-  - libzlib >=1.2.13,<2.0.0a0
+  - libzlib >=1.3.1,<2.0a0
   - xorg-libx11 >=1.8.9,<2.0a0
   - xorg-libxaw
   - xorg-libxfixes
@@ -28739,27 +28794,8 @@ packages:
   - zziplib >=0.13.69,<0.14.0a0
   license: MIT
   license_family: MIT
-  size: 4077677
-  timestamp: 1712611040895
-- kind: conda
-  name: ogre-next
-  version: 2.3.3
-  build: h74574cf_0
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/ogre-next-2.3.3-h74574cf_0.conda
-  sha256: 8a9a9c53eb9b7c84b678630fe8b263cefb7384218849b36fe12398350dae5032
-  md5: 60351a53782aba4802c35c4846634470
-  depends:
-  - __osx >=10.9
-  - freeimage >=3.18.0,<3.19.0a0
-  - freetype >=2.12.1,<3.0a0
-  - libcxx >=16
-  - libzlib >=1.2.13,<2.0.0a0
-  - zziplib >=0.13.69,<0.14.0a0
-  license: MIT
-  license_family: MIT
-  size: 3569585
-  timestamp: 1712611698919
+  size: 4039702
+  timestamp: 1724199771950
 - kind: conda
   name: onnxruntime-cpp
   version: 1.18.1
@@ -28907,23 +28943,22 @@ packages:
   timestamp: 1703367466828
 - kind: conda
   name: openblas
-  version: 0.3.27
-  build: pthreads_h29161c6_1
-  build_number: 1
+  version: 0.3.28
+  build: pthreads_h29161c6_0
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/openblas-0.3.27-pthreads_h29161c6_1.conda
-  sha256: 8f9b7431dda77788f7839a621fa01c2b4f70a9cffe33686001e93f9208ad1dec
-  md5: 0a9a5cddd1191ce62d408273029094a4
+  url: https://conda.anaconda.org/conda-forge/win-64/openblas-0.3.28-pthreads_h29161c6_0.conda
+  sha256: b11869d8846cf1a1ff8948a84d7abc3f995ebfc9b4174894c48a1bc0f746e65a
+  md5: 5edf7f55005508b496ab95d7e7efa9ed
   depends:
   - libflang >=5.0.0,<6.0.0.a0
-  - libopenblas 0.3.27 pthreads_hf0a32cb_1
+  - libopenblas 0.3.28 pthreads_hf0a32cb_0
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
   license: BSD-3-Clause
   license_family: BSD
-  size: 263118
-  timestamp: 1720443598917
+  size: 264856
+  timestamp: 1723935090369
 - kind: conda
   name: opencv
   version: 4.10.0
@@ -28982,6 +29017,24 @@ packages:
 - kind: conda
   name: opencv
   version: 4.10.0
+  build: qt6_py310h36cc372_602
+  build_number: 602
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/opencv-4.10.0-qt6_py310h36cc372_602.conda
+  sha256: 6cc6e761b41c1d2180622fa47bdd57207de1716d08daace0c6f5fdcd72f2caea
+  md5: e4f44a62e3ec9108337e0fab1cc42c28
+  depends:
+  - libopencv 4.10.0 qt6_py310hb73b763_602
+  - libprotobuf >=4.25.3,<4.25.4.0a0
+  - py-opencv 4.10.0 qt6_py310h7364d9e_602
+  - python_abi 3.10.* *_cp310
+  license: Apache-2.0
+  license_family: Apache
+  size: 26690
+  timestamp: 1721306440410
+- kind: conda
+  name: opencv
+  version: 4.10.0
   build: qt6_py310h681cb09_600
   build_number: 600
   subdir: linux-64
@@ -28997,24 +29050,6 @@ packages:
   license_family: Apache
   size: 26892
   timestamp: 1717732270918
-- kind: conda
-  name: opencv
-  version: 4.10.0
-  build: qt6_py312hfab33ed_602
-  build_number: 602
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/opencv-4.10.0-qt6_py312hfab33ed_602.conda
-  sha256: 18e78ffedc48c56cda2aaa4b69aeb4ce67adf0580e78b543cf2dbe750410f7cf
-  md5: 45964b3d1164e82cb15d8df383aacbd0
-  depends:
-  - libopencv 4.10.0 qt6_py312h00ae949_602
-  - libprotobuf >=4.25.3,<4.25.4.0a0
-  - py-opencv 4.10.0 qt6_py312h8df5404_602
-  - python_abi 3.12.* *_cp312
-  license: Apache-2.0
-  license_family: Apache
-  size: 26755
-  timestamp: 1721307498925
 - kind: conda
   name: openexr
   version: 3.2.2
@@ -29906,11 +29941,11 @@ packages:
 - kind: conda
   name: pillow
   version: 10.4.0
-  build: py312h381445a_0
+  build: py310h3e38d90_0
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/pillow-10.4.0-py312h381445a_0.conda
-  sha256: 2c76c1ded20c5199d134ccecab596412510a016218f342914fd85384a850e7ed
-  md5: cc1e714c3cc43c59d9d0efa228c16364
+  url: https://conda.anaconda.org/conda-forge/win-64/pillow-10.4.0-py310h3e38d90_0.conda
+  sha256: 61ca46cbe2655a2cccb26cd28bbcf8553e9260936e673229b012bd168927ce48
+  md5: fc84db805fe3d9abc75610fca86300c7
   depends:
   - freetype >=2.12.1,<3.0a0
   - lcms2 >=2.16,<3.0a0
@@ -29920,15 +29955,15 @@ packages:
   - libxcb >=1.16,<1.17.0a0
   - libzlib >=1.3.1,<2.0a0
   - openjpeg >=2.5.2,<3.0a0
-  - python >=3.12,<3.13.0a0
-  - python_abi 3.12.* *_cp312
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
   - tk >=8.6.13,<8.7.0a0
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
   license: HPND
-  size: 42560613
-  timestamp: 1719904152461
+  size: 42017999
+  timestamp: 1719904009428
 - kind: conda
   name: pip
   version: '24.2'
@@ -30900,54 +30935,34 @@ packages:
 - kind: conda
   name: py-opencv
   version: 4.10.0
-  build: qt6_py312h8df5404_602
+  build: qt6_py310h7364d9e_602
   build_number: 602
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/py-opencv-4.10.0-qt6_py312h8df5404_602.conda
-  sha256: af0f7d7c13652c70ce19a0d11ddf72d3bd1f7a973746616fcfdf8c4f7ac3e1d8
-  md5: 10e5cbd50a6deeaaa4f60e8682adaf4f
+  url: https://conda.anaconda.org/conda-forge/win-64/py-opencv-4.10.0-qt6_py310h7364d9e_602.conda
+  sha256: bd7cfd984f7749fd75aa5b1277706d6df0ee726b3d8f6433ea2fdf77bf0269e9
+  md5: 09b29c8a17df9fcdcce0c4b07c065bed
   depends:
-  - libopencv 4.10.0 qt6_py312h00ae949_602
+  - libopencv 4.10.0 qt6_py310hb73b763_602
   - libprotobuf >=4.25.3,<4.25.4.0a0
   - numpy >=1.19,<3
-  - python >=3.12,<3.13.0a0
-  - python_abi 3.12.* *_cp312
-  license: Apache-2.0
-  license_family: Apache
-  size: 1153406
-  timestamp: 1721307470345
-- kind: conda
-  name: pybind11
-  version: 2.13.1
-  build: py310h25c7140_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/pybind11-2.13.1-py310h25c7140_0.conda
-  sha256: 797014ab57862579813c608dce0bab2d22da2e740f078635c2df2751c9db3f6c
-  md5: 52642318a8526e7d561542c60b14064a
-  depends:
-  - libgcc-ng >=12
-  - libstdcxx-ng >=12
-  - pybind11-global 2.13.1 py310h25c7140_0
   - python >=3.10,<3.11.0a0
   - python_abi 3.10.* *_cp310
-  constrains:
-  - pybind11-abi ==4
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 191539
-  timestamp: 1719462337657
+  license: Apache-2.0
+  license_family: Apache
+  size: 1153646
+  timestamp: 1721306415329
 - kind: conda
   name: pybind11
-  version: 2.13.1
+  version: 2.13.4
   build: py310h6cd5c4a_0
   subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/pybind11-2.13.1-py310h6cd5c4a_0.conda
-  sha256: 25cdb291a93eb1174e5e3cae19fae9b70a5f5d2694fecdbad3c4df20d454ec28
-  md5: a9d0acaf9ec02e85865efd1b4c33e869
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/pybind11-2.13.4-py310h6cd5c4a_0.conda
+  sha256: 6acf213f928d1901367beef660649286273a70a558cc499ccb98cee9dfab6423
+  md5: bb81a6bc20164fa232bc990cbb2c2975
   depends:
   - libgcc-ng >=12
   - libstdcxx-ng >=12
-  - pybind11-global 2.13.1 py310h6cd5c4a_0
+  - pybind11-global 2.13.4 py310h6cd5c4a_0
   - python >=3.10,<3.11.0a0
   - python >=3.10,<3.11.0a0 *_cpython
   - python_abi 3.10.* *_cp310
@@ -30955,61 +30970,41 @@ packages:
   - pybind11-abi ==4
   license: BSD-3-Clause
   license_family: BSD
-  size: 191313
-  timestamp: 1719462427110
+  size: 192587
+  timestamp: 1723708174659
 - kind: conda
   name: pybind11
-  version: 2.13.1
-  build: py311h46c8309_0
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/pybind11-2.13.1-py311h46c8309_0.conda
-  sha256: 1a296dbc0cfbabe86461c13405f823d48624ae933a4c8865d82dec0f86bd77f4
-  md5: a52a753a7e61a6c57e43727df12bb433
+  version: 2.13.4
+  build: py310haa687a3_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/pybind11-2.13.4-py310haa687a3_0.conda
+  sha256: c382ce15823faa9a969990b85a86d8173e2e8012000f1b1f8b974f52e00119fa
+  md5: 99c3f466e0669f04922d0eada5191fad
   depends:
-  - __osx >=10.13
-  - libcxx >=16
-  - pybind11-global 2.13.1 py311h46c8309_0
-  - python >=3.11,<3.12.0a0
-  - python_abi 3.11.* *_cp311
+  - __glibc >=2.17,<3.0.a0
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - pybind11-global 2.13.4 py310haa687a3_0
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
   constrains:
   - pybind11-abi ==4
   license: BSD-3-Clause
   license_family: BSD
-  size: 195772
-  timestamp: 1719462403829
+  size: 192548
+  timestamp: 1723708078225
 - kind: conda
   name: pybind11
-  version: 2.13.1
-  build: py312h157fec4_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/pybind11-2.13.1-py312h157fec4_0.conda
-  sha256: 14fcb0265e5d4d7d522aaf84f1a980b98153a77cdbcfea7b3fa1cc2c3359f4bf
-  md5: 381e94d2bc47eb3b58a98129b824cdc0
-  depends:
-  - __osx >=11.0
-  - libcxx >=16
-  - pybind11-global 2.13.1 py312h157fec4_0
-  - python >=3.12,<3.13.0a0
-  - python >=3.12,<3.13.0a0 *_cpython
-  - python_abi 3.12.* *_cp312
-  constrains:
-  - pybind11-abi ==4
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 195918
-  timestamp: 1719462577816
-- kind: conda
-  name: pybind11
-  version: 2.13.1
-  build: py312hd5eb7cc_0
+  version: 2.13.4
+  build: py310hc19bc0b_0
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/pybind11-2.13.1-py312hd5eb7cc_0.conda
-  sha256: cb2aa836e8110b24d9e2b8117e9c351eecf9dc8f55a456bdc9f124679130aa49
-  md5: 1e186cead70702ee844a2865d5d3c256
+  url: https://conda.anaconda.org/conda-forge/win-64/pybind11-2.13.4-py310hc19bc0b_0.conda
+  sha256: 97962314370264515eca9c138d88e46cee556ed440662c5f97b57bc128ad6411
+  md5: 6ebc9e64381521c3b5f382612990210c
   depends:
-  - pybind11-global 2.13.1 py312hd5eb7cc_0
-  - python >=3.12,<3.13.0a0
-  - python_abi 3.12.* *_cp312
+  - pybind11-global 2.13.4 py310hc19bc0b_0
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
@@ -31017,8 +31012,49 @@ packages:
   - pybind11-abi ==4
   license: BSD-3-Clause
   license_family: BSD
-  size: 244558
-  timestamp: 1719462929157
+  size: 241647
+  timestamp: 1723708464707
+- kind: conda
+  name: pybind11
+  version: 2.13.4
+  build: py311h46c8309_0
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/pybind11-2.13.4-py311h46c8309_0.conda
+  sha256: 105740b771b9bac8228398e0c43cfd85ddbf5044660a2f2f5a1fa77895ba7042
+  md5: ca0e036f454968fd2d77ccf82e955fb9
+  depends:
+  - __osx >=10.13
+  - libcxx >=16
+  - pybind11-global 2.13.4 py311h46c8309_0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  constrains:
+  - pybind11-abi ==4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 197429
+  timestamp: 1723708184583
+- kind: conda
+  name: pybind11
+  version: 2.13.4
+  build: py312h157fec4_0
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/pybind11-2.13.4-py312h157fec4_0.conda
+  sha256: aca2b369c01614f170aff9fac8f13cd4f06b7badeaf630eec4979c00b9dfe626
+  md5: 81ecb3aa5cbc8cd704a29b92288a57d5
+  depends:
+  - __osx >=11.0
+  - libcxx >=16
+  - pybind11-global 2.13.4 py312h157fec4_0
+  - python >=3.12,<3.13.0a0
+  - python >=3.12,<3.13.0a0 *_cpython
+  - python_abi 3.12.* *_cp312
+  constrains:
+  - pybind11-abi ==4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 196833
+  timestamp: 1723708365356
 - kind: conda
   name: pybind11-abi
   version: '4'
@@ -31035,31 +31071,12 @@ packages:
   timestamp: 1610372835205
 - kind: conda
   name: pybind11-global
-  version: 2.13.1
-  build: py310h25c7140_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/pybind11-global-2.13.1-py310h25c7140_0.conda
-  sha256: 8d711967ac5a058f23229551ce16d75a0fc91e9c0cad79ce7b91462ce643a3cb
-  md5: 24cfaf96ea03106eab930465e055d85d
-  depends:
-  - libgcc-ng >=12
-  - libstdcxx-ng >=12
-  - python >=3.10,<3.11.0a0
-  - python_abi 3.10.* *_cp310
-  constrains:
-  - pybind11-abi ==4
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 179372
-  timestamp: 1719462319656
-- kind: conda
-  name: pybind11-global
-  version: 2.13.1
+  version: 2.13.4
   build: py310h6cd5c4a_0
   subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/pybind11-global-2.13.1-py310h6cd5c4a_0.conda
-  sha256: 3dcf1a3249f9b58d6011f7141b096612f9abc2f1e1b077fb1a708ab1c5803f8a
-  md5: 1d0497ae7bcd118a0a933cbba567ad74
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/pybind11-global-2.13.4-py310h6cd5c4a_0.conda
+  sha256: 1d8f73d7c076e1d4e9b2e49fe46a8c0ddbca3fe04b6a3ace208a38f0f727e2a2
+  md5: 178c3afa49d21e1244ee5fcf0e7e2b6e
   depends:
   - libgcc-ng >=12
   - libstdcxx-ng >=12
@@ -31070,16 +31087,56 @@ packages:
   - pybind11-abi ==4
   license: BSD-3-Clause
   license_family: BSD
-  size: 179799
-  timestamp: 1719462382102
+  size: 181053
+  timestamp: 1723708135662
 - kind: conda
   name: pybind11-global
-  version: 2.13.1
+  version: 2.13.4
+  build: py310haa687a3_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/pybind11-global-2.13.4-py310haa687a3_0.conda
+  sha256: 9b21e675e7ebd9edabf13801cb1e9d9b978abe04f3decdd8b02f1b56886d4fb9
+  md5: cb4bad6e0a8e8bfd535367bd3ceee55e
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  constrains:
+  - pybind11-abi ==4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 180365
+  timestamp: 1723708059347
+- kind: conda
+  name: pybind11-global
+  version: 2.13.4
+  build: py310hc19bc0b_0
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/pybind11-global-2.13.4-py310hc19bc0b_0.conda
+  sha256: 6d8bb16d3a5cf50f58d7238269116479449b3478d77e971e8e1f1715d53e8a2c
+  md5: 6a4ac5c620559587e0052efda01c6b81
+  depends:
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  constrains:
+  - pybind11-abi ==4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 180888
+  timestamp: 1723708285994
+- kind: conda
+  name: pybind11-global
+  version: 2.13.4
   build: py311h46c8309_0
   subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/pybind11-global-2.13.1-py311h46c8309_0.conda
-  sha256: 703aefaf5b907076e602252d65094221ebcd14f8528f7bf49640d7544347a587
-  md5: 449a2689fcfa37043934f656cdec12cf
+  url: https://conda.anaconda.org/conda-forge/osx-64/pybind11-global-2.13.4-py311h46c8309_0.conda
+  sha256: 7bc58b4be7e45e5abecdf72b4c1ef5f1088fedd365284e6c3f2b5dc3b71102aa
+  md5: 94da67585ebd7c88cec181a62ca3e15e
   depends:
   - __osx >=10.13
   - libcxx >=16
@@ -31089,16 +31146,16 @@ packages:
   - pybind11-abi ==4
   license: BSD-3-Clause
   license_family: BSD
-  size: 180177
-  timestamp: 1719462351794
+  size: 181419
+  timestamp: 1723708123655
 - kind: conda
   name: pybind11-global
-  version: 2.13.1
+  version: 2.13.4
   build: py312h157fec4_0
   subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/pybind11-global-2.13.1-py312h157fec4_0.conda
-  sha256: 10f64daeabc3aaa46956a5de62bf440007b1907c23b058b5d4ac088fedf6bbf8
-  md5: 862ada3f318f27af30b6c29a770b2856
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/pybind11-global-2.13.4-py312h157fec4_0.conda
+  sha256: aec25082b129e336088faaeda8fdf20a327b4307c468cc77f2b478afd9070198
+  md5: 380ce3d7a49e88ad3ac0aa22e58c4293
   depends:
   - __osx >=11.0
   - libcxx >=16
@@ -31109,28 +31166,8 @@ packages:
   - pybind11-abi ==4
   license: BSD-3-Clause
   license_family: BSD
-  size: 180568
-  timestamp: 1719462510912
-- kind: conda
-  name: pybind11-global
-  version: 2.13.1
-  build: py312hd5eb7cc_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/pybind11-global-2.13.1-py312hd5eb7cc_0.conda
-  sha256: 6e9cefc7c637438b052b6d3e0db035441815c5ed5cc21d561ae168b315f53e8b
-  md5: 06f97518657f4143f37b9298048a4cf8
-  depends:
-  - python >=3.12,<3.13.0a0
-  - python_abi 3.12.* *_cp312
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  constrains:
-  - pybind11-abi ==4
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 180291
-  timestamp: 1719462612888
+  size: 180979
+  timestamp: 1723708305286
 - kind: conda
   name: pygments
   version: 2.18.0
@@ -31182,6 +31219,28 @@ packages:
   license_family: GPL
   size: 5282574
   timestamp: 1695420653225
+- kind: conda
+  name: pyqt
+  version: 5.15.9
+  build: py310h1fd54f2_5
+  build_number: 5
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/pyqt-5.15.9-py310h1fd54f2_5.conda
+  sha256: 3aa9660d4b0c2db725bbad77840ac17180c5093617c34aa9467276dbac2d19e4
+  md5: 5df867d89a0482ea3591fe61f1558781
+  depends:
+  - pyqt5-sip 12.12.2 py310h00ffb61_5
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  - qt-main >=5.15.8,<5.16.0a0
+  - sip >=6.7.11,<6.8.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: GPL-3.0-only
+  license_family: GPL
+  size: 3881331
+  timestamp: 1695421370903
 - kind: conda
   name: pyqt
   version: 5.15.9
@@ -31246,27 +31305,27 @@ packages:
   size: 3937925
   timestamp: 1695422000443
 - kind: conda
-  name: pyqt
-  version: 5.15.9
-  build: py312he09f080_5
+  name: pyqt5-sip
+  version: 12.12.2
+  build: py310h00ffb61_5
   build_number: 5
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/pyqt-5.15.9-py312he09f080_5.conda
-  sha256: c524cafaf98661f3bd5819494b41563fe5a851f6e44a7d08631c99f1dfb961c7
-  md5: fb0861092c40e5d054e984abd88e5ea8
+  url: https://conda.anaconda.org/conda-forge/win-64/pyqt5-sip-12.12.2-py310h00ffb61_5.conda
+  sha256: 59cc61adf7563005c8d5d305539f3fbddf6fed0298d747cc0a93fba667191411
+  md5: bf433b3dde7783aed71126051d1a5878
   depends:
-  - pyqt5-sip 12.12.2 py312h53d5487_5
-  - python >=3.12.0rc3,<3.13.0a0
-  - python_abi 3.12.* *_cp312
-  - qt-main >=5.15.8,<5.16.0a0
-  - sip >=6.7.11,<6.8.0a0
+  - packaging
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  - sip
+  - toml
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
   license: GPL-3.0-only
   license_family: GPL
-  size: 3894083
-  timestamp: 1695421066159
+  size: 79787
+  timestamp: 1695418575552
 - kind: conda
   name: pyqt5-sip
   version: 12.12.2
@@ -31330,28 +31389,6 @@ packages:
   license_family: GPL
   size: 74911
   timestamp: 1695418163407
-- kind: conda
-  name: pyqt5-sip
-  version: 12.12.2
-  build: py312h53d5487_5
-  build_number: 5
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/pyqt5-sip-12.12.2-py312h53d5487_5.conda
-  sha256: 56242d5203e7231ee5bdd25df417dfc60a4f38e335f922f7e00f8c518ba87bd1
-  md5: dbaa69d84f7da6ac3ec20de2a9529a4b
-  depends:
-  - packaging
-  - python >=3.12.0rc3,<3.13.0a0
-  - python_abi 3.12.* *_cp312
-  - sip
-  - toml
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  license: GPL-3.0-only
-  license_family: GPL
-  size: 79366
-  timestamp: 1695418564486
 - kind: conda
   name: pyqt5-sip
   version: 12.12.2
@@ -31420,6 +31457,29 @@ packages:
 - kind: conda
   name: pyqtwebengine
   version: 5.15.9
+  build: py310he49db7d_5
+  build_number: 5
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/pyqtwebengine-5.15.9-py310he49db7d_5.conda
+  sha256: a1a8f9727c48bc65b0984ff312d4b74293ed1051c7b1db4ef88060fd1d2f14a2
+  md5: 7a77a2e247d8b386c56976b9bb205823
+  depends:
+  - pyqt >=5.15.9,<5.16.0a0
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  - qt-main >=5.15.8,<5.16.0a0
+  - qt-webengine >=5.15.8,<5.16.0a0
+  - sip >=6.7.11,<6.8.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: GPL-3.0-only
+  license_family: GPL
+  size: 126718
+  timestamp: 1695421915390
+- kind: conda
+  name: pyqtwebengine
+  version: 5.15.9
   build: py311hfec3007_5
   build_number: 5
   subdir: osx-64
@@ -31462,29 +31522,6 @@ packages:
   size: 127814
   timestamp: 1695422648234
 - kind: conda
-  name: pyqtwebengine
-  version: 5.15.9
-  build: py312hca0710b_5
-  build_number: 5
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/pyqtwebengine-5.15.9-py312hca0710b_5.conda
-  sha256: 8ad8577aca9867d994584baf11ac3a77ee4fe1dc4af09f8d866be5ccc97f5ddc
-  md5: 15365ae4f4c079772b40266af3009615
-  depends:
-  - pyqt >=5.15.9,<5.16.0a0
-  - python >=3.12.0rc3,<3.13.0a0
-  - python_abi 3.12.* *_cp312
-  - qt-main >=5.15.8,<5.16.0a0
-  - qt-webengine >=5.15.8,<5.16.0a0
-  - sip >=6.7.11,<6.8.0a0
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  license: GPL-3.0-only
-  license_family: GPL
-  size: 126135
-  timestamp: 1695421581088
-- kind: conda
   name: pyside6
   version: 6.7.2
   build: py310h5a2e0b3_2
@@ -31504,8 +31541,33 @@ packages:
   - qt6-main 6.7.2.*
   - qt6-main >=6.7.2,<6.8.0a0
   license: LGPL-3.0-only
+  license_family: LGPL
   size: 7692297
   timestamp: 1723106837610
+- kind: conda
+  name: pyside6
+  version: 6.7.2
+  build: py310h60c6385_2
+  build_number: 2
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/pyside6-6.7.2-py310h60c6385_2.conda
+  sha256: a4c13a4a102bc59f8cc860aa39a2c9fc79b7d496d3b191e01ee6828bf4c3ece7
+  md5: f34c3e9b93ec0c7e326160bc48d05bcb
+  depends:
+  - libclang13 >=18.1.8
+  - libxml2 >=2.12.7,<3.0a0
+  - libxslt >=1.1.39,<2.0a0
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  - qt6-main 6.7.2.*
+  - qt6-main >=6.7.2,<6.8.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: LGPL-3.0-only
+  license_family: LGPL
+  size: 9253213
+  timestamp: 1723107364387
 - kind: conda
   name: pyside6
   version: 6.7.2
@@ -31527,31 +31589,33 @@ packages:
   - qt6-main 6.7.2.*
   - qt6-main >=6.7.2,<6.8.0a0
   license: LGPL-3.0-only
+  license_family: LGPL
   size: 10618964
   timestamp: 1723106975129
 - kind: conda
-  name: pyside6
-  version: 6.7.2
-  build: py312h2ee7485_2
-  build_number: 2
+  name: python
+  version: 3.10.14
+  build: h4de0772_0_cpython
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/pyside6-6.7.2-py312h2ee7485_2.conda
-  sha256: 1576947d4c0dcf5fb04497aa350bae0cde45e09ae568d7760ff303a20620ad68
-  md5: ee646594cba1942d42cb3bd280243fd2
+  url: https://conda.anaconda.org/conda-forge/win-64/python-3.10.14-h4de0772_0_cpython.conda
+  sha256: 332f97d9927b65857d6d2d4d50d66dce9b37da81edb67833ae6b88ad52acbd0c
+  md5: 4a00e84f29d1eb418d84970598c444e1
   depends:
-  - libclang13 >=18.1.8
-  - libxml2 >=2.12.7,<3.0a0
-  - libxslt >=1.1.39,<2.0a0
-  - python >=3.12,<3.13.0a0
-  - python_abi 3.12.* *_cp312
-  - qt6-main 6.7.2.*
-  - qt6-main >=6.7.2,<6.8.0a0
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  license: LGPL-3.0-only
-  size: 9267851
-  timestamp: 1723107384817
+  - bzip2 >=1.0.8,<2.0a0
+  - libffi >=3.4,<4.0a0
+  - libsqlite >=3.45.2,<4.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - openssl >=3.2.1,<4.0a0
+  - tk >=8.6.13,<8.7.0a0
+  - tzdata
+  - vc >=14.1,<15
+  - vc14_runtime >=14.16.27033
+  - xz >=5.2.6,<6.0a0
+  constrains:
+  - python_abi 3.10.* *_cp310
+  license: Python-2.0
+  size: 15864027
+  timestamp: 1710938888352
 - kind: conda
   name: python
   version: 3.10.14
@@ -31663,32 +31727,6 @@ packages:
   size: 12926356
   timestamp: 1723142203193
 - kind: conda
-  name: python
-  version: 3.12.5
-  build: h889d299_0_cpython
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/python-3.12.5-h889d299_0_cpython.conda
-  sha256: 4cef304eb8877fd3094c14b57097ccc1b817b4afbf2223dd45d2b61e44064740
-  md5: db056d8b140ab2edd56a2f9bdb203dcd
-  depends:
-  - bzip2 >=1.0.8,<2.0a0
-  - libexpat >=2.6.2,<3.0a0
-  - libffi >=3.4,<4.0a0
-  - libsqlite >=3.46.0,<4.0a0
-  - libzlib >=1.3.1,<2.0a0
-  - openssl >=3.3.1,<4.0a0
-  - tk >=8.6.13,<8.7.0a0
-  - tzdata
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  - xz >=5.2.6,<6.0a0
-  constrains:
-  - python_abi 3.12.* *_cp312
-  license: Python-2.0
-  size: 15897752
-  timestamp: 1723141830317
-- kind: conda
   name: python-dateutil
   version: 2.9.0
   build: pyhd8ed1ab_0
@@ -31707,78 +31745,78 @@ packages:
 - kind: conda
   name: python_abi
   version: '3.10'
-  build: 4_cp310
-  build_number: 4
+  build: 5_cp310
+  build_number: 5
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/python_abi-3.10-4_cp310.conda
-  sha256: 456bec815bfc2b364763084d08b412fdc4c17eb9ccc66a36cb775fa7ac3cbaec
-  md5: 26322ec5d7712c3ded99dd656142b8ce
+  url: https://conda.anaconda.org/conda-forge/linux-64/python_abi-3.10-5_cp310.conda
+  sha256: 074d2f0b31f0333b7e553042b17ea54714b74263f8adda9a68a4bd8c7e219971
+  md5: 2921c34715e74b3587b4cff4d36844f9
   constrains:
   - python 3.10.* *_cpython
   license: BSD-3-Clause
   license_family: BSD
-  size: 6398
-  timestamp: 1695147363189
+  size: 6227
+  timestamp: 1723823165457
 - kind: conda
   name: python_abi
   version: '3.10'
-  build: 4_cp310
-  build_number: 4
+  build: 5_cp310
+  build_number: 5
   subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/python_abi-3.10-4_cp310.conda
-  sha256: 9191cc3ddf380b655c08b3436a8174ce0cc798a6dfcfa8ee80fa793d0b7165de
-  md5: b0ff2ed109650f9e90d627d3119eb442
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/python_abi-3.10-5_cp310.conda
+  sha256: 96653ed223e3a8646c22f409936d4c5ac0a22aeef99a3129a86581b80dec484c
+  md5: c6694ec383fb171da3ab68cae8d0e8f1
   constrains:
   - python 3.10.* *_cpython
   license: BSD-3-Clause
   license_family: BSD
-  size: 6436
-  timestamp: 1695147402616
+  size: 6295
+  timestamp: 1723823325134
+- kind: conda
+  name: python_abi
+  version: '3.10'
+  build: 5_cp310
+  build_number: 5
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/python_abi-3.10-5_cp310.conda
+  sha256: 0671bea4d5c5b8618ee7e2b1117d5a90901348ac459db57b654007f1644fa087
+  md5: 3c510f4c4383f5fbdb12fdd971b30d49
+  constrains:
+  - python 3.10.* *_cpython
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6715
+  timestamp: 1723823141288
 - kind: conda
   name: python_abi
   version: '3.11'
-  build: 4_cp311
-  build_number: 4
+  build: 5_cp311
+  build_number: 5
   subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/python_abi-3.11-4_cp311.conda
-  sha256: f56dfe2a57b3b27bad3f9527f943548e8b2526e949d9d6fc0a383020d9359afe
-  md5: fef7a52f0eca6bae9e8e2e255bc86394
+  url: https://conda.anaconda.org/conda-forge/osx-64/python_abi-3.11-5_cp311.conda
+  sha256: 9b092850a268aca99600b724bae849f51209ecd5628e609b4699debc59ff1945
+  md5: e6d62858c06df0be0e6255c753d74787
   constrains:
   - python 3.11.* *_cpython
   license: BSD-3-Clause
   license_family: BSD
-  size: 6478
-  timestamp: 1695147518012
+  size: 6303
+  timestamp: 1723823062672
 - kind: conda
   name: python_abi
   version: '3.12'
-  build: 4_cp312
-  build_number: 4
+  build: 5_cp312
+  build_number: 5
   subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/python_abi-3.12-4_cp312.conda
-  sha256: db25428e4f24f8693ffa39f3ff6dfbb8fd53bc298764b775b57edab1c697560f
-  md5: bbb3a02c78b2d8219d7213f76d644a2a
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/python_abi-3.12-5_cp312.conda
+  sha256: 49d624e4b809c799d2bf257b22c23cf3fc4460f5570d9a58e7ad86350aeaa1f4
+  md5: b76f9b1c862128e56ac7aa8cd2333de9
   constrains:
   - python 3.12.* *_cpython
   license: BSD-3-Clause
   license_family: BSD
-  size: 6508
-  timestamp: 1695147497048
-- kind: conda
-  name: python_abi
-  version: '3.12'
-  build: 4_cp312
-  build_number: 4
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/python_abi-3.12-4_cp312.conda
-  sha256: 488f8519d04b48f59bd6fde21ebe2d7a527718ff28aac86a8b53aa63658bdef6
-  md5: 17f4ccf6be9ded08bd0a376f489ac1a6
-  constrains:
-  - python 3.12.* *_cpython
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 6785
-  timestamp: 1695147430513
+  size: 6278
+  timestamp: 1723823099686
 - kind: conda
   name: pyyaml
   version: 6.0.2
@@ -31797,6 +31835,25 @@ packages:
   license_family: MIT
   size: 181235
   timestamp: 1723018382019
+- kind: conda
+  name: pyyaml
+  version: 6.0.2
+  build: py310ha8f682b_0
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/pyyaml-6.0.2-py310ha8f682b_0.conda
+  sha256: aa4a3fcf658b808b22a95468598942027fd802b59c55d2f1762837cd35e2e586
+  md5: 9419820c1b4d9ffcc4ba80920ca31834
+  depends:
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  - yaml >=0.2.5,<0.3.0a0
+  license: MIT
+  license_family: MIT
+  size: 157624
+  timestamp: 1723018854256
 - kind: conda
   name: pyyaml
   version: 6.0.2
@@ -31835,25 +31892,6 @@ packages:
 - kind: conda
   name: pyyaml
   version: 6.0.2
-  build: py312h4389bb4_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/pyyaml-6.0.2-py312h4389bb4_0.conda
-  sha256: 2413377ce0fd4eee66eaf5450d0200cd9124acfb9fc7932dcdc2f618bc8e840e
-  md5: a64ca370389c8bfacf848f40654ffc04
-  depends:
-  - python >=3.12,<3.13.0a0
-  - python_abi 3.12.* *_cp312
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  - yaml >=0.2.5,<0.3.0a0
-  license: MIT
-  license_family: MIT
-  size: 181385
-  timestamp: 1723018911152
-- kind: conda
-  name: pyyaml
-  version: 6.0.2
   build: py312h7e5086c_0
   subdir: osx-arm64
   url: https://conda.anaconda.org/conda-forge/osx-arm64/pyyaml-6.0.2-py312h7e5086c_0.conda
@@ -31871,12 +31909,32 @@ packages:
   timestamp: 1723018560445
 - kind: conda
   name: pyzmq
-  version: 26.1.0
+  version: 26.1.1
+  build: py310h656833d_0
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/pyzmq-26.1.1-py310h656833d_0.conda
+  sha256: b1df3b270644e974d75ee9c13778e4fa25b4824b063cdbf23970ccd402d280ca
+  md5: 4c1f1c80ae6a50ac5b32bdaf7c8fda21
+  depends:
+  - libsodium >=1.0.18,<1.0.19.0a0
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  - zeromq >=4.3.5,<4.3.6.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 317222
+  timestamp: 1724088813144
+- kind: conda
+  name: pyzmq
+  version: 26.1.1
   build: py310h7d2b5bf_0
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/pyzmq-26.1.0-py310h7d2b5bf_0.conda
-  sha256: 24a35f0a7fd3835bb46e4e58128036a720272ff9e5e62d4427fb29100d0c9f6f
-  md5: 4bd8378aa63d0caaf874cc98bae721fa
+  url: https://conda.anaconda.org/conda-forge/linux-64/pyzmq-26.1.1-py310h7d2b5bf_0.conda
+  sha256: 29ec33ab0b5c56e53d2f40697cdcc9e37fd9e456220196e98e155f4601f8b692
+  md5: c773b8af3fd4b1453ae2260fa5c87de9
   depends:
   - __glibc >=2.17,<3.0.a0
   - libgcc-ng >=12
@@ -31887,16 +31945,16 @@ packages:
   - zeromq >=4.3.5,<4.4.0a0
   license: BSD-3-Clause
   license_family: BSD
-  size: 337913
-  timestamp: 1722971797466
+  size: 337020
+  timestamp: 1724088218216
 - kind: conda
   name: pyzmq
-  version: 26.1.0
+  version: 26.1.1
   build: py310he875deb_0
   subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/pyzmq-26.1.0-py310he875deb_0.conda
-  sha256: 0fdd0a1296f6702abe9a1d4bb98d0d12eac71ff3503148c84983a73bcc513c73
-  md5: 0dde5f3769911ae4d9de17ec589022b2
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/pyzmq-26.1.1-py310he875deb_0.conda
+  sha256: 31cf37f072315e27252ba58b5b809576d172b7b2d452c5ff39cd09e2134702f3
+  md5: 9e7c863cf7ca6ba766097916a42811a8
   depends:
   - libgcc-ng >=12
   - libsodium >=1.0.18,<1.0.19.0a0
@@ -31906,16 +31964,16 @@ packages:
   - zeromq >=4.3.5,<4.4.0a0
   license: BSD-3-Clause
   license_family: BSD
-  size: 330304
-  timestamp: 1722973069675
+  size: 332227
+  timestamp: 1724089799786
 - kind: conda
   name: pyzmq
-  version: 26.1.0
+  version: 26.1.1
   build: py311hdb04418_0
   subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/pyzmq-26.1.0-py311hdb04418_0.conda
-  sha256: 159d45d8247bceae2bde57d2a1bd020f3d1069b7a7f1851bf4b5909dfecb1108
-  md5: cbccd0250ca5e98e66deff72bd23b102
+  url: https://conda.anaconda.org/conda-forge/osx-64/pyzmq-26.1.1-py311hdb04418_0.conda
+  sha256: 600f8a7096df5428233bd7c56658a3e63fbb774800344d65b360d4c0181b7604
+  md5: f2d14b5071936cae445ae41c40bbd1ad
   depends:
   - __osx >=10.13
   - libcxx >=16
@@ -31925,36 +31983,16 @@ packages:
   - zeromq >=4.3.5,<4.4.0a0
   license: BSD-3-Clause
   license_family: BSD
-  size: 366862
-  timestamp: 1722972024352
+  size: 367811
+  timestamp: 1724088405141
 - kind: conda
   name: pyzmq
-  version: 26.1.0
-  build: py312hd7027bb_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/pyzmq-26.1.0-py312hd7027bb_0.conda
-  sha256: 8710241a86d9f6d55fccf9c4a10cb519e552ff5f55d178c9a6cb18c7c2b4d1b4
-  md5: f03b5823588a12062dfb02295805f060
-  depends:
-  - libsodium >=1.0.18,<1.0.19.0a0
-  - python >=3.12,<3.13.0a0
-  - python_abi 3.12.* *_cp312
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  - zeromq >=4.3.5,<4.3.6.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 360916
-  timestamp: 1722972158192
-- kind: conda
-  name: pyzmq
-  version: 26.1.0
+  version: 26.1.1
   build: py312hfa13136_0
   subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/pyzmq-26.1.0-py312hfa13136_0.conda
-  sha256: 778f324396a1d64a95fab98025288782129d5a7fd06b9e2c0ec5cdb679732d0d
-  md5: f8fa2f2cc93fbd47c35d3c3447cc0183
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/pyzmq-26.1.1-py312hfa13136_0.conda
+  sha256: bc7576969187ca2734f324627457d014f927cc963e1bc6960f9cccdd6c3bee9f
+  md5: d3745fb1e83d5387fe7c15e842ed1b34
   depends:
   - __osx >=11.0
   - libcxx >=16
@@ -31965,8 +32003,8 @@ packages:
   - zeromq >=4.3.5,<4.4.0a0
   license: BSD-3-Clause
   license_family: BSD
-  size: 360348
-  timestamp: 1722971946384
+  size: 360498
+  timestamp: 1724088358370
 - kind: conda
   name: qhull
   version: '2020.2'
@@ -33282,19 +33320,19 @@ packages:
   timestamp: 1720071699988
 - kind: conda
   name: setuptools
-  version: 72.1.0
+  version: 72.2.0
   build: pyhd8ed1ab_0
   subdir: noarch
   noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/setuptools-72.1.0-pyhd8ed1ab_0.conda
-  sha256: d239e7f1b1a5617eeadda4e91183592f5a15219e97e16bc721d7b0597ee89a80
-  md5: e06d4c26df4f958a8d38696f2c344d15
+  url: https://conda.anaconda.org/conda-forge/noarch/setuptools-72.2.0-pyhd8ed1ab_0.conda
+  sha256: 0252f6570de8ff29d489958fc7826677a518061b1aa5e1828a427eec8a7928a4
+  md5: 1462aa8b243aad09ef5d0841c745eb89
   depends:
   - python >=3.8
   license: MIT
   license_family: MIT
-  size: 1462612
-  timestamp: 1722586785703
+  size: 1459799
+  timestamp: 1724163617860
 - kind: conda
   name: sigtool
   version: 0.1.3
@@ -33418,6 +33456,27 @@ packages:
 - kind: conda
   name: sip
   version: 6.7.12
+  build: py310h00ffb61_0
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/sip-6.7.12-py310h00ffb61_0.conda
+  sha256: 159f95e125ff48fa84cfbff8ef7ccfe14b6960df108b6c1d3472d0248bb07781
+  md5: 882ddccbb0d5c47da05eb35ec4813c16
+  depends:
+  - packaging
+  - ply
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  - tomli
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: GPL-3.0-only
+  license_family: GPL
+  size: 504474
+  timestamp: 1697300911843
+- kind: conda
+  name: sip
+  version: 6.7.12
   build: py310hc6cd4ac_0
   subdir: linux-64
   url: https://conda.anaconda.org/conda-forge/linux-64/sip-6.7.12-py310hc6cd4ac_0.conda
@@ -33455,27 +33514,6 @@ packages:
   license_family: GPL
   size: 573640
   timestamp: 1697300780749
-- kind: conda
-  name: sip
-  version: 6.7.12
-  build: py312h53d5487_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/sip-6.7.12-py312h53d5487_0.conda
-  sha256: 2347c2e7d5e7282b991d5d4f7448d9e6fe8c26e5d6df0d09f0e60b11b7d19586
-  md5: a5d3d1363d6d0b4827d6b940414a5b76
-  depends:
-  - packaging
-  - ply
-  - python >=3.12,<3.13.0a0
-  - python_abi 3.12.* *_cp312
-  - tomli
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  license: GPL-3.0-only
-  license_family: GPL
-  size: 589657
-  timestamp: 1697301028797
 - kind: conda
   name: sip
   version: 6.8.3
@@ -34776,6 +34814,24 @@ packages:
 - kind: conda
   name: tornado
   version: 6.4.1
+  build: py310ha8f682b_0
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/tornado-6.4.1-py310ha8f682b_0.conda
+  sha256: 3835993b73c51cc2182e6db7e02ff8e789a15a6c99d58b3b5201fd9b2d7819df
+  md5: 3a4766af5964f09e907838d42447c098
+  depends:
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Apache-2.0
+  license_family: Apache
+  size: 653198
+  timestamp: 1717723134108
+- kind: conda
+  name: tornado
+  version: 6.4.1
   build: py310hc51659f_0
   subdir: linux-64
   url: https://conda.anaconda.org/conda-forge/linux-64/tornado-6.4.1-py310hc51659f_0.conda
@@ -34805,24 +34861,6 @@ packages:
   license_family: Apache
   size: 859395
   timestamp: 1717722909139
-- kind: conda
-  name: tornado
-  version: 6.4.1
-  build: py312h4389bb4_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/tornado-6.4.1-py312h4389bb4_0.conda
-  sha256: 1db4650b15e902828ecc67754eb287971879401ce35437f3a8c3c3da2158af2c
-  md5: 00a82356b77563593acad8b86de9c5c7
-  depends:
-  - python >=3.12,<3.13.0a0
-  - python_abi 3.12.* *_cp312
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  license: Apache-2.0
-  license_family: Apache
-  size: 844267
-  timestamp: 1717723122629
 - kind: conda
   name: tornado
   version: 6.4.1
@@ -34995,6 +35033,24 @@ packages:
   license_family: Apache
   size: 374055
   timestamp: 1695848183607
+- kind: conda
+  name: unicodedata2
+  version: 15.1.0
+  build: py310h8d17308_0
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/unicodedata2-15.1.0-py310h8d17308_0.conda
+  sha256: 7beadca7de88d62b65124a98e0c442cef787dac2ac41768deb7200fd33d07603
+  md5: f9f25aeb0eed2dd8c770f137c45da3c2
+  depends:
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Apache-2.0
+  license_family: Apache
+  size: 370116
+  timestamp: 1695848575933
 - kind: conda
   name: unicodedata2
   version: 15.1.0
@@ -35488,6 +35544,21 @@ packages:
 - kind: conda
   name: vtk
   version: 9.3.0
+  build: qt_py310h1234567_200
+  build_number: 200
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/vtk-9.3.0-qt_py310h1234567_200.conda
+  sha256: db20a433580b0d1a788d0ee9e457f7277ba56b78acf5f478f5835fa1abc7aac1
+  md5: c3243e116e9fd81e7ca5efb1b43083c0
+  depends:
+  - vtk-base 9.3.0 qt_py310h1234567_200
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 21663
+  timestamp: 1718294211655
+- kind: conda
+  name: vtk
+  version: 9.3.0
   build: qt_py311h1234567_200
   build_number: 200
   subdir: osx-64
@@ -35517,21 +35588,6 @@ packages:
   license_family: BSD
   size: 21444
   timestamp: 1718297893706
-- kind: conda
-  name: vtk
-  version: 9.3.0
-  build: qt_py312h1234567_200
-  build_number: 200
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/vtk-9.3.0-qt_py312h1234567_200.conda
-  sha256: f8c10a82dbaa2334f96cc72c49e09094f0cbb310898446a81824d2fb8dbf26e9
-  md5: a9d67585c2d353c3a2dd8280074d9304
-  depends:
-  - vtk-base 9.3.0 qt_py312h1234567_200
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 21620
-  timestamp: 1718294384709
 - kind: conda
   name: vtk-base
   version: 9.3.0
@@ -35657,6 +35713,59 @@ packages:
 - kind: conda
   name: vtk-base
   version: 9.3.0
+  build: qt_py310h1234567_200
+  build_number: 200
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/vtk-base-9.3.0-qt_py310h1234567_200.conda
+  sha256: d67e5ff6be9a7cb1ba2473e1c6ae80ea1ca04c5cc384accdaaea90c768be9968
+  md5: be6783f012b1948f979c52fbec37230c
+  depends:
+  - double-conversion >=3.3.0,<3.4.0a0
+  - eigen
+  - expat
+  - ffmpeg >=6.1.1,<7.0a0
+  - freetype >=2.12.1,<3.0a0
+  - gl2ps >=1.4.2,<1.4.3.0a0
+  - glew >=2.1.0,<2.2.0a0
+  - hdf5 >=1.14.3,<1.14.4.0a0
+  - jsoncpp >=1.9.5,<1.9.6.0a0
+  - libexpat >=2.6.2,<3.0a0
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libnetcdf >=4.9.2,<4.9.3.0a0
+  - libogg >=1.3.4,<1.4.0a0
+  - libpng >=1.6.43,<1.7.0a0
+  - libsqlite >=3.46.0,<4.0a0
+  - libtheora >=1.1.1,<1.2.0a0
+  - libtiff >=4.6.0,<4.7.0a0
+  - libxml2 >=2.12.7,<3.0a0
+  - libzlib >=1.2.13,<2.0a0
+  - loguru
+  - lz4-c >=1.9.3,<1.10.0a0
+  - nlohmann_json
+  - numpy
+  - proj >=9.3.1,<9.3.2.0a0
+  - pugixml >=1.14,<1.15.0a0
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  - qt6-main >=6.7.1,<6.8.0a0
+  - sqlite
+  - tbb >=2021.12.0
+  - tbb-devel
+  - ucrt >=10.0.20348.0
+  - utfcpp
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  - wslink
+  - zlib
+  constrains:
+  - paraview ==9999999999
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 33242929
+  timestamp: 1718294095936
+- kind: conda
+  name: vtk-base
+  version: 9.3.0
   build: qt_py311h1234567_200
   build_number: 200
   subdir: osx-64
@@ -35759,59 +35868,6 @@ packages:
   license_family: BSD
   size: 34332059
   timestamp: 1718297669390
-- kind: conda
-  name: vtk-base
-  version: 9.3.0
-  build: qt_py312h1234567_200
-  build_number: 200
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/vtk-base-9.3.0-qt_py312h1234567_200.conda
-  sha256: c23a7fbc749b0d76c3f19d3f9a71ad0edd8d3b10ed814085f577e86228cfe387
-  md5: 0a63447c2dcbe146b0e2addcc19fd6d7
-  depends:
-  - double-conversion >=3.3.0,<3.4.0a0
-  - eigen
-  - expat
-  - ffmpeg >=6.1.1,<7.0a0
-  - freetype >=2.12.1,<3.0a0
-  - gl2ps >=1.4.2,<1.4.3.0a0
-  - glew >=2.1.0,<2.2.0a0
-  - hdf5 >=1.14.3,<1.14.4.0a0
-  - jsoncpp >=1.9.5,<1.9.6.0a0
-  - libexpat >=2.6.2,<3.0a0
-  - libjpeg-turbo >=3.0.0,<4.0a0
-  - libnetcdf >=4.9.2,<4.9.3.0a0
-  - libogg >=1.3.4,<1.4.0a0
-  - libpng >=1.6.43,<1.7.0a0
-  - libsqlite >=3.46.0,<4.0a0
-  - libtheora >=1.1.1,<1.2.0a0
-  - libtiff >=4.6.0,<4.7.0a0
-  - libxml2 >=2.12.7,<3.0a0
-  - libzlib >=1.2.13,<2.0a0
-  - loguru
-  - lz4-c >=1.9.3,<1.10.0a0
-  - nlohmann_json
-  - numpy
-  - proj >=9.3.1,<9.3.2.0a0
-  - pugixml >=1.14,<1.15.0a0
-  - python >=3.12,<3.13.0a0
-  - python_abi 3.12.* *_cp312
-  - qt6-main >=6.7.1,<6.8.0a0
-  - sqlite
-  - tbb >=2021.12.0
-  - tbb-devel
-  - ucrt >=10.0.20348.0
-  - utfcpp
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  - wslink
-  - zlib
-  constrains:
-  - paraview ==9999999999
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 33334664
-  timestamp: 1718294265362
 - kind: conda
   name: vtk-io-ffmpeg
   version: 9.3.0
@@ -35969,6 +36025,7 @@ packages:
   - msgpack-python >=1,<2
   - python >=3.7
   license: BSD-3-Clause
+  license_family: BSD
   size: 34031
   timestamp: 1723075844900
 - kind: conda
@@ -38303,6 +38360,26 @@ packages:
 - kind: conda
   name: yarl
   version: 1.9.4
+  build: py310h8d17308_0
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/yarl-1.9.4-py310h8d17308_0.conda
+  sha256: d2dbebe86bae6217636787b7ed2f1b2db9cb9d2462d4507c01698ef72d277ce7
+  md5: cd2e7569bc83ce51822e11fa52930f15
+  depends:
+  - idna >=2.0
+  - multidict >=4.0
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Apache-2.0
+  license_family: Apache
+  size: 103653
+  timestamp: 1705509067258
+- kind: conda
+  name: yarl
+  version: 1.9.4
   build: py310hb299538_0
   subdir: linux-aarch64
   url: https://conda.anaconda.org/conda-forge/linux-aarch64/yarl-1.9.4-py310hb299538_0.conda
@@ -38354,26 +38431,6 @@ packages:
   license_family: Apache
   size: 111018
   timestamp: 1705509068239
-- kind: conda
-  name: yarl
-  version: 1.9.4
-  build: py312he70551f_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/yarl-1.9.4-py312he70551f_0.conda
-  sha256: 57089bd47731282b4f58c378b4711f397393e6e1c8252aa49af881e36685e07d
-  md5: 9dee8a153f1644fbc66c40bcda96bf59
-  depends:
-  - idna >=2.0
-  - multidict >=4.0
-  - python >=3.12,<3.13.0a0
-  - python_abi 3.12.* *_cp312
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  license: Apache-2.0
-  license_family: Apache
-  size: 111720
-  timestamp: 1705509335395
 - kind: conda
   name: zeromq
   version: 4.3.5

--- a/pixi.toml
+++ b/pixi.toml
@@ -9,6 +9,9 @@ authors = ["Silvio Traversaro <silvio@traversaro.it>"]
 channels = ["conda-forge", "robotology"]
 platforms = ["linux-64", "linux-aarch64", "win-64", "osx-64", "osx-arm64"]
 
+[system-requirements]
+linux = "4.18"
+
 [activation]
 scripts = ["pixi_activation.sh", ".build/install/share/robotology-superbuild/setup.sh"]
 


### PR DESCRIPTION
The default version of pixi 0.27.1 is `5.10`, and so running anything on a HPC system running Rocky Linux 8 results in errors like:

~~~
  × The current system has a mismatching virtual package. The project requires '__linux' to be at least version '5.10' but the system has version '4.18.0'
~~~

xref: https://github.com/prefix-dev/pixi/issues/1884