### PR TITLE
Remove graphviz and YARP 3.9 workaround

### DIFF
--- a/cmake/BuildYARP.cmake
+++ b/cmake/BuildYARP.cmake
@@ -43,12 +43,6 @@ if(ROBOTOLOGY_USES_PYTHON)
   list(APPEND YARP_OPTIONAL_CMAKE_ARGS "-DCMAKE_INSTALL_PYTHON3DIR=${ROBOTOLOGY_SUPERBUILD_PYTHON_FULL_INSTALL_DIR}")
 endif()
 
-# Workaround for graphviz==9 failures with YARP <= 3.9
-# See https://github.com/robotology/robotology-superbuild/issues/1604
-if(ROBOTOLOGY_CONFIGURING_UNDER_CONDA)
-  list(APPEND YARP_OPTIONAL_CMAKE_ARGS "-DYARP_COMPILE_yarpviz:BOOL=OFF")
-endif()
-
 if(ROBOTOLOGY_SUPERBUILD_USING_LOCAL_SWIG_4_2_1_WORKAROUND_ON_NOBLE)
   list(APPEND YARP_OPTIONAL_CMAKE_ARGS "-DSWIG_EXECUTABLE=${robotology_superbuild_local_noble_swig_4_2_1_SOURCE_DIR}/bin/swig")
   list(APPEND YARP_OPTIONAL_CMAKE_ARGS "-DSWIG_DIR=${robotology_superbuild_local_noble_swig_4_2_1_SOURCE_DIR}/share/swig/4.2.1")


### PR DESCRIPTION
Fix https://github.com/robotology/robotology-superbuild/issues/1604 .