### PR TITLE
Switch to use macos-14 (arm) in matlab-one-line-install-test

### DIFF
--- a/.github/workflows/matlab-one-line-install-test.yml
+++ b/.github/workflows/matlab-one-line-install-test.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-24.04, macos-13, windows-latest]
+        os: [ubuntu-24.04, macos-14, windows-latest]
         matlab_version: [R2022a, R2023a, R2024a, latest]
     runs-on: ${{ matrix.os }}
     


### PR DESCRIPTION
We stopped producing binaries for osx-64 (Intel) in https://github.com/robotology/robotology-superbuild/pull/1712, so it does not make sense that we continue to test them, and we should test osx-arm64 binaries now.