### PR TITLE
Drop support for apt dependencies on Ubuntu 20.04

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -191,7 +191,6 @@ jobs:
         cmake_generator:
           - "Ninja"
         docker_image:
-          - "ubuntu:20.04"
           - "ubuntu:22.04"
           - "ubuntu:24.04"
 
@@ -203,10 +202,6 @@ jobs:
             project_tags_cmake_options: ""
           - project_tags: Unstable
             project_tags_cmake_options: "-DROBOTOLOGY_PROJECT_TAGS=Unstable"
-        exclude:
-          # Not supported anymore, see https://github.com/robotology/robotology-superbuild/issues/1783
-          - project_tags: Unstable
-            docker_image: "ubuntu:20.04"
 
     container:
       image: ${{ matrix.docker_image }}
@@ -230,27 +225,11 @@ jobs:
         chmod +x ./.ci/install_debian.sh
         bash ./.ci/install_debian.sh
 
-    - name: Install recent CMake [Docker/Ubuntu Focal]
-      if: matrix.docker_image == 'ubuntu:20.04'
-      run: |
-        apt-get -y update
-        apt-get install -y ca-certificates software-properties-common gpg wget
-        wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | gpg --dearmor - | tee /usr/share/keyrings/kitware-archive-keyring.gpg >/dev/null
-        echo 'deb [signed-by=/usr/share/keyrings/kitware-archive-keyring.gpg] https://apt.kitware.com/ubuntu/ focal main' | tee /etc/apt/sources.list.d/kitware.list >/dev/null
-        apt-add-repository 'deb https://apt.kitware.com/ubuntu/ focal main'
-        apt-get install -y cmake
-
     - name: Configure [Docker]
       run: |
         mkdir -p build
         cd build
         cmake -C ${GITHUB_WORKSPACE}/.ci/initial-cache.gh.cmake  -G"${{ matrix.cmake_generator }}" -DNON_INTERACTIVE_BUILD:BOOL=TRUE -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}  ${{ matrix.project_tags_cmake_options }}  ..
-
-    - name: Disable MuJoCo and gz-sim for distros released before 2022 [Docker ubuntu:20.04]
-      if: (matrix.docker_image == 'ubuntu:20.04')
-      run: |
-       cd build
-       cmake  -DROBOTOLOGY_USES_MUJOCO:BOOL=OFF -DROBOTOLOGY_USES_GZ:BOOL=OFF .
 
     - name: Disable Gazebo Classic support for distro without Gazebo Classic binaries [Docker ubuntu:24.04]
       if: (matrix.docker_image == 'ubuntu:24.04')

--- a/.github/workflows/generate-conda-packages.yaml
+++ b/.github/workflows/generate-conda-packages.yaml
@@ -52,7 +52,7 @@ jobs:
             fail-fast: false
             matrix:
               include:
-                - os: ubuntu-20.04
+                - os: ubuntu-22.04
                   conda_platform: linux-64
                 - os: macos-14
                   conda_platform: osx-arm64

--- a/.github/workflows/generate-non-periodical-conda-package.yaml
+++ b/.github/workflows/generate-non-periodical-conda-package.yaml
@@ -18,7 +18,7 @@ jobs:
             fail-fast: false
             matrix:
               include:
-                - os: ubuntu-20.04
+                - os: ubuntu-22.04
                   conda_platform: linux-64
                 - os: macos-14
                   conda_platform: osx-arm64

--- a/.github/workflows/update-latest-releases.yml
+++ b/.github/workflows/update-latest-releases.yml
@@ -11,7 +11,7 @@ on:
 jobs:
     update-latest-releases:
         name: "Update latest releases"
-        runs-on: [ubuntu-20.04]
+        runs-on: [ubuntu-22.04]
         steps:
         - uses: actions/checkout@v4
 

--- a/README.md
+++ b/README.md
@@ -102,7 +102,6 @@ We also support an additional deprecated way of compiling the superbuild, on Win
 ## Linux from source with dependencies provided by apt
 
 The following apt-based distributions are supported and tested by the robotology-superbuild:
-* Ubuntu 20.04 (Focal Fossa)
 * Ubuntu 22.04 (Jammy Jellyfish)
 * Ubuntu 24.04 (Noble Numbat)
 
@@ -119,27 +118,18 @@ Besides the packages listed in `apt.txt` file, the script `install_apt_dependenc
 
 For what regards CMake, the robotology-superbuild requires CMake 3.19 . If you are using a recent Debian-based system such as Ubuntu 22.04, the default CMake is recent enough and you do not need to do further steps.
 
-If instead you use an older distro in which the default version of CMake is older, you can easily install a newer CMake version in several ways. For the following distributions, we recommend the following methods:
-* Ubuntu 20.04 "Focal" : install a recent CMake via Kitware APT Repository, see https://apt.kitware.com/ .
-
-
 For some [profile](doc/cmake-options.md#profile-cmake-options) or [dependency](doc/cmake-options.md#dependencies-cmake-options) specific CMake option you may need to install additional system dependencies, following the dependency-specific documentation listed in the following. If you do not want to enable an option, you should ignore the corresponding section and continue with the installation process.
 
 Note that the `ROBOTOLOGY_USES_GAZEBO` option is enabled by default (except on Ubuntu 24.04 when installing with apt dependencies), so you should install Gazebo Classic unless you plan to disable this option.
 
 #### `ROBOTOLOGY_USES_GAZEBO`
 
-On Linux with apt dependencies install Gazebo Classic, if you are on:
-* Ubuntu 20.04
-
-follow the instructions available at https://gazebosim.org/tutorials?tut=install_ubuntu . Make sure to install also the development files, i.e. `libgazebo*-dev` on Debian/Ubuntu.
-
-Otherwise, if you are on other supported Debian/Ubuntu systems, just install the system provided gazebo package with:
+If you are on Ubuntu 22.04 or another Debian/Ubuntu systems where the `libgazebo-dev` Gazebo Classic package is available in apt, just install the system provided gazebo package with:
 ~~~~
 sudo apt install libgazebo-dev
 ~~~~
 
-If you are on Ubuntu 24.04, please use conda if you want to install Gazebo Classic, as no Gazebo Classic packages are available via apt.
+If you are on Ubuntu 24.04, please use conda or pixi to install robotology-superbuild dependencies if you want to install Gazebo Classic, as no Gazebo Classic packages are available via apt.
 
 #### `ROBOTOLOGY_USES_GZ`
 

--- a/apt.txt
+++ b/apt.txt
@@ -11,6 +11,7 @@ libassimp-dev
 libboost-filesystem-dev
 libboost-system-dev
 libboost-thread-dev
+libdc1394-dev
 libedit-dev
 libeigen3-dev
 libgsl0-dev

--- a/cmake/Buildbipedal-locomotion-framework.cmake
+++ b/cmake/Buildbipedal-locomotion-framework.cmake
@@ -33,11 +33,6 @@ if (ROBOTOLOGY_ENABLE_DYNAMICS_FULL_DEPS)
   list(APPEND bipedal-locomotion-framework_DEPENDS CppAD)
   list(APPEND bipedal-locomotion-framework_DEPENDS LieGroupControllers)
 
-  if (ROBOTOLOGY_BUILD_QHULL)
-    find_or_build_package(qhull QUIET)
-    list(APPEND bipedal-locomotion-framework_DEPENDS qhull)
-  endif()
-
   if (ROBOTOLOGY_BUILD_tomlplusplus)
     find_or_build_package(tomlplusplus QUIET)
     list(APPEND bipedal-locomotion-framework_DEPENDS tomlplusplus)

--- a/cmake/RobotologySuperbuildLogic.cmake
+++ b/cmake/RobotologySuperbuildLogic.cmake
@@ -8,27 +8,6 @@ else()
   set(ROBOTOLOGY_CONFIGURING_UNDER_CONDA OFF)
 endif()
 
-
-# We only build qhull on Ubuntu 20.04, not on any other platform
-# See https://github.com/robotology/robotology-superbuild/issues/1269#issuecomment-1257811559
-# See https://stackoverflow.com/questions/26919334/detect-underlying-platform-flavour-in-cmake
-if(ROBOTOLOGY_CONFIGURING_UNDER_CONDA OR APPLE OR WIN32)
-  set(ROBOTOLOGY_BUILD_QHULL OFF)
-else()
-  find_program(ROBSUB_LSB_RELEASE lsb_release)
-  if(ROBSUB_LSB_RELEASE)
-    execute_process(COMMAND lsb_release -cs
-      OUTPUT_VARIABLE LSB_RELEASE_CODENAME
-      OUTPUT_STRIP_TRAILING_WHITESPACE
-    )
-  endif()
-  if(LSB_RELEASE_CODENAME STREQUAL "focal")
-    set(ROBOTOLOGY_BUILD_QHULL ON)
-  else()
-    set(ROBOTOLOGY_BUILD_QHULL OFF)
-  endif()
-endif()
-
 # On conda-forge we get tomlplusplus from conda-forge, otherwise we build it
 if(ROBOTOLOGY_CONFIGURING_UNDER_CONDA)
   set(ROBOTOLOGY_BUILD_tomlplusplus OFF)
@@ -78,7 +57,7 @@ if(ROBOTOLOGY_ENABLE_CORE)
     find_or_build_package(idyntree-matlab-bindings)
   endif()
   find_or_build_package(whole-body-estimators)
-  
+
   if(NOT ROBOTOLOGY_SKIP_ROBOTS_CONFIGURATION)
     find_or_build_package(robots-configuration)
   endif()

--- a/doc/cmake-options.md
+++ b/doc/cmake-options.md
@@ -102,7 +102,7 @@ Not all options are supported on all platforms. The following table provides a r
 | `ROBOTOLOGY_USES_MOVEIT`                                       | ✔️                               |             ❌              |                 ✔️                        |              ❌                           |                  ❌                        |
 | `ROBOTOLOGY_USES_IGNITION`                                          | ❌                               |             ❌              |                 ✔️                        |              ❌                           |               ❌                            |
 | `ROBOTOLOGY_USES_MATLAB`                                            | ✔️                               |             ❌              |                 ✔️                        |              ✔️                           |               ✔️                            |
-| `ROBOTOLOGY_USES_OCTAVE`<sup id="a4">[4!](#f4)</sup>                                            | ✔️                               |              ❌             |                  ❌                       |        )       ❌                          |                  ❌                         |
+| `ROBOTOLOGY_USES_OCTAVE`                                           | ✔️                               |              ❌             |                  ❌                       |        )       ❌                          |                  ❌                         |
 | `ROBOTOLOGY_USES_PYTHON`                | ✔️                               |              ❌             |                  ✔️                       |               ✔️                          |                  ✔️                         |
 | `ROBOTOLOGY_USES_CFW2CAN`                                           |  ✔️                              |             ❌              |                 ✔️                        |              ❌                           |                 ❌                          |
 | `ROBOTOLOGY_USES_XSENS_MVN_SDK`                                     |  ❌                              |             ✔️              |                 ❌                        |              ❌                           |                 ❌                          |
@@ -115,7 +115,6 @@ Not all options are supported on all platforms. The following table provides a r
 
 <b id="f3">3!</b>:`ROBOTOLOGY_USES_GZ`  with apt dependencies do not support building on Debian distros (only Ubuntu is supported). Furthermore it does not run on Windows (https://github.com/gazebosim/gz-sim/issues/2089) and have known problems on macOS (https://github.com/robotology/gz-sim-yarp-plugins/issues/90).
 
-<b id="f4">4!</b>:`ROBOTOLOGY_USES_OCTAVE` do not support building with apt dependencies on Ubuntu 20.04.
 
 
 Profile-specific documentation

--- a/scripts/install_apt_dependencies.sh
+++ b/scripts/install_apt_dependencies.sh
@@ -7,20 +7,3 @@
 SCRIPT_DIR=$(cd "$(dirname "$BASH_SOURCE")"; cd -P "$(dirname "$(readlink "$BASH_SOURCE" || echo .)")"; pwd)
 
 xargs -a ${SCRIPT_DIR}/../apt.txt apt-get install -y
-
-# Handle libdc1394 package (see https://github.com/robotology/robotology-superbuild/issues/854)
-# On Ubuntu 20.04 install libdc1394-22-dev, otherwise libdc1394-dev
-# Remove once Ubuntu 20.04 compatibility is dropped
-ROBSUP_DISTRO_NAME=$(lsb_release -i | cut -d: -f2 | sed s/'^\t'//)
-ROBSUP_DISTRO_VERSION=$(lsb_release -r | cut -d: -f2 | sed s/'^\t'//)
-ROBSUP_DISTRO_CODENAME=$(lsb_release -c | cut -d: -f2 | sed s/'^\t'//)
-
-echo "ROBSUP_DISTRO_NAME: ${ROBSUP_DISTRO_NAME}"
-echo "ROBSUP_DISTRO_VERSION: ${ROBSUP_DISTRO_VERSION}"
-echo "ROBSUP_DISTRO_CODENAME: ${ROBSUP_DISTRO_CODENAME}"
-if [[ ("$ROBSUP_DISTRO_NAME" == "Ubuntu" && "$ROBSUP_DISTRO_VERSION" == "20.04") ]]
-then
-  apt-get install -y libdc1394-22-dev
-else
-  apt-get install -y libdc1394-dev
-fi


### PR DESCRIPTION
YARP 3.11 is not supporting anymore Ubuntu 20.04 with apt dependencies, so as preliminary step for updating to YARP 3.11 we also drop support here. Ubuntu 20.04 users can use conda depenencies if they watn to use newer versions of robotology-superbuild.

Fix https://github.com/robotology/robotology-superbuild/issues/1439 .