### PR TITLE
Fix set of AMENT_PREFIX_PATH environment in conda package of human-gazebo

### DIFF
--- a/conda/multisheller/human-gazebo_activate.msh
+++ b/conda/multisheller/human-gazebo_activate.msh
@@ -1,5 +1,7 @@
 if_(is_set("COMSPEC")).then_([
-	sys.list_append("YARP_DATA_DIRS", path.join(env("CONDA_PREFIX"), "Library\\share\\human-gazebo"))
+	sys.list_append("YARP_DATA_DIRS", path.join(env("CONDA_PREFIX"), "Library\\share\\human-gazebo")),
+	sys.list_append("AMENT_PREFIX_PATH", path.join(env("CONDA_PREFIX"), "Library"))
 ]).else_([
-	sys.list_append("YARP_DATA_DIRS", path.join(env("CONDA_PREFIX"), "share/human-gazebo"))
+	sys.list_append("YARP_DATA_DIRS", path.join(env("CONDA_PREFIX"), "share/human-gazebo")),
+	sys.list_append("AMENT_PREFIX_PATH", env("CONDA_PREFIX"))
 ])

--- a/conda/multisheller/human-gazebo_deactivate.msh
+++ b/conda/multisheller/human-gazebo_deactivate.msh
@@ -1,5 +1,7 @@
 if_(is_set("COMSPEC")).then_([
-	sys.list_remove("YARP_DATA_DIRS", path.join(env("CONDA_PREFIX"), "Library\\share\\human-gazebo"))
+	sys.list_remove("YARP_DATA_DIRS", path.join(env("CONDA_PREFIX"), "Library\\share\\human-gazebo")),
+	sys.list_remove("AMENT_PREFIX_PATH", path.join(env("CONDA_PREFIX"), "Library"))
 ]).else_([
-	sys.list_remove("YARP_DATA_DIRS", path.join(env("CONDA_PREFIX"), "share/human-gazebo"))
+	sys.list_remove("YARP_DATA_DIRS", path.join(env("CONDA_PREFIX"), "share/human-gazebo")),
+  	sys.list_remove("AMENT_PREFIX_PATH", env("CONDA_PREFIX"))
 ])


### PR DESCRIPTION
The `human-gazebo` repo install URDF files that use the `package://` URIs, so we need to make sure that `AMENT_PREFIX_PATH` is defined to ensure that the URIs are correctly resolved. We only set `AMENT_PREFIX_PATH` and not env variables related to gz-sim, ROS 1 or Gazebo Classic  we do not envison that these URDF files are used there.