### PR TITLE
Bump icub-firmware and icub-firmware-build patch number in 2024.11.2

### DIFF
--- a/releases/2024.11.2.yaml
+++ b/releases/2024.11.2.yaml
@@ -134,11 +134,11 @@ repositories:
   icub-firmware:
     type: git
     url: https://github.com/robotology/icub-firmware.git
-    version: v1.41.0
+    version: v1.41.1
   icub-firmware-build:
     type: git
     url: https://github.com/robotology/icub-firmware-build.git
-    version: v1.41.0
+    version: v1.41.1
   icub-firmware-models:
     type: git
     url: https://github.com/robotology/icub-firmware-models.git


### PR DESCRIPTION
The patch has been bumped for icub-firmware and icub-firmware-build, for including:
- https://github.com/robotology/icub-firmware-build/pull/187
- https://github.com/robotology/icub-firmware/pull/551


cc @ale-git @S-Dafarra 