### PR TITLE
Add yarp-devices-ros2, xsens-moveit2 and icub-tech-iit-documentation to latest.release.yaml

### DIFF
--- a/releases/latest.releases.yaml
+++ b/releases/latest.releases.yaml
@@ -287,3 +287,15 @@ repositories:
     type: git
     url: https://github.com/ami-iit/qpsolvers-eigen.git
     version: v0.1.0
+  yarp-devices-ros2:
+    type: git
+    url: https://github.com/robotology/yarp-devices-ros2
+    version: v1.0.0
+  xcub-moveit2:
+    type: git
+    url: https://github.com/icub-tech-iit/xcub-moveit2
+    version: v1.0.0
+  icub-tech-iit-documentation:
+    type: git
+    url: https://github.com/icub-tech-iit/documentation
+    version: v1.0.0


### PR DESCRIPTION
Follow up to https://github.com/robotology/robotology-superbuild/pull/1746 . We are missing a `xcub-moveit2` tag, do you think we can do it @martinaxgloria @Nicogene ? I think we can safely ignore https://github.com/icub-tech-iit/xcub-moveit2/pull/33 for now.