### PR TITLE
CI: Remove hardcoding specific miniforge3 version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,10 +44,6 @@ jobs:
     - uses: conda-incubator/setup-miniconda@v3
       with:
         miniforge-variant: Miniforge3
-        # This is to use mamba 2.* 
-        # Change back to latest once 25.1.1 gets officially released
-        miniforge-version: 25.1.1-0
-        conda-remove-defaults: "true"
 
     - name: Install files to enable compilation of mex files [Conda/Linux]
       if: contains(matrix.os, 'ubuntu')


### PR DESCRIPTION
The pin was added in https://github.com/robotology/robotology-superbuild/pull/1818, but since then new release of miniforge were released, and as we saw other failures (https://github.com/robotology/robotology-superbuild/issues/1843) let's check if this helps.

Fix https://github.com/robotology/robotology-superbuild/issues/1843 .