### PR TITLE
Cleanup Python snippet required to run Python bindings on Windows

### DIFF
--- a/doc/cmake-options.md
+++ b/doc/cmake-options.md
@@ -372,9 +372,8 @@ Furthermore, due to Python ignoring the directories in `PATH`, before running py
 
 ~~~python
 import os
-import platform
 
-if platform.system() == "Windows":
+if os.name == "nt":
     superbuild_dll_path = os.path.join(os.environ.get('ROBOTOLOGY_SUPERBUILD_INSTALL_PREFIX',""), 'bin')
     if (os.exists(superbuild_dll_path)):
         os.add_dll_directory(superbuild_dll_path)

--- a/doc/cmake-options.md
+++ b/doc/cmake-options.md
@@ -372,7 +372,12 @@ Furthermore, due to Python ignoring the directories in `PATH`, before running py
 
 ~~~python
 import os
-os.add_dll_directory(os.path.join(os.environ['ROBOTOLOGY_SUPERBUILD_INSTALL_PREFIX'], 'bin'))
+import platform
+
+if platform.system() == "Windows":
+    superbuild_dll_path = os.path.join(os.environ.get('ROBOTOLOGY_SUPERBUILD_INSTALL_PREFIX',""), 'bin')
+    if (os.exists(superbuild_dll_path)):
+        os.add_dll_directory(superbuild_dll_path)
 ~~~
 
 see https://github.com/robotology/robotology-superbuild/issues/1268 for more details.


### PR DESCRIPTION
I modified the code to fail with no effect on non-Windows and non-superbuild installation, so that the snippet can be added to any script without preventing to run the script in context different from a Windows superbuild install.