### PR TITLE
Fix various CI issues of late february 2025

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Source Installation
 ## Clone the repo
 The first step to install `robotology-superbuild` from source is to download the `robotology-superbuild` code itself, and this is done through [Git](https://git-scm.com/).
 
-Once you install Git, you need to set your name and email to sign your commits, as this is required by the superbuild:
+Once you install Git, it is suggest that you set your name and email to sign your commits, to ensure that commits will have meaningful metadata:
 ```
 git config --global user.name FirstName LastName
 git config --global user.email user@email.domain

--- a/cmake/BuildQpSolversEigen.cmake
+++ b/cmake/BuildQpSolversEigen.cmake
@@ -14,7 +14,8 @@ list(APPEND QpSolversEigen_DEPENDS OsqpEigen)
 
 
 # proxqp only supports MSVC Toolset v143, i.e. Visual Studio 2022
-if(NOT MSVC OR MSVC_VERSION VERSION_GREATER_EQUAL 1930)
+# 1943 skipped due to https://github.com/robotology/robotology-superbuild/issues/1814#issuecomment-2690292052
+if(NOT MSVC OR (MSVC_VERSION VERSION_GREATER_EQUAL 1930 AND NOT MSVC_VERSION VERSION_EQUAL 1943))
   find_or_build_package(proxsuite QUIET)
   list(APPEND QpSolversEigen_DEPENDS proxsuite)
   set(QPSOLVERSEIGEN_ENABLE_PROXQP ON)

--- a/cmake/Buildcasadi.cmake
+++ b/cmake/Buildcasadi.cmake
@@ -12,7 +12,8 @@ find_or_build_package(osqp QUIET)
 list(APPEND casadi_DEPENDS osqp)
 
 # proxqp only supports MSVC Toolset v143, i.e. Visual Studio 2022
-if(NOT MSVC OR MSVC_VERSION VERSION_GREATER_EQUAL 1930)
+# 1943 skipped due to https://github.com/robotology/robotology-superbuild/issues/1814#issuecomment-2690292052
+if(NOT MSVC OR (MSVC_VERSION VERSION_GREATER_EQUAL 1930 AND NOT MSVC_VERSION VERSION_EQUAL 1943))
   find_or_build_package(proxsuite QUIET)
   list(APPEND casadi_DEPENDS proxsuite)
   set(casadi_WITH_PROXQP ON)

--- a/cmake/ProjectsTagsStable.cmake
+++ b/cmake/ProjectsTagsStable.cmake
@@ -16,5 +16,6 @@ set_tag(casadi-matlab-bindings_TAG v3.6.7.0)
 # Robotology projects
 set_tag(YCM_TAG master)
 set_tag(YARP_TAG yarp-3.11)
-set_tag(yarp-matlab-bindings_TAG yarp-3.10)
+set_tag(yarp-devices-ros2_TAG v1.1.0)
+set_tag(yarp-matlab-bindings_TAG yarp-3.11)
 set_tag(gym-ignition_TAG v1.3.1)

--- a/releases/latest.releases.yaml
+++ b/releases/latest.releases.yaml
@@ -118,7 +118,7 @@ repositories:
   HumanDynamicsEstimation:
     type: git
     url: https://github.com/robotology/human-dynamics-estimation.git
-    version: v4.2.0
+    version: v4.2.1
   human-gazebo:
     type: git
     url: https://github.com/robotology/human-gazebo.git

--- a/releases/latest.releases.yaml
+++ b/releases/latest.releases.yaml
@@ -42,11 +42,11 @@ repositories:
   GazeboYARPPlugins:
     type: git
     url: https://github.com/robotology/gazebo-yarp-plugins.git
-    version: v4.12.0
+    version: v4.12.1
   icub-models:
     type: git
     url: https://github.com/robotology/icub-models.git
-    version: v3.0.0
+    version: v3.1.0
   ergocub-software:
     type: git
     url: https://github.com/icub-tech-iit/ergocub-software.git
@@ -106,7 +106,7 @@ repositories:
   whole-body-estimators:
     type: git
     url: https://github.com/robotology/whole-body-estimators.git
-    version: v0.11.2
+    version: v0.11.3
   walking-teleoperation:
     type: git
     url: https://github.com/robotology/walking-teleoperation.git

--- a/releases/latest.releases.yaml
+++ b/releases/latest.releases.yaml
@@ -22,7 +22,7 @@ repositories:
   YCM:
     type: git
     url: https://github.com/robotology/ycm.git
-    version: v0.18.1
+    version: v0.18.2
   YARP:
     type: git
     url: https://github.com/robotology/yarp.git

--- a/releases/latest.releases.yaml
+++ b/releases/latest.releases.yaml
@@ -54,7 +54,7 @@ repositories:
   yarp-matlab-bindings:
     type: git
     url: https://github.com/robotology/yarp-matlab-bindings.git
-    version: v3.10.0
+    version: v3.11.0
   RobotTestingFramework:
     type: git
     url: https://github.com/robotology/robot-testing-framework.git


### PR DESCRIPTION
* Fix build of ROBOTOLOGY_USES_ROS2 on Stable branches by pinning yarp-devices-ros2 with a version compatible with YARP 3.11
* Fix build of HDE on Windows with LatestRelease and VS 17.13 by bumping version to 4.2.1 that includes https://github.com/robotology/human-dynamics-estimation/pull/423
* Bump YCM to v0.18.2


Fix https://github.com/robotology/robotology-superbuild/issues/1814 .