### PR TITLE
Bump YARP in Stable and Unstable branches to 3.11.1

### DIFF
--- a/cmake/ProjectsTagsStable.cmake
+++ b/cmake/ProjectsTagsStable.cmake
@@ -16,7 +16,6 @@ set_tag(casadi-matlab-bindings_TAG v3.6.7.0)
 
 # Robotology projects
 set_tag(YCM_TAG master)
-set_tag(YARP_TAG yarp-3.10)
-set_tag(yarp-devices-ros2_TAG v1.0.0)
+set_tag(YARP_TAG yarp-3.11)
 set_tag(yarp-matlab-bindings_TAG yarp-3.10)
 set_tag(gym-ignition_TAG v1.3.1)

--- a/cmake/ProjectsTagsUnstable.cmake
+++ b/cmake/ProjectsTagsUnstable.cmake
@@ -16,7 +16,7 @@ set_tag(casadi-matlab-bindings_TAG v3.6.7.0)
 
 # Robotology projects
 # Pin YARP and yarp-devices-ros2 to a version before the yarp::dev::ReturnValue changes
-set_tag(YARP_TAG master)
+set_tag(YARP_TAG yarp-3.11)
 set_tag(ICUB_TAG devel)
 set_tag(RobotTestingFramework_TAG devel)
 set_tag(blockTest_TAG devel)

--- a/cmake/ProjectsTagsUnstable.cmake
+++ b/cmake/ProjectsTagsUnstable.cmake
@@ -11,13 +11,12 @@ set_tag(manif_TAG 0.0.5)
 set_tag(qhull_TAG 2020.2)
 set_tag(CppAD_TAG 20250000.2)
 set_tag(proxsuite_TAG v0.7.1)
-set_tag(casadi_TAG 3.6.6)
-set_tag(casadi-matlab-bindings_TAG v3.6.6.0)
+set_tag(casadi_TAG 3.6.7)
+set_tag(casadi-matlab-bindings_TAG v3.6.7.0)
 
 # Robotology projects
 # Pin YARP and yarp-devices-ros2 to a version before the yarp::dev::ReturnValue changes
-set_tag(YARP_TAG 43ba0305f8ca690cea5c2a8a6bcdcec60d3ddd0a)
-set_tag(yarp-devices-ros2_TAG e4ba8fa2efe7486edd3ade40b2236e69acb6ab37)
+set_tag(YARP_TAG master)
 set_tag(ICUB_TAG devel)
 set_tag(RobotTestingFramework_TAG devel)
 set_tag(blockTest_TAG devel)


### PR DESCRIPTION
Furthermore also update casadi in Stable and Unstable branches to 3.6.7 as it remained in 3.6.6 there (leftover from https://github.com/robotology/robotology-superbuild/pull/1725).

I did not bumped YARP in latest releases to 3.11.1 as we are blocked on https://github.com/robotology/yarp-devices-ros2/issues/80 .