### PR TITLE
Fix path of setup.sh in installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ cd robotology-superbuild
 mkdir build
 cd build
 ccmake ../
-source ./install/share/robotology-superbuild.sh
+source ./install/share/robotology-superbuild/setup.sh
 make
 ```
 You can configure the ccmake environment if you know you will use some particular set of software (put them in "ON").


### PR DESCRIPTION
The path of the `setup.sh` script used in apt instructions was wrong, and was wrong since it was added in https://github.com/robotology/robotology-superbuild/pull/1547 . 

The equivalent instructions in the conda instructions was already correct, so we do not need to fix it.

Thanks @kaidegast for the report.