### PR TITLE
Upgrade osqp to v1.0.0 in LatestReleases and Stable, Unstable branches

### DIFF
--- a/cmake/BuildOsqpEigen.cmake
+++ b/cmake/BuildOsqpEigen.cmake
@@ -12,7 +12,7 @@ ycm_ep_helper(OsqpEigen TYPE GIT
               TAG master
               COMPONENT dynamics
               FOLDER src
-              CMAKE_ARGS -DBUILD_TESTING:BOOL=OFF -DOSQP_IS_V1:BOOL=OFF -DOSQP_IS_V1_FINAL:BOOL=OFF
+              CMAKE_ARGS -DBUILD_TESTING:BOOL=OFF -DOSQP_IS_V1:BOOL=ON -DOSQP_IS_V1_FINAL:BOOL=ON
               DEPENDS osqp)
 
 set(OsqpEigen_CONDA_PKG_NAME osqp-eigen)

--- a/cmake/Buildcasadi.cmake
+++ b/cmake/Buildcasadi.cmake
@@ -29,8 +29,8 @@ endif()
 
 ycm_ep_helper(casadi TYPE GIT
               STYLE GITHUB
-              REPOSITORY casadi/casadi.git
-              TAG 3.7.0
+              REPOSITORY ami-iit/casadi.git
+              TAG 3.7.0.1
               COMPONENT external
               FOLDER src
               CMAKE_ARGS -DWITH_IPOPT:BOOL=ON
@@ -56,4 +56,8 @@ ycm_ep_helper(casadi TYPE GIT
 
 set(casadi_CONDA_PKG_NAME casadi)
 set(casadi_CONDA_PKG_CONDA_FORGE_OVERRIDE ON)
-
+# This is a small hack. To avoid incompatibilities between the version tagged in the ami fork
+# (something like 3.7.0.1) and the version available in conda-forge when generating conda metapackages
+# such as robotology-distro, we override the conda package version of casadi
+# here. This needs to be removed as soon as we stop using our fork in the superbuild 
+set(casadi_CONDA_VERSION 3.7.0)

--- a/cmake/Buildosqp.cmake
+++ b/cmake/Buildosqp.cmake
@@ -12,7 +12,9 @@ ycm_ep_helper(osqp TYPE GIT
               FOLDER src
               CMAKE_ARGS -DUNITTESTS:BOOL=OFF
                          -DOSQP_BUILD_STATIC_LIB:BOOL=OFF
-                         -DQDLDL_BUILD_STATIC_LIB:BOOL=OFF)
+                         -DQDLDL_BUILD_STATIC_LIB:BOOL=OFF
+                         # Workaround for CMake 4.0 compatibility, drop when we update to osqp 1.0.0
+                         -DCMAKE_POLICY_VERSION_MINIMUM=3.10)
 
 set(osqp_CONDA_PKG_NAME libosqp)
 set(osqp_CONDA_PKG_CONDA_FORGE_OVERRIDE ON)

--- a/cmake/Buildosqp.cmake
+++ b/cmake/Buildosqp.cmake
@@ -12,14 +12,7 @@ ycm_ep_helper(osqp TYPE GIT
               FOLDER src
               CMAKE_ARGS -DUNITTESTS:BOOL=OFF
                          -DOSQP_BUILD_STATIC_LIB:BOOL=OFF
-                         -DQDLDL_BUILD_STATIC_LIB:BOOL=OFF
-                         # Workaround for CMake 4.0 compatibility, drop when we update to osqp 1.0.0
-                         -DCMAKE_POLICY_VERSION_MINIMUM=3.10)
+                         -DQDLDL_BUILD_STATIC_LIB:BOOL=OFF)
 
 set(osqp_CONDA_PKG_NAME libosqp)
 set(osqp_CONDA_PKG_CONDA_FORGE_OVERRIDE ON)
-# This is a small hack. To avoid incompatibilities between the version tagged in the robotology-dependencies fork
-# (something like 0.6.3.x) and the version available in conda-forge when generating conda metapackages
-# such as robotology-distro, we override the conda package version of manif
-# here. This needs to be removed as soon as we stop using our fork in the superbuild 
-set(osqp_CONDA_VERSION 0.6.3)

--- a/cmake/Buildosqp.cmake
+++ b/cmake/Buildosqp.cmake
@@ -16,3 +16,8 @@ ycm_ep_helper(osqp TYPE GIT
 
 set(osqp_CONDA_PKG_NAME libosqp)
 set(osqp_CONDA_PKG_CONDA_FORGE_OVERRIDE ON)
+# This is a small hack. To avoid incompatibilities between the version tagged in the robotology-dependencies fork
+# (something like 0.6.3.x) and the version available in conda-forge when generating conda metapackages
+# such as robotology-distro, we override the conda package version of manif
+# here. This needs to be removed as soon as we stop using our fork in the superbuild 
+set(osqp_CONDA_VERSION 0.6.3)

--- a/cmake/Buildosqp.cmake
+++ b/cmake/Buildosqp.cmake
@@ -16,3 +16,8 @@ ycm_ep_helper(osqp TYPE GIT
 
 set(osqp_CONDA_PKG_NAME libosqp)
 set(osqp_CONDA_PKG_CONDA_FORGE_OVERRIDE ON)
+# This is a small hack. To avoid incompatibilities between the version tagged in the robotology-dependencies fork
+# (something like 1.0.0.x) and the version available in conda-forge when generating conda metapackages
+# such as robotology-distro, we override the conda package version of manif
+# here. This needs to be removed as soon as we stop using our fork in the superbuild 
+set(osqp_CONDA_VERSION 1.0.0)

--- a/cmake/ProjectsTagsStable.cmake
+++ b/cmake/ProjectsTagsStable.cmake
@@ -5,7 +5,8 @@ macro(set_tag tag_name tag_value)
 endmacro()
 
 # External projects
-set_tag(osqp_TAG v1.0.0)
+set_tag(osqp_REPOSITORY robotology-dependencies/osqp.git)
+set_tag(osqp_TAG v1.0.0.1)
 set_tag(osqp-matlab_TAG v0.9.0.1)
 set_tag(manif_TAG 0.0.5)
 set_tag(CppAD_TAG 20250000.2)

--- a/cmake/ProjectsTagsStable.cmake
+++ b/cmake/ProjectsTagsStable.cmake
@@ -6,7 +6,7 @@ endmacro()
 
 # External projects
 set_tag(osqp_TAG v1.0.0)
-set_tag(osqp-matlab_TAG v0.9.0.0)
+set_tag(osqp-matlab_TAG v0.9.0.1)
 set_tag(manif_TAG 0.0.5)
 set_tag(CppAD_TAG 20250000.2)
 set_tag(proxsuite_TAG v0.7.1)

--- a/cmake/ProjectsTagsStable.cmake
+++ b/cmake/ProjectsTagsStable.cmake
@@ -5,8 +5,7 @@ macro(set_tag tag_name tag_value)
 endmacro()
 
 # External projects
-set_tag(osqp_REPOSITORY robotology-dependencies/osqp.git)
-set_tag(osqp_TAG v0.6.3.1)
+set_tag(osqp_TAG v1.0.0)
 set_tag(manif_TAG 0.0.5)
 set_tag(CppAD_TAG 20250000.2)
 set_tag(proxsuite_TAG v0.7.1)

--- a/cmake/ProjectsTagsStable.cmake
+++ b/cmake/ProjectsTagsStable.cmake
@@ -9,7 +9,8 @@ set_tag(osqp_TAG v1.0.0)
 set_tag(manif_TAG 0.0.5)
 set_tag(CppAD_TAG 20250000.2)
 set_tag(proxsuite_TAG v0.7.1)
-set_tag(casadi_TAG 3.7.0)
+set_tag(casadi_REPOSITORY ami-iit/osqp.git)
+set_tag(casadi_TAG 3.7.0.1)
 set_tag(casadi-matlab-bindings_TAG v3.7.0.0)
 
 # Robotology projects

--- a/cmake/ProjectsTagsStable.cmake
+++ b/cmake/ProjectsTagsStable.cmake
@@ -9,7 +9,7 @@ set_tag(osqp_TAG v1.0.0)
 set_tag(manif_TAG 0.0.5)
 set_tag(CppAD_TAG 20250000.2)
 set_tag(proxsuite_TAG v0.7.1)
-set_tag(casadi_REPOSITORY ami-iit/osqp.git)
+set_tag(casadi_REPOSITORY ami-iit/casadi.git)
 set_tag(casadi_TAG 3.7.0.1)
 set_tag(casadi-matlab-bindings_TAG v3.7.0.0)
 

--- a/cmake/ProjectsTagsStable.cmake
+++ b/cmake/ProjectsTagsStable.cmake
@@ -6,6 +6,7 @@ endmacro()
 
 # External projects
 set_tag(osqp_TAG v1.0.0)
+set_tag(osqp-matlab_TAG v0.9.0.0)
 set_tag(manif_TAG 0.0.5)
 set_tag(CppAD_TAG 20250000.2)
 set_tag(proxsuite_TAG v0.7.1)

--- a/cmake/ProjectsTagsUnstable.cmake
+++ b/cmake/ProjectsTagsUnstable.cmake
@@ -5,7 +5,8 @@ macro(set_tag tag_name tag_value)
 endmacro()
 
 # External projects
-set_tag(osqp_TAG v1.0.0)
+set_tag(osqp_REPOSITORY robotology-dependencies/osqp.git)
+set_tag(osqp_TAG v1.0.0.1)
 set_tag(osqp-matlab_TAG v0.9.0.1)
 set_tag(manif_TAG 0.0.5)
 set_tag(CppAD_TAG 20250000.2)

--- a/cmake/ProjectsTagsUnstable.cmake
+++ b/cmake/ProjectsTagsUnstable.cmake
@@ -6,7 +6,7 @@ endmacro()
 
 # External projects
 set_tag(osqp_TAG v1.0.0)
-set_tag(osqp-matlab_TAG v0.9.0.0)
+set_tag(osqp-matlab_TAG v0.9.0.1)
 set_tag(manif_TAG 0.0.5)
 set_tag(CppAD_TAG 20250000.2)
 set_tag(proxsuite_TAG v0.7.1)

--- a/cmake/ProjectsTagsUnstable.cmake
+++ b/cmake/ProjectsTagsUnstable.cmake
@@ -5,8 +5,7 @@ macro(set_tag tag_name tag_value)
 endmacro()
 
 # External projects
-set_tag(osqp_REPOSITORY robotology-dependencies/osqp.git)
-set_tag(osqp_TAG v0.6.3.1)
+set_tag(osqp_TAG v1.0.0)
 set_tag(manif_TAG 0.0.5)
 set_tag(CppAD_TAG 20250000.2)
 set_tag(proxsuite_TAG v0.7.1)

--- a/cmake/ProjectsTagsUnstable.cmake
+++ b/cmake/ProjectsTagsUnstable.cmake
@@ -9,7 +9,8 @@ set_tag(osqp_TAG v1.0.0)
 set_tag(manif_TAG 0.0.5)
 set_tag(CppAD_TAG 20250000.2)
 set_tag(proxsuite_TAG v0.7.1)
-set_tag(casadi_TAG 3.7.0)
+set_tag(casadi_REPOSITORY ami-iit/osqp.git)
+set_tag(casadi_TAG 3.7.0.1)
 set_tag(casadi-matlab-bindings_TAG v3.7.0.0)
 
 # Robotology projects

--- a/cmake/ProjectsTagsUnstable.cmake
+++ b/cmake/ProjectsTagsUnstable.cmake
@@ -9,7 +9,7 @@ set_tag(osqp_TAG v1.0.0)
 set_tag(manif_TAG 0.0.5)
 set_tag(CppAD_TAG 20250000.2)
 set_tag(proxsuite_TAG v0.7.1)
-set_tag(casadi_REPOSITORY ami-iit/osqp.git)
+set_tag(casadi_REPOSITORY ami-iit/casadi.git)
 set_tag(casadi_TAG 3.7.0.1)
 set_tag(casadi-matlab-bindings_TAG v3.7.0.0)
 

--- a/cmake/ProjectsTagsUnstable.cmake
+++ b/cmake/ProjectsTagsUnstable.cmake
@@ -6,6 +6,7 @@ endmacro()
 
 # External projects
 set_tag(osqp_TAG v1.0.0)
+set_tag(osqp-matlab_TAG v0.9.0.0)
 set_tag(manif_TAG 0.0.5)
 set_tag(CppAD_TAG 20250000.2)
 set_tag(proxsuite_TAG v0.7.1)

--- a/releases/latest.releases.yaml
+++ b/releases/latest.releases.yaml
@@ -86,7 +86,7 @@ repositories:
   OsqpEigen:
     type: git
     url: https://github.com/robotology/osqp-eigen.git
-    version: v0.10.0
+    version: v0.10.1
   UnicyclePlanner:
     type: git
     url: https://github.com/robotology/unicycle-footstep-planner.git

--- a/releases/latest.releases.yaml
+++ b/releases/latest.releases.yaml
@@ -5,8 +5,8 @@ repositories:
     version: v3.2.0.1
   osqp:
     type: git
-    url: https://github.com/osqp/osqp.git
-    version: v1.0.0
+    url: https://github.com/robotology-dependencies/osqp.git
+    version: v0.6.3.1
   manif:
     type: git
     url: https://github.com/artivis/manif.git
@@ -178,7 +178,7 @@ repositories:
   osqp-matlab:
     type: git
     url: https://github.com/ami-iit/osqp-matlab-cmake-buildsystem.git
-    version: v0.9.0.0
+    version: v0.6.2.4
   robometry:
     type: git
     url: https://github.com/robotology/robometry.git

--- a/releases/latest.releases.yaml
+++ b/releases/latest.releases.yaml
@@ -178,7 +178,7 @@ repositories:
   osqp-matlab:
     type: git
     url: https://github.com/ami-iit/osqp-matlab-cmake-buildsystem.git
-    version: v0.6.2.4
+    version: v0.9.0.0
   robometry:
     type: git
     url: https://github.com/robotology/robometry.git

--- a/releases/latest.releases.yaml
+++ b/releases/latest.releases.yaml
@@ -5,8 +5,8 @@ repositories:
     version: v3.2.0.1
   osqp:
     type: git
-    url: https://github.com/robotology-dependencies/osqp.git
-    version: v0.6.3.1
+    url: https://github.com/osqp/osqp.git
+    version: v1.0.0
   manif:
     type: git
     url: https://github.com/artivis/manif.git
@@ -17,8 +17,8 @@ repositories:
     version: 20250000.2
   casadi:
     type: git
-    url: https://github.com/casadi/casadi.git
-    version: 3.7.0
+    url: https://github.com/ami-iit/casadi.git
+    version: 3.7.0.1
   YCM:
     type: git
     url: https://github.com/robotology/ycm.git

--- a/releases/latest.releases.yaml
+++ b/releases/latest.releases.yaml
@@ -5,8 +5,8 @@ repositories:
     version: v3.2.0.1
   osqp:
     type: git
-    url: https://github.com/robotology-dependencies/osqp.git
-    version: v0.6.3.1
+    url: https://github.com/osqp/osqp.git
+    version: v1.0.0
   manif:
     type: git
     url: https://github.com/artivis/manif.git
@@ -178,7 +178,7 @@ repositories:
   osqp-matlab:
     type: git
     url: https://github.com/ami-iit/osqp-matlab-cmake-buildsystem.git
-    version: v0.6.2.4
+    version: v0.9.0.0
   robometry:
     type: git
     url: https://github.com/robotology/robometry.git

--- a/releases/latest.releases.yaml
+++ b/releases/latest.releases.yaml
@@ -5,8 +5,8 @@ repositories:
     version: v3.2.0.1
   osqp:
     type: git
-    url: https://github.com/osqp/osqp.git
-    version: v1.0.0
+    url: https://github.com/robotology-dependencies/osqp.git
+    version: v1.0.0.1
   manif:
     type: git
     url: https://github.com/artivis/manif.git

--- a/releases/latest.releases.yaml
+++ b/releases/latest.releases.yaml
@@ -178,7 +178,7 @@ repositories:
   osqp-matlab:
     type: git
     url: https://github.com/ami-iit/osqp-matlab-cmake-buildsystem.git
-    version: v0.9.0.0
+    version: v0.9.0.1
   robometry:
     type: git
     url: https://github.com/robotology/robometry.git

--- a/releases/latest.releases.yaml
+++ b/releases/latest.releases.yaml
@@ -162,7 +162,7 @@ repositories:
   bipedal-locomotion-framework:
     type: git
     url: https://github.com/ami-iit/bipedal-locomotion-framework.git
-    version: v0.21.1
+    version: v0.22.0
   LieGroupControllers:
     type: git
     url: https://github.com/ami-iit/lie-group-controllers.git


### PR DESCRIPTION
To permit to generate again conda packages for the `robotology` channel, we need to align with the osqp version used in conda-forge, that is now osqp v1. At the moment this PR does not do that as latest releases still uses osqp v1, waiting for a blf release.

To do this, we also need to switch back to use a casadi fork that incorporates https://github.com/casadi/casadi/pull/4105 .
