### PR TITLE
Use latest conda and conda-libmamba-solver to avoid segfaults on Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,6 +80,13 @@ jobs:
         echo "GHA_Matlab_ROOT_DIR=${GITHUB_WORKSPACE}/msdk_R2020a_mexw64" >> $GITHUB_ENV
         echo "GHA_Matlab_MEX_EXTENSION=mexw64" >> $GITHUB_ENV
 
+    # se latest conda-libmamba-solver to avoid segfaults on Windows
+    - name: Use latest conda-libmamba-solver to avoid segfaults on Windows [Conda/Windows]
+      if: contains(matrix.os, 'windows')
+      shell: bash -l {0}
+      run: |
+        conda -n base conda-libmamba-solver>=25.1.1
+
     - name: Dependencies [Conda]
       shell: bash -l {0}
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,10 @@ jobs:
     - uses: conda-incubator/setup-miniconda@v3
       with:
         miniforge-variant: Miniforge3
+        # This is to use mamba 2.* 
+        # Change back to latest once 25.1.1 gets officially released
         miniforge-version: 25.1.1-0
+        conda-remove-defaults: "true"
 
     - name: Install files to enable compilation of mex files [Conda/Linux]
       if: contains(matrix.os, 'ubuntu')

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
     - uses: conda-incubator/setup-miniconda@v3
       with:
         miniforge-variant: Miniforge3
-        miniforge-version: latest
+        miniforge-version: 25.1.1
 
     - name: Install files to enable compilation of mex files [Conda/Linux]
       if: contains(matrix.os, 'ubuntu')
@@ -79,13 +79,6 @@ jobs:
         rm msdk_R2020a_mexw64.zip
         echo "GHA_Matlab_ROOT_DIR=${GITHUB_WORKSPACE}/msdk_R2020a_mexw64" >> $GITHUB_ENV
         echo "GHA_Matlab_MEX_EXTENSION=mexw64" >> $GITHUB_ENV
-
-    # se latest conda-libmamba-solver to avoid segfaults on Windows
-    - name: Use latest conda-libmamba-solver to avoid segfaults on Windows [Conda/Windows]
-      if: contains(matrix.os, 'windows')
-      shell: bash -l {0}
-      run: |
-        conda install -n base conda-libmamba-solver>=25.1.1
 
     - name: Dependencies [Conda]
       shell: bash -l {0}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
     - uses: conda-incubator/setup-miniconda@v3
       with:
         miniforge-variant: Miniforge3
-        miniforge-version: 25.1.1
+        miniforge-version: 25.1.1-0
 
     - name: Install files to enable compilation of mex files [Conda/Linux]
       if: contains(matrix.os, 'ubuntu')

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,7 +85,7 @@ jobs:
       if: contains(matrix.os, 'windows')
       shell: bash -l {0}
       run: |
-        conda -n base conda-libmamba-solver>=25.1.1
+        conda install -n base conda-libmamba-solver>=25.1.1
 
     - name: Dependencies [Conda]
       shell: bash -l {0}


### PR DESCRIPTION
In the last months we had frequengly segfaults when using conda install on Windows. This CI upgrades the used version of mamba to 2.*, to check if that fixes the segfaults.