### PR TITLE
Add iDynTree dependency to yarp-device-openxrheadset

### DIFF
--- a/cmake/Buildyarp-device-openxrheadset.cmake
+++ b/cmake/Buildyarp-device-openxrheadset.cmake
@@ -6,6 +6,7 @@ include(FindOrBuildPackage)
 
 find_or_build_package(YARP QUIET)
 find_or_build_package(OpenXR QUIET)
+find_or_build_package(iDynTree QUIET)
 
 ycm_ep_helper(yarp-device-openxrheadset TYPE GIT
               STYLE GITHUB
@@ -14,6 +15,7 @@ ycm_ep_helper(yarp-device-openxrheadset TYPE GIT
               COMPONENT dynamics
               FOLDER src
               DEPENDS YARP
-                      OpenXR)
+                      OpenXR
+                      iDynTree)
 
 set(yarp-device-openxrheadset_CONDA_DEPENDENCIES glew glm glfw xorg-xproto)


### PR DESCRIPTION
`yarp-device-openxrheadset` has a optional dependency on iDynTree (see https://github.com/ami-iit/yarp-device-openxrheadset/blob/639803744f63a8496e417861300eac7ad31e0da0/src/utils/CMakeLists.txt#L7-L9), so without an explicit dependency what is actually build is actually subject to a race condition: if `yarp-device-openxrheadset` is built before `iDynTree` it is built without `iDynTree` support, if it is built after it is with with `iDynTree` support. To avoid the race condition, we just add the dependency.