### PR TITLE
Update casadi to 3.6.6 and stop using ami-iit fork

### DIFF
--- a/.github/workflows/pixi-ci.yml
+++ b/.github/workflows/pixi-ci.yml
@@ -42,7 +42,7 @@ jobs:
     - uses: prefix-dev/setup-pixi@v0.8.1
 
     - name: Build
-      shell: bash -l {0}
+      shell: bash
       run: |
         # Avoid YCM complaining that the git user is not set
         # Eventually we could consider removing that check in YCM

--- a/cmake/Buildcasadi.cmake
+++ b/cmake/Buildcasadi.cmake
@@ -28,8 +28,8 @@ endif()
 
 ycm_ep_helper(casadi TYPE GIT
               STYLE GITHUB
-              REPOSITORY ami-iit/casadi.git
-              TAG 3.6.5.backport3724
+              REPOSITORY casadi/casadi.git
+              TAG 3.6.6
               COMPONENT external
               FOLDER src
               CMAKE_ARGS -DWITH_IPOPT:BOOL=ON
@@ -55,8 +55,4 @@ ycm_ep_helper(casadi TYPE GIT
 
 set(casadi_CONDA_PKG_NAME casadi)
 set(casadi_CONDA_PKG_CONDA_FORGE_OVERRIDE ON)
-# This is a small hack. To avoid incompatibilities between the version tagged in the ami-iit fork
-# and the version available in conda-forge when generating conda metapackages
-# such as robotology-distro and robotology-distro-all, we override the conda package version of casadi
-# here. This needs to be removed as soon as we stop use our fork in the superbuild 
-set(casadi_CONDA_VERSION 3.6.5)
+

--- a/cmake/ProjectsTagsStable.cmake
+++ b/cmake/ProjectsTagsStable.cmake
@@ -11,8 +11,8 @@ set_tag(manif_TAG 0.0.5)
 set_tag(qhull_TAG 2020.2)
 set_tag(CppAD_TAG 20240000.2)
 set_tag(proxsuite_TAG v0.6.4)
-set_tag(casadi_TAG 3.6.5.backport3724)
-set_tag(casadi-matlab-bindings_TAG v3.6.5.0)
+set_tag(casadi_TAG 3.6.6)
+set_tag(casadi-matlab-bindings_TAG v3.6.6.0)
 
 # Robotology projects
 set_tag(YCM_TAG master)

--- a/cmake/ProjectsTagsUnstable.cmake
+++ b/cmake/ProjectsTagsUnstable.cmake
@@ -11,8 +11,8 @@ set_tag(manif_TAG 0.0.5)
 set_tag(qhull_TAG 2020.2)
 set_tag(CppAD_TAG 20240000.2)
 set_tag(proxsuite_TAG v0.6.4)
-set_tag(casadi_TAG 3.6.5.backport3724)
-set_tag(casadi-matlab-bindings_TAG v3.6.5.0)
+set_tag(casadi_TAG 3.6.6)
+set_tag(casadi-matlab-bindings_TAG v3.6.6)
 
 # Robotology projects
 set_tag(YARP_TAG yarp-3.9)

--- a/cmake/ProjectsTagsUnstable.cmake
+++ b/cmake/ProjectsTagsUnstable.cmake
@@ -12,7 +12,7 @@ set_tag(qhull_TAG 2020.2)
 set_tag(CppAD_TAG 20240000.2)
 set_tag(proxsuite_TAG v0.6.4)
 set_tag(casadi_TAG 3.6.6)
-set_tag(casadi-matlab-bindings_TAG v3.6.6)
+set_tag(casadi-matlab-bindings_TAG v3.6.6.0)
 
 # Robotology projects
 set_tag(YARP_TAG yarp-3.9)

--- a/releases/latest.releases.yaml
+++ b/releases/latest.releases.yaml
@@ -22,7 +22,7 @@ repositories:
   casadi:
     type: git
     url: https://github.com/casadi/casadi.git
-    version: 3.6.5
+    version: 3.6.6
   YCM:
     type: git
     url: https://github.com/robotology/ycm.git
@@ -202,7 +202,7 @@ repositories:
   casadi-matlab-bindings:
     type: git
     url: https://github.com/ami-iit/casadi-matlab-bindings.git
-    version: v3.6.5.0
+    version: v3.6.6
   idyntree-yarp-tools:
     type: git
     url: https://github.com/robotology/idyntree-yarp-tools.git


### PR DESCRIPTION
Since casadi 3.6.6 includes https://github.com/casadi/casadi/pull/3724, we can now switch back to use the main casadi repository. The only fix we added on top of it is https://github.com/casadi/casadi/pull/3832, but at the moment we did not enable fatrop in the superbuild (while we enabled it on conda-forge on Linux, see https://github.com/conda-forge/casadi-feedstock/pull/115), so we can just keep using 3.6.6 . 

Fix https://github.com/robotology/robotology-superbuild/issues/1714 .

