### PR TITLE
Fix upload of conda packages after migration to rattler-build

### DIFF
--- a/.github/workflows/generate-conda-packages.yaml
+++ b/.github/workflows/generate-conda-packages.yaml
@@ -192,10 +192,10 @@ jobs:
             PREFIX_DEV_TOKEN: ${{ secrets.PREFIX_DEV_TOKEN }}
           run: |
             cd ${CONDA_BLD_PATH}/${{ matrix.conda_platform}}/
-            ls *.tar.bz2
-            anaconda upload --skip-existing *.tar.bz2
+            ls *.conda
+            anaconda upload --skip-existing *.conda
             pixi auth login https://prefix.dev --token $PREFIX_DEV_TOKEN
-            for condapackage in *.tar.bz2; do
+            for condapackage in *.conda; do
               pixi upload https://prefix.dev/api/v1/upload/robotology "$condapackage"
             done
             pixi auth logout https://prefix.dev
@@ -210,10 +210,10 @@ jobs:
             PREFIX_DEV_TOKEN: ${{ secrets.PREFIX_DEV_TOKEN }}
           run: |
             cd ${CONDA_BLD_PATH}/noarch/
-            ls *.tar.bz2
-            anaconda upload --skip-existing *.tar.bz2
+            ls *.conda
+            anaconda upload --skip-existing *.conda
             pixi auth login https://prefix.dev --token $PREFIX_DEV_TOKEN
-            for condapackage in *.tar.bz2; do
+            for condapackage in *.conda; do
               pixi upload https://prefix.dev/api/v1/upload/robotology "$condapackage"
             done
             pixi auth logout https://prefix.dev

--- a/.github/workflows/generate-non-periodical-conda-package.yaml
+++ b/.github/workflows/generate-non-periodical-conda-package.yaml
@@ -61,10 +61,10 @@ jobs:
             PREFIX_DEV_TOKEN: ${{ secrets.PREFIX_DEV_TOKEN }}
           run: |
             cd ${CONDA_PREFIX}/conda-bld/${{ matrix.conda_platform}}/
-            ls *.tar.bz2
-            anaconda upload --skip-existing *.tar.bz2
+            ls *.conda
+            anaconda upload --skip-existing *.conda
             pixi auth login https://prefix.dev --token $PREFIX_DEV_TOKEN
-            for condapackage in *.tar.bz2; do
+            for condapackage in *.conda; do
               pixi upload https://prefix.dev/api/v1/upload/robotology "$condapackage"
             done
             pixi auth logout https://prefix.dev

--- a/conda/cmake/CondaGenerationOptions.cmake
+++ b/conda/cmake/CondaGenerationOptions.cmake
@@ -2,7 +2,7 @@
 # to ensure that binaries belonging to different rebuilds
 # can be distinguished even if the version number is the same
 if(NOT CONDA_BUILD_NUMBER)
-  set(CONDA_BUILD_NUMBER 159)
+  set(CONDA_BUILD_NUMBER 160)
 endif()
 
 # This option is enabled only when the metapackages robotology-distro are


### PR DESCRIPTION
After migration to rattler-build done https://github.com/robotology/robotology-superbuild/pull/1821, the packages are created as `.conda` packages, not anymore as `.tar.bz2`. So there was some upload-related code that needed to be modified, this PR fixes that.