### PR TITLE
 Add conda + LatestReleases CI build  and switch fail-fast option to true

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,11 +29,14 @@ jobs:
         project_tags:
           - Default
           - Unstable
+          - LatestReleases
         include:
           - project_tags: Default
             project_tags_cmake_options: ""
           - project_tags: Unstable
             project_tags_cmake_options: "-DROBOTOLOGY_PROJECT_TAGS=Unstable"
+          - project_tags: LatestReleases
+            project_tags_cmake_options: "-DROBOTOLOGY_PROJECT_TAGS=Custom -DROBOTOLOGY_PROJECT_TAGS_CUSTOM_FILE=${GITHUB_WORKSPACE}/releases/latest.releases.yaml"
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
     name: '[conda:Tags:${{ matrix.project_tags }}@${{ matrix.os }}@${{ matrix.build_type }}]'
     runs-on: ${{ matrix.os }}
     strategy:
-      fail-fast: false
+      fail-fast: true
       matrix:
         build_type: [Release]
         os: [ubuntu-latest, macos-13, macos-14, windows-2019, windows-2022]
@@ -191,7 +191,7 @@ jobs:
     name: '[docker:Tags:${{ matrix.project_tags }}@${{ matrix.docker_image }}@${{ matrix.build_type }}]'
     runs-on: ubuntu-22.04
     strategy:
-      fail-fast: false
+      fail-fast: true
       matrix:
         build_type: [Debug]
         cmake_generator:
@@ -252,7 +252,7 @@ jobs:
     name: '[Tags:${{ matrix.project_tags }}@${{ matrix.os }}@${{ matrix.build_type }}]'
     runs-on: ${{ matrix.os }}
     strategy:
-      fail-fast: false
+      fail-fast: true
       matrix:
         build_type: [Release]
         os: [ubuntu-22.04, windows-2019]


### PR DESCRIPTION
I was aware we were missing the `LatestReleases` CI with conda, but we nefer have problem. We experienced the first problem in https://github.com/robotology/robotology-superbuild/issues/1708, so let's enable it. To reduce the amount of jobs anyhow, in the same PR we change fail-fast to true, to avoid wasting CI jobs in non-necessary builds.