### PR TITLE
Switch robotology conda binary packages generation to target osx-arm64 instead of osx-64

### DIFF
--- a/.github/workflows/generate-conda-packages.yaml
+++ b/.github/workflows/generate-conda-packages.yaml
@@ -54,8 +54,8 @@ jobs:
               include:
                 - os: ubuntu-20.04
                   conda_platform: linux-64
-                - os: macos-11.0
-                  conda_platform: osx-64
+                - os: macos-14
+                  conda_platform: osx-arm64
                 - os: windows-2019
                   conda_platform: win-64
 
@@ -79,11 +79,11 @@ jobs:
         - name: Install files to enable compilation of mex files [Conda/macOS]
           if: contains(matrix.os, 'macos')
           run: |
-            curl -L -O https://github.com/robotology/robotology-vcpkg-ports/releases/download/storage/msdk_R2020a_mexmaci64.zip
-            unzip msdk_R2020a_mexmaci64.zip
-            rm msdk_R2020a_mexmaci64.zip
-            echo "GHA_Matlab_ROOT_DIR=${GITHUB_WORKSPACE}/msdk_R2020a_mexmaci64" >> $GITHUB_ENV
-            echo "GHA_Matlab_MEX_EXTENSION=mexmaci64" >> $GITHUB_ENV
+            curl -L -O https://github.com/robotology/robotology-vcpkg-ports/releases/download/storage/msdk_R2023b_mexmaca64.zip
+            unzip msdk_R2023b_mexmaca64.zip
+            rm msdk_R2023b_mexmaca64.zip
+            echo "GHA_Matlab_ROOT_DIR=${GITHUB_WORKSPACE}/msdk_R2023b_mexmaca64" >> $GITHUB_ENV
+            echo "GHA_Matlab_MEX_EXTENSION=mexmaca64" >> $GITHUB_ENV
 
         - name: Install files to enable compilation of mex files [Conda/Windows]
           if: contains(matrix.os, 'windows')

--- a/.github/workflows/generate-non-periodical-conda-package.yaml
+++ b/.github/workflows/generate-non-periodical-conda-package.yaml
@@ -20,8 +20,8 @@ jobs:
               include:
                 - os: ubuntu-20.04
                   conda_platform: linux-64
-                - os: macos-11.0
-                  conda_platform: osx-64
+                - os: macos-14
+                  conda_platform: osx-arm64
                 - os: windows-2019
                   conda_platform: win-64
 

--- a/doc/conda-forge.md
+++ b/doc/conda-forge.md
@@ -19,12 +19,14 @@ Depending on the speficic package, the binary packages are hosted either in [`co
 The following conda platforms are supported by all packages of the robotology-superbuild:
 
 * `linux-64` (Linux on x86-64)
-* `osx-64` (macOS on x86-64)
+* `osx-arm64` (macOS on ARM 64-bit)
 * `win-64` (Windows on x86-64)
 
 Some packages are also available for:
 * `linux-aarch64` (Linux on ARM 64-bit)
-* `osx-arm64` (macOS on ARM 64-bit)
+* `osx-64` (macOS on x86-64)
+
+As the switch from building the `robotology` channel packages from `osx-64` to `osx-arm64` happened in September 2024 (see https://github.com/robotology/robotology-superbuild/pull/1712), it may happen that some older packages are only available for `osx-64` and not `osx-arm64`.
 
 If you need a binary package on a platform in which it is not available, feel free to [open an issue](https://github.com/robotology/robotology-superbuild/issues/new) requesting it.
 


### PR DESCRIPTION
At least in `ami-iit` lab no one is using anymore Intel macOS laptops, and all macOS users have Apple Silicon laptops. For this reason, we switch the generation of robotology conda binary packages to target `osx-arm64` instead of `osx-64` . Note that this does not affect packages that are built by conda-forge. Indeed, if you are actually a users of one package from the `robotology` channel on `osx-64`, feel free to comment here, probably the easiest way to support any package that you still use is to migrate its conda binary package from the `robotology` channel to the `conda-forge` one.