### PR TITLE
conda: Set QT_HOST_PATH in conda's build.sh CMake template for osx-arm64 compat

### DIFF
--- a/conda/cmake_recipe_template/build.sh
+++ b/conda/cmake_recipe_template/build.sh
@@ -7,11 +7,15 @@ cd {{ source_subdir }}
 mkdir build
 cd build
 
+# QT_HOST_PATH is added as it is required on osx-arm64 for all
+# packages that depend (even transitively) on qt6-main
+# Workaround for https://github.com/conda-forge/qt-main-feedstock/issues/273
 cmake .. \
     -GNinja \
     -DCMAKE_BUILD_TYPE=Release \
     -DCMAKE_PREFIX_PATH=$PREFIX \
     -DCMAKE_INSTALL_PREFIX=$PREFIX \
+    -DQT_HOST_PATH=$PREFIX \
     -DCMAKE_INSTALL_LIBDIR=lib \
     -DCMAKE_VERBOSE_MAKEFILE=OFF \
     -DCMAKE_INSTALL_SYSTEM_RUNTIME_LIBS_SKIP=True \


### PR DESCRIPTION
Currently conda packages build on osx-arm64 fail with error:

~~~
2024-10-03T20:47:09.6134360Z CMake Error at /Users/runner/miniconda3/envs/test/conda-bld/walking-controllers_1727988336360/_h_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold/lib/cmake/Qt6/QtPublicDependencyHelpers.cmake:258 (message):
2024-10-03T20:47:09.6136720Z   To use a cross-compiled Qt, please set the QT_HOST_PATH cache variable to
2024-10-03T20:47:09.6137370Z   the location of your host Qt installation.
2024-10-03T20:47:09.6137790Z Call Stack (most recent call first):
~~~

This is due to https://github.com/conda-forge/qt-main-feedstock/issues/273 . As a workaround, we add `-DQT_HOST_PATH=$PREFIX` in the build.sh template for CMake projects.