### PR TITLE
Add missing pixi dependency in generate-conda-packages and missing prefix.dev upload to generate-non-periodical-conda-package job

### DIFF
--- a/.github/workflows/generate-conda-packages.yaml
+++ b/.github/workflows/generate-conda-packages.yaml
@@ -98,7 +98,7 @@ jobs:
         - name: Dependencies for conda recipes generation and upload
           shell: bash -l {0}
           run: |
-            conda install pyyaml jinja2 conda-build ninja anaconda-client conda-forge-pinning mamba boa multisheller
+            conda install pyyaml jinja2 conda-build ninja anaconda-client conda-forge-pinning mamba boa multisheller pixi
 
         - name: Print used environment
           shell: bash -l {0}

--- a/.github/workflows/generate-non-periodical-conda-package.yaml
+++ b/.github/workflows/generate-non-periodical-conda-package.yaml
@@ -36,7 +36,7 @@ jobs:
         - name: Dependencies for conda recipes generation and upload
           shell: bash -l {0}
           run: |
-            conda install pyyaml jinja2 conda-build ninja anaconda-client conda-forge-pinning mamba boa multisheller
+            conda install pyyaml jinja2 conda-build ninja anaconda-client conda-forge-pinning mamba boa multisheller pixi
 
         - name: Print used environment
           shell: bash -l {0}
@@ -64,7 +64,13 @@ jobs:
           if: (github.event_name == 'workflow_dispatch' && github.event.inputs.upload_conda_binaries == 'true')
           env:
             ANACONDA_API_TOKEN: ${{ secrets.ANACONDA_API_TOKEN }}
+            PREFIX_DEV_TOKEN: ${{ secrets.PREFIX_DEV_TOKEN }}
           run: |
             cd ${CONDA_PREFIX}/conda-bld/${{ matrix.conda_platform}}/
             ls *.tar.bz2
             anaconda upload --skip-existing *.tar.bz2
+            pixi auth login https://prefix.dev --token $PREFIX_DEV_TOKEN
+            for condapackage in *.tar.bz2; do
+              pixi upload https://prefix.dev/api/v1/upload/robotology "$condapackage"
+            done
+            pixi auth logout https://prefix.dev

--- a/conda/cmake/CondaGenerationOptions.cmake
+++ b/conda/cmake/CondaGenerationOptions.cmake
@@ -2,7 +2,7 @@
 # to ensure that binaries belonging to different rebuilds
 # can be distinguished even if the version number is the same
 if(NOT CONDA_BUILD_NUMBER)
-  set(CONDA_BUILD_NUMBER 132)
+  set(CONDA_BUILD_NUMBER 133)
 endif()
 
 # This option is enabled only when the metapackages robotology-distro and robotology-distro-all are


### PR DESCRIPTION
Follow up of https://github.com/robotology/robotology-superbuild/pull/1716 .