### PR TITLE
Add missing xorg-xorgproto dependency in yarp-device-openxrheadset

### DIFF
--- a/cmake/Buildyarp-device-openxrheadset.cmake
+++ b/cmake/Buildyarp-device-openxrheadset.cmake
@@ -16,4 +16,4 @@ ycm_ep_helper(yarp-device-openxrheadset TYPE GIT
               DEPENDS YARP
                       OpenXR)
 
-set(yarp-device-openxrheadset_CONDA_DEPENDENCIES glew glm glfw)
+set(yarp-device-openxrheadset_CONDA_DEPENDENCIES glew glm glfw xorg-xproto)


### PR DESCRIPTION
See https://github.com/ami-iit/yarp-device-openxrheadset/pull/56 for more details.