### PR TITLE
Update Buildrobometry.cmake after the addition of IRawValuesPublisher

### DIFF
--- a/cmake/Buildrobometry.cmake
+++ b/cmake/Buildrobometry.cmake
@@ -5,6 +5,7 @@
 include(YCMEPHelper)
 
 find_or_build_package(YARP QUIET)
+find_or_build_package(ICUB QUIET)
 find_or_build_package(matioCpp QUIET)
 
 ycm_ep_helper(robometry TYPE GIT
@@ -15,6 +16,7 @@ ycm_ep_helper(robometry TYPE GIT
               FOLDER src
               DEPENDS YCM
                       YARP
+                      ICUB
                       matioCpp)
 
 set(robometry_CONDA_PKG_NAME librobometry)


### PR DESCRIPTION
In `telemetryDeviceDumper` it has been added the usage of `IRawValuesPublisher` by @MSECode, this made the device dependent also by ICUB 2.7.0 or higher.

I am unsure if the superbuild compiles the device right now, because if the dependencies are not found the compilation of the device is skipped.

See:
- https://github.com/robotology/robometry/pull/190



cc @traversaro @S-Dafarra @valegagge