### PR TITLE
Add qpsolvers-eigen and sharedlibpp to the robotology-superbuild

### DIFF
--- a/cmake/BuildBlockFactory.cmake
+++ b/cmake/BuildBlockFactory.cmake
@@ -10,11 +10,15 @@ else()
   set(BLOCKFACTORY_USES_SIMULINK OFF)
 endif()
 
+find_or_build_package(sharedlibpp QUIET)
+
 ycm_ep_helper(BlockFactory TYPE GIT
               STYLE GITHUB
               REPOSITORY robotology/blockfactory.git
               TAG master
               COMPONENT dynamics
               FOLDER src
+              DEPENDS sharedlibpp
               CMAKE_ARGS -DUSES_MATLAB:BOOL=${BLOCKFACTORY_USES_SIMULINK}
+                         -DBLOCKFACTORY_USES_SYSTEM_SHAREDLIBPP:BOOL=ON
                          -DENABLE_WARNINGS:BOOL=OFF)

--- a/cmake/BuildQpSolversEigen.cmake
+++ b/cmake/BuildQpSolversEigen.cmake
@@ -1,0 +1,39 @@
+# SPDX-FileCopyrightText: Fondazione Istituto Italiano di Tecnologia (IIT)
+# SPDX-License-Identifier: BSD-3-Clause
+
+include(YCMEPHelper)
+include(FindOrBuildPackage)
+
+set(QpSolversEigen_DEPENDS "")
+find_or_build_package(sharedlibpp QUIET)
+list(APPEND QpSolversEigen_DEPENDS sharedlibpp)
+find_or_build_package(YCM QUIET)
+list(APPEND QpSolversEigen_DEPENDS YCM)
+find_or_build_package(OsqpEigen QUIET)
+list(APPEND QpSolversEigen_DEPENDS OsqpEigen)
+
+
+# proxqp only supports MSVC Toolset v143, i.e. Visual Studio 2022
+if(NOT MSVC OR MSVC_VERSION VERSION_GREATER_EQUAL 1930)
+  find_or_build_package(proxsuite QUIET)
+  list(APPEND QpSolversEigen_DEPENDS proxsuite)
+  set(QPSOLVERSEIGEN_ENABLE_PROXQP ON)
+else()
+  set(QPSOLVERSEIGEN_ENABLE_PROXQP OFF)
+endif()
+
+ycm_ep_helper(QpSolversEigen TYPE GIT
+              STYLE GITHUB
+              REPOSITORY ami-iit/qpsolvers-eigen.git
+              TAG main
+              COMPONENT dynamics
+              FOLDER src
+              CMAKE_ARGS -DBUILD_TESTING:BOOL=OFF
+                         -DQPSOLVERSEIGEN_USES_SYSTEM_SHAREDLIBPP:BOOL=ON
+                         -DQPSOLVERSEIGEN_USES_SYSTEM_YCM:BOOL=ON
+                         -DQPSOLVERSEIGEN_ENABLE_OSQP:BOOL=ON
+                         -DQPSOLVERSEIGEN_ENABLE_PROXQP:BOOL=${QPSOLVERSEIGEN_ENABLE_PROXQP}
+              DEPENDS ${QpSolversEigen_DEPENDS})
+
+set(QpSolversEigen_CONDA_PKG_NAME qpsolvers-eigen)
+set(QpSolversEigen_CONDA_PKG_CONDA_FORGE_OVERRIDE ON)

--- a/cmake/BuildWBToolbox.cmake
+++ b/cmake/BuildWBToolbox.cmake
@@ -9,8 +9,10 @@ find_or_build_package(YARP QUIET)
 find_or_build_package(ICUB QUIET)
 find_or_build_package(iDynTree QUIET)
 find_or_build_package(qpOASES QUIET)
+find_or_build_package(sharedlibpp QUIET)
 find_or_build_package(BlockFactory QUIET)
 find_or_build_package(OsqpEigen QUIET)
+find_or_build_package(QpSolversEigen QUIET)
 
 ycm_ep_helper(WBToolbox TYPE GIT
               STYLE GITHUB
@@ -27,6 +29,8 @@ ycm_ep_helper(WBToolbox TYPE GIT
                       iDynTree
                       qpOASES
                       BlockFactory
-                      OsqpEigen)
+                      OsqpEigen
+                      sharedlibpp
+                      QpSolversEigen)
 
 set(WBToolbox_CONDA_DEPENDENCIES eigen) 

--- a/cmake/Buildsharedlibpp.cmake
+++ b/cmake/Buildsharedlibpp.cmake
@@ -1,0 +1,18 @@
+# SPDX-FileCopyrightText: Fondazione Istituto Italiano di Tecnologia (IIT)
+# SPDX-License-Identifier: BSD-3-Clause
+
+include(YCMEPHelper)
+
+find_or_build_package(YCM QUIET)
+
+ycm_ep_helper(sharedlibpp TYPE GIT
+              STYLE GITHUB
+              REPOSITORY ami-iit/sharedlibpp.git
+              TAG main
+              COMPONENT dynamics
+              FOLDER src
+              DEPENDS YCM
+              CMAKE_ARGS)
+
+set(sharedlibpp_CONDA_PKG_NAME sharedlibpp)
+set(sharedlibpp_CONDA_PKG_CONDA_FORGE_OVERRIDE ON)

--- a/cmake/Buildsharedlibpp.cmake
+++ b/cmake/Buildsharedlibpp.cmake
@@ -14,5 +14,5 @@ ycm_ep_helper(sharedlibpp TYPE GIT
               DEPENDS YCM
               CMAKE_ARGS)
 
-set(sharedlibpp_CONDA_PKG_NAME sharedlibpp)
+set(sharedlibpp_CONDA_PKG_NAME libsharedlibpp)
 set(sharedlibpp_CONDA_PKG_CONDA_FORGE_OVERRIDE ON)

--- a/releases/latest.releases.yaml
+++ b/releases/latest.releases.yaml
@@ -82,7 +82,7 @@ repositories:
   BlockFactory:
     type: git
     url: https://github.com/robotology/blockfactory.git
-    version: v1.0.0
+    version: v1.0.1
   WBToolbox:
     type: git
     url: https://github.com/robotology/wb-toolbox.git

--- a/releases/latest.releases.yaml
+++ b/releases/latest.releases.yaml
@@ -82,11 +82,11 @@ repositories:
   BlockFactory:
     type: git
     url: https://github.com/robotology/blockfactory.git
-    version: v0.8.6
+    version: v1.0.0
   WBToolbox:
     type: git
     url: https://github.com/robotology/wb-toolbox.git
-    version: v5.7.0
+    version: v6.0.0
   OsqpEigen:
     type: git
     url: https://github.com/robotology/osqp-eigen.git
@@ -275,3 +275,11 @@ repositories:
     type: git
     url: https://github.com/robotology/gz-sim-yarp-plugins.git
     version: v0.3.0
+  sharedlibpp:
+    type: git
+    url: https://github.com/ami-iit/sharedlibpp.git
+    version: v0.0.3
+  QpSolversEigen:
+    type: git
+    url: https://github.com/ami-iit/qpsolvers-eigen.git
+    version: v0.0.1


### PR DESCRIPTION
This PR adds `qpsolvers-eigen` and `sharedlibpp` to the superbuild, in view of the integration of `qpsolvers-eigen` to WBToolbox.

Furthermore, as `qpsolvers-eigen` depends on `sharedlibpp`, this PR also updates BlockFactory and WBToolbox to 1.0.0 and 6.0.0, that are the versions that are compatible with the external `sharedlibpp`. Before blockfactory 1.0.0, blockfactory had an internal library called shlibpp that was also used by WBToolbox. This library is not substituted by sharedlibpp.