### PR TITLE
Fix compilation of robotology-superbuild with CMake 4.0.0

### DIFF
--- a/cmake/BuildOpenVR.cmake
+++ b/cmake/BuildOpenVR.cmake
@@ -9,6 +9,8 @@ ycm_ep_helper(OpenVR TYPE GIT
               TAG fix_upstream
               COMPONENT external
               FOLDER src
-              CMAKE_ARGS -DBUILD_SHARED:BOOL=ON)
+              CMAKE_ARGS -DBUILD_SHARED:BOOL=ON
+                         # Workaround for CMake 4.0 compatibility, this is a reason why we need to drop OpenVR
+                         -DCMAKE_POLICY_VERSION_MINIMUM=3.10)
 
 set(OpenVR_CONDA_PKG_NAME openvr)

--- a/cmake/Buildbipedal-locomotion-framework.cmake
+++ b/cmake/Buildbipedal-locomotion-framework.cmake
@@ -65,7 +65,7 @@ endif()
 ycm_ep_helper(bipedal-locomotion-framework TYPE GIT
               STYLE GITHUB
               REPOSITORY ami-iit/bipedal-locomotion-framework.git
-              TAG master
+              TAG fixcmake4numpy2
               COMPONENT dynamics
               FOLDER src
               CMAKE_ARGS -DBUILD_TESTING:BOOL=OFF

--- a/cmake/Buildbipedal-locomotion-framework.cmake
+++ b/cmake/Buildbipedal-locomotion-framework.cmake
@@ -65,7 +65,7 @@ endif()
 ycm_ep_helper(bipedal-locomotion-framework TYPE GIT
               STYLE GITHUB
               REPOSITORY ami-iit/bipedal-locomotion-framework.git
-              TAG fixcmake4numpy2
+              TAG master
               COMPONENT dynamics
               FOLDER src
               CMAKE_ARGS -DBUILD_TESTING:BOOL=OFF
@@ -82,6 +82,8 @@ ycm_ep_helper(bipedal-locomotion-framework TYPE GIT
                          -DFRAMEWORK_USE_onnxruntime:BOOL=${ROBOTOLOGY_ENABLE_DYNAMICS_FULL_DEPS}
                          -DFRAMEWORK_COMPILE_PYTHON_BINDINGS:BOOL=${ROBOTOLOGY_USES_PYTHON}
                          ${bipedal-locomotion-framework_OPTIONAL_CMAKE_ARGS}
+                         # Remove once https://github.com/ami-iit/bipedal-locomotion-framework/pull/955 is merged and released
+                         -DCMAKE_POLICY_VERSION_MINIMUM=3.16
               DEPENDS ${bipedal-locomotion-framework_DEPENDS})
 
 set(bipedal-locomotion-framework_CONDA_PKG_NAME bipedal-locomotion-framework)

--- a/cmake/Buildosqp.cmake
+++ b/cmake/Buildosqp.cmake
@@ -12,7 +12,9 @@ ycm_ep_helper(osqp TYPE GIT
               FOLDER src
               CMAKE_ARGS -DUNITTESTS:BOOL=OFF
                          -DOSQP_BUILD_STATIC_LIB:BOOL=OFF
-                         -DQDLDL_BUILD_STATIC_LIB:BOOL=OFF)
+                         -DQDLDL_BUILD_STATIC_LIB:BOOL=OFF
+                         # Workaround for CMake 4.0 compatibility, drop when we update to osqp 1.0.0
+                         -DCMAKE_POLICY_VERSION_MINIMUM=3.10)
 
 set(osqp_CONDA_PKG_NAME libosqp)
 set(osqp_CONDA_PKG_CONDA_FORGE_OVERRIDE ON)

--- a/releases/latest.releases.yaml
+++ b/releases/latest.releases.yaml
@@ -90,7 +90,7 @@ repositories:
   UnicyclePlanner:
     type: git
     url: https://github.com/robotology/unicycle-footstep-planner.git
-    version: v0.8.0
+    version: v0.8.1
   walking-controllers:
     type: git
     url: https://github.com/robotology/walking-controllers.git

--- a/releases/latest.releases.yaml
+++ b/releases/latest.releases.yaml
@@ -114,7 +114,7 @@ repositories:
   yarp-devices-forcetorque:
     type: git
     url: https://github.com/robotology/yarp-devices-forcetorque.git
-    version: v0.3.2
+    version: v0.3.3
   HumanDynamicsEstimation:
     type: git
     url: https://github.com/robotology/human-dynamics-estimation.git


### PR DESCRIPTION
Fix https://github.com/robotology/robotology-superbuild/issues/1831 .


Specific fixes:
* [Fix compilation of osqp with CMake 4.0.0 by passing -DCMAKE_POLICY_VERSION_MINIMUM=3.10](https://github.com/robotology/robotology-superbuild/pull/1832/commits/80acc7245e2ab42f3475369da1ee0402f5511940)