### PR TITLE
 Document the new prefix.dev robotology channel mirror  and upload new robotology conda packages to both anaconda.org and prefix.dev

### DIFF
--- a/.github/workflows/generate-conda-packages.yaml
+++ b/.github/workflows/generate-conda-packages.yaml
@@ -221,10 +221,16 @@ jobs:
           if: github.event_name == 'schedule' || github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && github.event.inputs.upload_conda_binaries == 'true')
           env:
             ANACONDA_API_TOKEN: ${{ secrets.ANACONDA_API_TOKEN }}
+            PREFIX_DEV_TOKEN: ${{ secrets.PREFIX_DEV_TOKEN }}
           run: |
             cd ${CONDA_BLD_PATH}/${{ matrix.conda_platform}}/
             ls *.tar.bz2
             anaconda upload --skip-existing *.tar.bz2
+            pixi auth login https://prefix.dev --token $PREFIX_DEV_TOKEN
+            for condapackage in *.tar.bz2; do
+              pixi upload https://prefix.dev/api/v1/upload/robotology "$condapackage"
+            done
+            pixi auth logout https://prefix.dev
 
         # Only on linux-64 we upload noarch packages (noarch packages need to be uploaded only once, as they can be reused across platforms)
         - name: Upload conda packages (noarch)
@@ -233,10 +239,16 @@ jobs:
           if: matrix.conda_platform == 'linux-64' && (github.event_name == 'schedule' || github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && github.event.inputs.upload_conda_binaries == 'true'))
           env:
             ANACONDA_API_TOKEN: ${{ secrets.ANACONDA_API_TOKEN }}
+            PREFIX_DEV_TOKEN: ${{ secrets.PREFIX_DEV_TOKEN }}
           run: |
             cd ${CONDA_BLD_PATH}/noarch/
             ls *.tar.bz2
             anaconda upload --skip-existing *.tar.bz2
+            pixi auth login https://prefix.dev --token $PREFIX_DEV_TOKEN
+            for condapackage in *.tar.bz2; do
+              pixi upload https://prefix.dev/api/v1/upload/robotology "$condapackage"
+            done
+            pixi auth logout https://prefix.dev
 
         - name: Build robotology-distro-all conda metapackage (if necessary)
           if: github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && github.event.inputs.test_metapackages_generation == 'true')
@@ -253,11 +265,16 @@ jobs:
           if: github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && github.event.inputs.test_metapackages_generation == 'true' && github.event.inputs.upload_conda_binaries == 'true')
           env:
             ANACONDA_API_TOKEN: ${{ secrets.ANACONDA_API_TOKEN }}
+            PREFIX_DEV_TOKEN: ${{ secrets.PREFIX_DEV_TOKEN }}
           run: |
             cd ${CONDA_BLD_PATH}/${{ matrix.conda_platform}}/
             ls robotology-distro-all-*.tar.bz2
             anaconda upload --skip-existing robotology-distro-all-*.tar.bz2
-
+            pixi auth login https://prefix.dev --token $PREFIX_DEV_TOKEN
+            for condapackage in robotology-distro-all-*.tar.bz2; do
+              pixi upload https://prefix.dev/api/v1/upload/robotology "$condapackage"
+            done
+            pixi auth logout https://prefix.dev
   
 
     # If the  generate-conda-packages completed correctly and binaries are uploaded,

--- a/conda/cmake/CondaGenerationOptions.cmake
+++ b/conda/cmake/CondaGenerationOptions.cmake
@@ -2,7 +2,7 @@
 # to ensure that binaries belonging to different rebuilds
 # can be distinguished even if the version number is the same
 if(NOT CONDA_BUILD_NUMBER)
-  set(CONDA_BUILD_NUMBER 131)
+  set(CONDA_BUILD_NUMBER 132)
 endif()
 
 # This option is enabled only when the metapackages robotology-distro and robotology-distro-all are

--- a/doc/conda-forge.md
+++ b/doc/conda-forge.md
@@ -94,7 +94,7 @@ To ensure redundancy, the `robotology` channel is available on two servers:
 * [`prefix.dev`](https://prefix.dev/channels/robotology)
 * [`anaconda.org`](https://anaconda.org/robotology/)
 
-The full history of packages is available on the prefix.dev mirror, so if you aim for reproducibility, try to use the prefix.dev mirror by specifying the channel via `-c https://repo.prefix.dev/robotology`. On the anaconda.org, some packages built before 1st of July 2022 are not available, so if you only care for the latest packages, you can also install packages by simply passing `-c robotology` to conda.
+The full history of packages is available on the prefix.dev mirror, so if you aim for reproducibility, try to use the prefix.dev mirror by specifying the channel via `-c https://repo.prefix.dev/robotology`. On the anaconda.org, some packages built before 1st of January 2023 are not available, so if you only care for the latest packages, you can also install packages by simply passing `-c robotology` to conda.
 
 ## Source installation
 

--- a/doc/conda-forge.md
+++ b/doc/conda-forge.md
@@ -14,7 +14,7 @@ For an overview of advantages and disadvantages of conda and conda-forge, check 
 
 This section describes how to install the binary packages built from the `robotology-superbuild` on conda on Windows, macOS and Linux.
 
-Depending on the speficic package, the binary packages are hosted either in [`conda-forge`](https://anaconda.org/conda-forge) or [`robotology`](https://anaconda.org/robotology). Only packages that are built as part of the profiles and options that are supported on Conda (see [documentation on CMake options](cmake-options.md)) are available as conda binary packages.
+Depending on the speficic package, the binary packages are hosted either in [`conda-forge`](https://prefix.dev/channels/conda-forge) or [`robotology`](https://prefix.dev/channels/robotology) channels. Only packages that are built as part of the profiles and options that are supported on Conda (see [documentation on CMake options](cmake-options.md)) are available as conda binary packages.
 
 The following conda platforms are supported by all packages of the robotology-superbuild:
 
@@ -63,30 +63,38 @@ conda activate robotologyenv
 
 Once you are in an activated environment, you can install robotology packages by just running the command:
 ~~~
-conda install -c conda-forge -c robotology <packagename>
+conda install -c conda-forge -c https://repo.prefix.dev/robotology <packagename>
 ~~~
 
 The list of available packages is available at https://anaconda.org/robotology/repo .
 
 For example, if you want to install yarp and icub-main, you simple need to install:
 ~~~
-conda install -c conda-forge -c robotology yarp icub-main
+conda install -c conda-forge -c https://repo.prefix.dev/robotology yarp icub-main
 ~~~
 
 In addition, if you want to simulate the iCub in Gazebo Classic, you should also install `icub-models` and `gazebo-yarp-plugins`:
 ~~~
-conda install -c conda-forge -c robotology gazebo-yarp-plugins icub-models
+conda install -c conda-forge gazebo-yarp-plugins icub-models
 ~~~
 
 While if you want to simulate it with Modern Gazebo (gz-sim), you should install `icub-models` and `gz-sim-yarp-plugins`:
 ~~~
-conda install -c conda-forge -c robotology gz-sim-yarp-plugins icub-models
+conda install -c conda-forge gz-sim-yarp-plugins icub-models
 ~~~
 
 If you want to develop some C++ code on the top of these libraries, it is recommended to also install the necessary compiler and development tools directly in the same environment:
 ~~~
 conda install -c conda-forge compilers cmake pkg-config make ninja
 ~~~
+
+### Advanced: robotology channel mirrors
+
+To ensure redundancy, the `robotology` channel is available on two servers:
+* [`prefix.dev`](https://prefix.dev/channels/robotology)
+* [`anaconda.org`](https://anaconda.org/robotology/)
+
+The full history of packages is available on the prefix.dev mirror, so if you aim for reproducibility, try to use the prefix.dev mirror by specifying the channel via `-c https://repo.prefix.dev/robotology`. On the anaconda.org, some packages built before 1st of July 2022 are not available, so if you only care for the latest packages, you can also install packages by simply passing `-c robotology` to conda.
 
 ## Source installation
 


### PR DESCRIPTION
This permit us to keep latest packages on `robotology` channel on anaconda.org so that `-c robotology` continue to work for latest packages even on vanilla conda, but we keep the full history of packages in prefix.dev robotology.

To kickstart the upload, I used the following two scripts (that I do not upload in the repo as they will not be necessary in the future):

`download_all.sh`:

~~~sh
conda-mirror --upstream-channel robotology --target-directory robotology_mirror --platform noarch
conda-mirror --upstream-channel robotology --target-directory robotology_mirror --platform linux-64
conda-mirror --upstream-channel robotology --target-directory robotology_mirror --platform osx-64
conda-mirror --upstream-channel robotology --target-directory robotology_mirror --platform win-64
~~~

`upload_all.sh`:

~~~sh
# The script requires PREFIX_DEV_TOKEN to be defined to upload files to prefix.dev
if [ -z "${PREFIX_DEV_TOKEN}" ]; then
  echo "Error: The environment variable PREFIX_DEV_TOKEN is not defined, please define it with your prefix.dev API key"
  exit 1
fi

pixi auth login https://prefix.dev --token $PREFIX_DEV_TOKEN

# Function to check if a file exists on the server
file_exists_on_server() {
  local file_path="$1"
  # Extract the filename
  local filename=$(basename "$file_path")
  # Extract the platform directory from the file path
  local platform=$(echo "$file_path" | grep -oE 'noarch|linux-64|osx-64|win-64')
  # Construct the URL where the file would be hosted
  local url="https://repo.prefix.dev/robotology/$platform/$filename"
  # Perform a HEAD request to check if the file exists
  local status_code=$(curl -s -o /dev/null -w "%{http_code}" -I "$url")
  if [ "$status_code" -ne 404 ]; then
    return 0  # File exists
  else
    return 1  # File does not exist
  fi
}

# Collect all files into an array
files=(
  ./robotology_mirror/noarch/*.tar.bz2
  ./robotology_mirror/noarch/*.conda
  ./robotology_mirror/linux-64/*.tar.bz2
  ./robotology_mirror/linux-64/*.conda
  ./robotology_mirror/osx-64/*.tar.bz2
  ./robotology_mirror/osx-64/*.conda
  ./robotology_mirror/win-64/*.tar.bz2
  ./robotology_mirror/win-64/*.conda
)

# Loop over the array and upload each file if not already present
for file in "${files[@]}"; do
  # Check if the file exists locally before proceeding
  if [ -f "$file" ]; then
    if file_exists_on_server "$file"; then
      echo "Skipping upload of '$file'; it already exists on the server."
    else
      echo "Uploading '$file'..."
      pixi upload https://prefix.dev/api/v1/upload/robotology "$file"
    fi
  else
    echo "File '$file' does not exist locally. Skipping."
  fi
done

pixi auth logout https://prefix.dev
~~~