### PR TITLE
Fix configuration of osqp-eigen with multiple-config CMake generators

### DIFF
--- a/cmake/BuildOsqpEigen.cmake
+++ b/cmake/BuildOsqpEigen.cmake
@@ -12,7 +12,7 @@ ycm_ep_helper(OsqpEigen TYPE GIT
               TAG master
               COMPONENT dynamics
               FOLDER src
-              CMAKE_ARGS -DBUILD_TESTING:BOOL=OFF -DOSQP_IS_V1:BOOL=OFF
+              CMAKE_ARGS -DBUILD_TESTING:BOOL=OFF -DOSQP_IS_V1:BOOL=OFF -DOSQP_IS_V1_FINAL:BOOL=OFF
               DEPENDS osqp)
 
 set(OsqpEigen_CONDA_PKG_NAME osqp-eigen)


### PR DESCRIPTION
Similar to https://github.com/robotology/robotology-superbuild/pull/1452, required after https://github.com/robotology/osqp-eigen/pull/189 .