### PR TITLE
Enable pixi-ci on linux-aarch64

### DIFF
--- a/.github/workflows/pixi-ci.yml
+++ b/.github/workflows/pixi-ci.yml
@@ -22,7 +22,7 @@ jobs:
       fail-fast: false
       matrix:
         build_type: [Release]
-        os: [ubuntu-22.04, macos-13, macos-14, windows-2019]
+        os: [ubuntu-22.04, ubuntu-24.04-arm, macos-13, macos-14, windows-2019]
         pixi_task: [build-all, build-ros2, build-ros2moveit]
         exclude:
           # ros is not supported on osx-arm64 (incompatibility with gz-sim8)
@@ -36,6 +36,8 @@ jobs:
           - os: windows-2019
             pixi_task: build-ros2
           # moveit is only supported on Linux for now (missing required package in robostack)
+          - os: ubuntu-24.04-arm
+            pixi_task: build-ros2moveit
           - os: macos-13
             pixi_task: build-ros2moveit
           - os: macos-14


### PR DESCRIPTION
With https://github.blog/changelog/2025-01-16-linux-arm64-hosted-runners-now-available-for-free-in-public-repositories-public-preview/ we finally have GitHub Action CI on Linux arm64!