### PR TITLE
Update YCMBootstrapFetch.cmake to avoid CMP0169 related warnings and update YCM to 0.17.1

### DIFF
--- a/cmake/YCMBootstrapFetch.cmake
+++ b/cmake/YCMBootstrapFetch.cmake
@@ -97,10 +97,4 @@ FetchContent_Declare(YCM
                      GIT_REPOSITORY https://github.com/${YCM_FETCHCONTENT_REPOSITORY}
                      GIT_TAG ${YCM_FETCHCONTENT_TAG})
 
-FetchContent_GetProperties(YCM)
-if(NOT YCM_POPULATED)
-    message(STATUS "Fetching YCM.")
-    FetchContent_Populate(YCM)
-    # Add YCM modules in CMAKE_MODULE_PATH
-    include(${ycm_SOURCE_DIR}/tools/UseYCMFromSource.cmake)
-endif()
+FetchContent_MakeAvailable(YCM)

--- a/releases/latest.releases.yaml
+++ b/releases/latest.releases.yaml
@@ -26,7 +26,7 @@ repositories:
   YCM:
     type: git
     url: https://github.com/robotology/ycm.git
-    version: v0.16.9
+    version: v0.17.0
   YARP:
     type: git
     url: https://github.com/robotology/yarp.git

--- a/releases/latest.releases.yaml
+++ b/releases/latest.releases.yaml
@@ -26,7 +26,7 @@ repositories:
   YCM:
     type: git
     url: https://github.com/robotology/ycm.git
-    version: v0.17.0
+    version: v0.17.1
   YARP:
     type: git
     url: https://github.com/robotology/yarp.git


### PR DESCRIPTION
This will remove all the noisy warnings:

~~~
CMake Warning (dev) at D:/miniforge3/envs/robsub/Library/share/[cmake-3](https://gitlab.kitware.com/cmake/cmake/-/issues/3).30/Modules/FetchContent.cmake:1953 (message):
Calling FetchContent_Populate(YCM) is deprecated, call
FetchContent_MakeAvailable(YCM) instead. Policy CMP0169 can be set to OLD
to allow FetchContent_Populate(YCM) to be called directly for now, but the
ability to call it with declared details will be removed completely in a
future version.
Call Stack (most recent call first):
cmake/YCMBootstrapFetch.cmake:103 (FetchContent_Populate)
CMakeLists.txt:60 (include)
~~~

in recent CMake releases.