### PR TITLE
bipedal-locomotion-framework:  Enable YarpRobotLoggerDevice on macOS and Windows

### DIFF
--- a/cmake/Buildbipedal-locomotion-framework.cmake
+++ b/cmake/Buildbipedal-locomotion-framework.cmake
@@ -48,12 +48,6 @@ if(ROBOTOLOGY_USES_PCL_AND_VTK)
   list(APPEND bipedal-locomotion-framework_OPTIONAL_CMAKE_ARGS "-DFRAMEWORK_USE_PCL:BOOL=ON")
 endif()
 
-# Workaround for part of https://github.com/robotology/robotology-superbuild/issues/1307
-if(APPLE OR WIN32)
-  list(APPEND bipedal-locomotion-framework_OPTIONAL_CMAKE_ARGS "-DENABLE_YarpRobotLoggerDevice:BOOL=OFF")
-endif()
-
-
 # Just on Linux without conda, we download onnxruntime
 # On conda instead, we install onnxruntime-cpp package
 if(ROBOTOLOGY_ENABLE_DYNAMICS_FULL_DEPS)


### PR DESCRIPTION
The workaround was added in https://github.com/robotology/robotology-superbuild/pull/1308 for https://github.com/robotology/robotology-superbuild/issues/1307 . 

The root issue was was discussed in https://github.com/ami-iit/bipedal-locomotion-framework/issues/579, https://github.com/ami-iit/matio-cpp/pull/63 and fixed in https://github.com/ami-iit/bipedal-locomotion-framework/pull/580, but the workaround in the robotology-superbuild was never removed.

Fix https://github.com/robotology/robotology-superbuild/issues/1841 .

cc @FabioBergonti @GiulioRomualdi @isorrentino @AntonioViscomi 