### PR TITLE
Fix URL and branch in BuildResolveRoboticsURICpp

### DIFF
--- a/cmake/BuildResolveRoboticsURICpp.cmake
+++ b/cmake/BuildResolveRoboticsURICpp.cmake
@@ -6,7 +6,7 @@ include(FindOrBuildPackage)
 
 ycm_ep_helper(ResolveRoboticsURICpp TYPE GIT
                                     STYLE GITHUB
-                                    REPOSITORY robotology/ycm.git
+                                    REPOSITORY ami-iit/resolve-robotics-uri-cpp.git
                                     COMPONENT core
                                     FOLDER src)
 

--- a/cmake/BuildResolveRoboticsURICpp.cmake
+++ b/cmake/BuildResolveRoboticsURICpp.cmake
@@ -7,6 +7,7 @@ include(FindOrBuildPackage)
 ycm_ep_helper(ResolveRoboticsURICpp TYPE GIT
                                     STYLE GITHUB
                                     REPOSITORY ami-iit/resolve-robotics-uri-cpp.git
+                                    TAG main
                                     COMPONENT core
                                     FOLDER src)
 


### PR DESCRIPTION
Due to a typo in https://github.com/robotology/robotology-superbuild/pull/1791, YCM was downloaded instead lf ami-iit/resolve-robotics-uri-cpp . FYI @isorrentino 