### PR TITLE
Enable ROBOMETRY_USES_SYSTEM_nlohmann_json when building robometry

### DIFF
--- a/cmake/Buildrobometry.cmake
+++ b/cmake/Buildrobometry.cmake
@@ -17,7 +17,8 @@ ycm_ep_helper(robometry TYPE GIT
               DEPENDS YCM
                       YARP
                       ICUB
-                      matioCpp)
+                      matioCpp
+              CMAKE_ARGS -DROBOMETRY_USES_SYSTEM_nlohmann_json:BOOL=ON)
 
 set(robometry_CONDA_PKG_NAME librobometry)
 set(robometry_CONDA_PKG_CONDA_FORGE_OVERRIDE ON)


### PR DESCRIPTION
Now that we dropped support for Ubuntu 20.04 with apt dependencies, we can drop the need for manually downloading and compiling nlohmman_json as part of robometry (see https://github.com/robotology/robometry/blob/v1.2.6/CMakeLists.txt#L72-L89).

This should speedup the configuration time of robometry.