### PR TITLE
Use Ubuntu 24.04 in one-line MATLAB installer

### DIFF
--- a/.github/workflows/matlab-one-line-install-test.yml
+++ b/.github/workflows/matlab-one-line-install-test.yml
@@ -18,12 +18,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-22.04, macos-13, windows-latest]
-        matlab_version: [R2022a, R2022b, R2023a, latest]
-        exclude:
-          # R2020* is not supported on Windows on GitHub Actions
-          - os: windows-latest
-            matlab_version: R2020b
+        os: [ubuntu-24.04, macos-13, windows-latest]
+        matlab_version: [R2022a, R2023a, R2024a, latest]
     runs-on: ${{ matrix.os }}
     
     steps:


### PR DESCRIPTION
Workaround for https://github.com/robotology/robotology-superbuild/issues/1771 .