### PR TITLE
CI: Replace deprecated macos-12 images with macos-13

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
       fail-fast: false
       matrix:
         build_type: [Release]
-        os: [ubuntu-latest, macos-12, macos-14, windows-2019, windows-2022]
+        os: [ubuntu-latest, macos-13, macos-14, windows-2019, windows-2022]
         project_tags:
           - Default
           - Unstable
@@ -53,7 +53,7 @@ jobs:
         echo "GHA_Matlab_MEX_EXTENSION=mexa64" >> $GITHUB_ENV
 
     - name: Install files to enable compilation of mex files [Conda/macOS Intel]
-      if: matrix.os == 'macos-12'
+      if: matrix.os == 'macos-13'
       run: |
         curl -L -O https://github.com/robotology/robotology-vcpkg-ports/releases/download/storage/msdk_R2020a_mexmaci64.zip
         unzip msdk_R2020a_mexmaci64.zip


### PR DESCRIPTION
The `macos-12` is now deprecated and will be removed soon, see https://github.com/actions/runner-images/issues/10721 . To continue testing macOS with Intel processor, we can switch to use `macos-13`.