### PR TITLE
Add workaround for ensuring that executables that use qt6 work on Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -150,7 +150,7 @@ endif()
 # See https://github.com/robotology/robotology-superbuild/issues/871 and
 # https://github.com/robotology/robotology-superbuild/issues/882
 if(WIN32 AND ROBOTOLOGY_CONFIGURING_UNDER_CONDA AND EXISTS $ENV{CONDA_PREFIX}/qt.conf)
-  configure_file($ENV{CONDA_PREFIX}/qt.conf ${YCM_EP_INSTALL_DIR}/bin/qt.conf COPYONLY)
+  configure_file($ENV{CONDA_PREFIX}/qt.conf ${YCM_EP_INSTALL_DIR}/bin/qt6.conf COPYONLY)
 endif()
 
 # Install qt6.conf on Windows on conda as a workaround for https://github.com/conda-forge/qt-main-feedstock/issues/275

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -153,6 +153,11 @@ if(WIN32 AND ROBOTOLOGY_CONFIGURING_UNDER_CONDA AND EXISTS $ENV{CONDA_PREFIX}/qt
   configure_file($ENV{CONDA_PREFIX}/qt.conf ${YCM_EP_INSTALL_DIR}/bin/qt.conf COPYONLY)
 endif()
 
+# Install qt6.conf on Windows on conda as a workaround for https://github.com/conda-forge/qt-main-feedstock/issues/275
+if(WIN32 AND ROBOTOLOGY_CONFIGURING_UNDER_CONDA AND EXISTS $ENV{CONDA_PREFIX}/Library/bin/qt6.conf)
+  configure_file($ENV{CONDA_PREFIX}/Library/bin/qt6.conf ${YCM_EP_INSTALL_DIR}/bin/qt.conf COPYONLY)
+endif()
+
 ycm_write_dot_file(${CMAKE_CURRENT_BINARY_DIR}/robotology-superbuild.dot)
 
 set_package_properties(Git PROPERTIES TYPE RUNTIME)


### PR DESCRIPTION
Add a workaround for https://github.com/conda-forge/qt-main-feedstock/issues/275 . In a nutshell, qt6 executable that are not installed in `%CONDA_PREFIX%\Library\bin` on Windows fail with error:

~~~
qt.qpa.plugin: Could not find the Qt platform plugin "windows" in ""
~~~

At the moment (unfortunately) we do not have a lot of qt6 executables in the robotology-superbuild, but any executable that calls for example OpenCV's `cv::imshow` with a recent build of opencv (that uses qt6 under the hood) would trigger the error, so this workaround should work.