### PR TITLE
Do not run CI of ROBOTOLOGY_PROJECT_TAGS=Unstable on Ubuntu 20.04 with apt dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -203,6 +203,10 @@ jobs:
             project_tags_cmake_options: ""
           - project_tags: Unstable
             project_tags_cmake_options: "-DROBOTOLOGY_PROJECT_TAGS=Unstable"
+        exclude:
+          # Not supported anymore, see https://github.com/robotology/robotology-superbuild/issues/1783
+          - project_tags: Unstable
+            docker_image: "ubuntu:20.04"
 
     container:
       image: ${{ matrix.docker_image }}


### PR DESCRIPTION
Workaround for https://github.com/robotology/robotology-superbuild/issues/1783 .