### PR TITLE
Add deactivation scripts for sh and Command Prompt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -135,11 +135,13 @@ else()
   set(ROBOTOLOGY_WITH_MATLAB_AND_MUJOCO OFF)
 endif()
 configure_file_with_cmakeif(${CMAKE_CURRENT_SOURCE_DIR}/cmake/template/setup.sh.in ${YCM_EP_INSTALL_DIR}/share/${PROJECT_NAME}/setup.sh @ONLY)
+configure_file_with_cmakeif(${CMAKE_CURRENT_SOURCE_DIR}/cmake/template/deactivate.sh.in ${YCM_EP_INSTALL_DIR}/share/${PROJECT_NAME}/deactivate.sh @ONLY)
 
 if(WIN32)
   file(TO_NATIVE_PATH ${PROJECT_SOURCE_DIR} PROJECT_SOURCE_DIR_NATIVE_PATH)
   file(TO_NATIVE_PATH ${YCM_EP_INSTALL_DIR} YCM_EP_INSTALL_DIR_NATIVE_PATH)
   configure_file_with_cmakeif(${CMAKE_CURRENT_SOURCE_DIR}/cmake/template/setup.bat.in ${YCM_EP_INSTALL_DIR}/share/${PROJECT_NAME}/setup.bat @ONLY)
+  configure_file_with_cmakeif(${CMAKE_CURRENT_SOURCE_DIR}/cmake/template/deactivate.bat.in ${YCM_EP_INSTALL_DIR}/share/${PROJECT_NAME}/deactivate.bat @ONLY)
   configure_file_with_cmakeif(${CMAKE_CURRENT_SOURCE_DIR}/cmake/template/addPathsToUserEnvVariables.ps1.in
                               ${YCM_EP_INSTALL_DIR}/share/${PROJECT_NAME}/addPathsToUserEnvVariables.ps1 @ONLY)
   configure_file_with_cmakeif(${CMAKE_CURRENT_SOURCE_DIR}/cmake/template/removePathsFromUserEnvVariables.ps1.in

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ download and compile software developed in the robotology GitHub organization, s
 
 [CMake](https://cmake.org/) is an open-source, cross-platform family of tools designed to build, test and package software.
 A [YCM Superbuild](http://robotology.github.io/ycm-cmake-modules/gh-pages/git-master/index.html#superbuild) is a CMake project whose only goal is to download and build several other projects.
-If you are familiar with ROS, it is something similar to [catkin](http://wiki.ros.org/catkin/workspaces) or [colcon workspace](https://colcon.readthedocs.io/en/released/user/quick-start.html), but using pure CMake for portability reasons and for customizing the build via CMake options. Furthermore, the `robotology-superbuild` also contains some infrastructure to build **binaries** of the contained projects for some platforms. 
+If you are familiar with ROS, it is something similar to [catkin](http://wiki.ros.org/catkin/workspaces) or [colcon workspace](https://colcon.readthedocs.io/en/released/user/quick-start.html), but using pure CMake for portability reasons and for customizing the build via CMake options. Furthermore, the `robotology-superbuild` also contains some infrastructure to build **binaries** of the contained projects for some platforms.
 You can read more about the superbuild concept in [YCM documentation](http://robotology.github.io/ycm-cmake-modules/gh-pages/latest/index.html) or in the [related IRC paper](http://lornat75.github.io/papers/2018/domenichelli-irc.pdf).
 
 Table of Contents
@@ -20,10 +20,10 @@ Table of Contents
   * [FAQs](#faqs)
   * [Mantainers](#mantainers)
 
-Superbuild 
+Superbuild
 ==========
 
-The `robotology-superbuild` is an infrastructure to simplify development and use of **open source research software** developed at the **[Italian Institute of Technology](https://iit.it/)**, in particular as part of the **[iCub project](https://icub.iit.it/)**. 
+The `robotology-superbuild` is an infrastructure to simplify development and use of **open source research software** developed at the **[Italian Institute of Technology](https://iit.it/)**, in particular as part of the **[iCub project](https://icub.iit.it/)**.
 
 ### Profiles and Optional Dependencies
 As a huge number of software projects are contained in the `robotology-superbuild`, and a tipical user is only interested in some of them, there are several **options** to instruct the superbuild on which packages should be built and which one should not be built. In particular, the robotology-superbuild is divided in different **profiles**, that specify the specific subset of robotology packages to build. You can read more on the available **profiles** and how to enable them in the [`doc/cmake-options.md#profile-specific-documentation`](doc/cmake-options.md#profile-specific-documentation).
@@ -31,7 +31,7 @@ As a huge number of software projects are contained in the `robotology-superbuil
 Furthermore, some **dependencies** of software contained in the `robotology-superbuild` are either tricky to install or proprietary, and for this reason software that depends on those  optional dependencies can be **enabled** or **disabled** with specific options,as documented in [`doc/cmake-options.md#dependencies-specific-documentation`](doc/cmake-options.md#dependencies-specific-documentation).
 
 ### Versioning
-For what regards versioning, software in the robotology-superbuild can be consumed in two forms: 
+For what regards versioning, software in the robotology-superbuild can be consumed in two forms:
 
 #### [Rolling update](https://en.wikipedia.org/wiki/Rolling_release)
 In this form, the superbuild will get the latest changes for a branch of each subproject, and will build it. This has the advantage that you get all the latest changes from the software contained in the `robotology-superbuild`, while the downside that the specific software that you use may change at each update. The **rolling update** can be used only when building robotology-superbuild software **from source**. By default, the `robotology-superbuild` uses the latest "stable" branches of the robotology repositories, but in some cases it may be necessary to use the "unstable" active development branches. For this advanced functionalities, please refer to the documentation on changing the default project tags, available at [`doc/change-project-tags.md`](doc/change-project-tags.md).
@@ -45,7 +45,7 @@ The available releases can be seen on [GitHub's release page](https://github.com
 Binary Installation
 ===================
 
-We provide binary packages for Linux, macOS and Windows of the software contained in the robotology-superbuild via the [conda package manager](https://docs.conda.io), relying on the community-mantained [`conda-forge`](https://conda-forge.org/) channel and for some packages on our own `robotology` conda channel. 
+We provide binary packages for Linux, macOS and Windows of the software contained in the robotology-superbuild via the [conda package manager](https://docs.conda.io), relying on the community-mantained [`conda-forge`](https://conda-forge.org/) channel and for some packages on our own `robotology` conda channel.
 
 Please refer to [`doc/conda-forge.md`](doc/conda-forge.md) document for instructions on how to install the conda binary packages, in particular the [`Binary Installation`](doc/conda-forge.md#binary-installation) section.
 
@@ -97,7 +97,7 @@ For each project, the repository will be downloaded in the `src/<package_name>` 
 The build directory for a given project will be instead the `src/<package_name>` subdirectory of the superbuild build directory. 
 All the software packages are installed using the `install` directory of the build as installation prefix.
 
-We also support an additional deprecated way of compiling the superbuild, on Windows using dependencies provided by [vcpkg](https://vcpkg.io/). Documentation for them can be found in [`doc/deprecated-installation-methods.md`](doc/deprecated-installation-methods.md). 
+We also support an additional deprecated way of compiling the superbuild, on Windows using dependencies provided by [vcpkg](https://vcpkg.io/). Documentation for them can be found in [`doc/deprecated-installation-methods.md`](doc/deprecated-installation-methods.md).
 
 ## Linux from source with dependencies provided by apt
 
@@ -241,7 +241,7 @@ yarp conf ${WINDOWS_HOST} 10000 > /dev/null 2>&1
 
 
 ## Update
-If you are using the `robotology-superbuild` in its default branch and not from a release tag (i.e. in **rolling update** mode), to update the superbuild you need to first update the 
+If you are using the `robotology-superbuild` in its default branch and not from a release tag (i.e. in **rolling update** mode), to update the superbuild you need to first update the
 `robotology-superbuild` repository itself with the git command:
 ~~~
 git pull
@@ -272,7 +272,7 @@ For this reason, if you are activly developing on a repository managed by the `r
 option to `TRUE`. This option will ensure that the superbuild will not try to automatically update the `<package_name>` repository. See  https://robotology.github.io/ycm-cmake-modules/gh-pages/latest/manual/ycm-superbuild.7.html?#developer-mode
 for more details on this options.
 
-> [!IMPORTANT]  
+> [!IMPORTANT]
 > Before August 2024 the robotology-superbuild raised an error if you called `make update-all` or `ninja update-all` and there was repo with local modification with `YCM_EP_DEVEL_MODE_<package>` set to `OFF`. Since August 2024, instead the robotology-superbuild will silently discard the local modifications. To avoid losing data, **never call the `update-all` target** if you have local modifications in a package and you did not set `YCM_EP_DEVEL_MODE_<package>` to `ON` for that package.
 
 By default, the `robotology-superbuild` uses the latest "stable" branches of the robotology repositories, but in some cases it may be necessary to use the "unstable" active development branches, or use some fixed tags. For this advanced functionalities, please refer to the documentation on changing the default project tags, available at [`doc/change-project-tags.md`](doc/change-project-tags.md).

--- a/cmake/template/deactivate.bat.in
+++ b/cmake/template/deactivate.bat.in
@@ -1,0 +1,144 @@
+rem Automatically generated deactivate file for @PROJECT_NAME@
+
+rem Function to remove a value from an environment variable (semicolon-separated list)
+rem This is implemented inline since batch doesn't have functions like bash
+
+rem Check if robotology-superbuild environment is active
+if "%ROBOTOLOGY_SUPERBUILD_INSTALL_PREFIX%"=="" (
+    echo Warning: robotology-superbuild environment variables not found. Nothing to deactivate.
+    goto :eof
+)
+
+set "ROBOTOLOGY_SUPERBUILD_INSTALL_PREFIX_LOCAL=%ROBOTOLOGY_SUPERBUILD_INSTALL_PREFIX%"
+set "ROBOTOLOGY_SUPERBUILD_SOURCE_DIR="
+set "ROBOTOLOGY_SUPERBUILD_INSTALL_PREFIX="
+
+rem Cleanup PATH
+call :remove_from_path PATH "%ROBOTOLOGY_SUPERBUILD_INSTALL_PREFIX_LOCAL%\bin"
+
+rem Cleanup YARP related env variables
+call :remove_from_env YARP_DATA_DIRS "%ROBOTOLOGY_SUPERBUILD_INSTALL_PREFIX_LOCAL%\share\yarp"
+call :remove_from_env YARP_DATA_DIRS "%ROBOTOLOGY_SUPERBUILD_INSTALL_PREFIX_LOCAL%\share\iCub"
+call :remove_from_env YARP_DATA_DIRS "%ROBOTOLOGY_SUPERBUILD_INSTALL_PREFIX_LOCAL%\share\ergoCub"
+call :remove_from_env YARP_DATA_DIRS "%ROBOTOLOGY_SUPERBUILD_INSTALL_PREFIX_LOCAL%\share\ICUBcontrib"
+
+rem Cleanup CMAKE_PREFIX_PATH
+call :remove_from_env CMAKE_PREFIX_PATH "%ROBOTOLOGY_SUPERBUILD_INSTALL_PREFIX_LOCAL%"
+
+rem Cleanup BLOCKFACTORY_PLUGIN_PATH
+call :remove_from_env BLOCKFACTORY_PLUGIN_PATH "%ROBOTOLOGY_SUPERBUILD_INSTALL_PREFIX_LOCAL%\@BLOCKFACTORY_PLUGIN_PATH_DIRECTORY@\blockfactory"
+
+rem Cleanup variables useful to find resources in URDF and SDF files
+call :remove_from_env ROS_PACKAGE_PATH "%ROBOTOLOGY_SUPERBUILD_INSTALL_PREFIX_LOCAL%\share"
+call :remove_from_env AMENT_PREFIX_PATH "%ROBOTOLOGY_SUPERBUILD_INSTALL_PREFIX_LOCAL%"
+call :remove_from_env GAZEBO_MODEL_PATH "%ROBOTOLOGY_SUPERBUILD_INSTALL_PREFIX_LOCAL%\share\gazebo\models"
+call :remove_from_env GAZEBO_MODEL_PATH "%ROBOTOLOGY_SUPERBUILD_INSTALL_PREFIX_LOCAL%\share\iCub\robots"
+call :remove_from_env GAZEBO_MODEL_PATH "%ROBOTOLOGY_SUPERBUILD_INSTALL_PREFIX_LOCAL%\share\ergoCub\robots"
+call :remove_from_env GAZEBO_MODEL_PATH "%ROBOTOLOGY_SUPERBUILD_INSTALL_PREFIX_LOCAL%\share"
+
+rem Cleanup XDG_DATA_DIRS
+call :remove_from_env XDG_DATA_DIRS "%ROBOTOLOGY_SUPERBUILD_INSTALL_PREFIX_LOCAL%\share"
+
+@cmakeif ROBOTOLOGY_USES_GAZEBO
+rem Cleanup ROBOTOLOGY_USES_GAZEBO-specific lines
+call :remove_from_env GAZEBO_PLUGIN_PATH "%ROBOTOLOGY_SUPERBUILD_INSTALL_PREFIX_LOCAL%\bin"
+call :remove_from_env GAZEBO_RESOURCE_PATH "%ROBOTOLOGY_SUPERBUILD_INSTALL_PREFIX_LOCAL%\share\gazebo\worlds"
+@endcmakeif ROBOTOLOGY_USES_GAZEBO
+
+@cmakeif ROBOTOLOGY_USES_GZ
+rem Cleanup ROBOTOLOGY_USES_GZ-specific lines
+call :remove_from_env GZ_SIM_SYSTEM_PLUGIN_PATH "%ROBOTOLOGY_SUPERBUILD_INSTALL_PREFIX_LOCAL%\bin"
+call :remove_from_env GZ_SIM_RESOURCE_PATH "%ROBOTOLOGY_SUPERBUILD_INSTALL_PREFIX_LOCAL%\share\gazebo\models"
+call :remove_from_env GZ_SIM_RESOURCE_PATH "%ROBOTOLOGY_SUPERBUILD_INSTALL_PREFIX_LOCAL%\share\iCub\robots"
+call :remove_from_env GZ_SIM_RESOURCE_PATH "%ROBOTOLOGY_SUPERBUILD_INSTALL_PREFIX_LOCAL%\share\ergoCub\robots"
+call :remove_from_env GZ_SIM_RESOURCE_PATH "%ROBOTOLOGY_SUPERBUILD_INSTALL_PREFIX_LOCAL%\share"
+call :remove_from_env GZ_SIM_RESOURCE_PATH "%ROBOTOLOGY_SUPERBUILD_INSTALL_PREFIX_LOCAL%\share\gazebo\worlds"
+@endcmakeif ROBOTOLOGY_USES_GZ
+
+@cmakeif ROBOTOLOGY_ENABLE_ROBOT_TESTING
+rem Cleanup ROBOTOLOGY_ENABLE_ROBOT_TESTING-specific lines
+call :remove_from_path PATH "%ROBOTOLOGY_SUPERBUILD_INSTALL_PREFIX_LOCAL%\lib\robottestingframework"
+call :remove_from_env YARP_DATA_DIRS "@PROJECT_SOURCE_DIR_NATIVE_PATH@\src\icub-tests\suites"
+call :remove_from_env BLOCKTEST_RESOURCE_PATH "%ROBOTOLOGY_SUPERBUILD_INSTALL_PREFIX_LOCAL%\bin"
+@endcmakeif ROBOTOLOGY_ENABLE_ROBOT_TESTING
+
+@cmakeif ROBOTOLOGY_ENABLE_HUMAN_DYNAMICS
+rem Cleanup ROBOTOLOGY_ENABLE_HUMAN_DYNAMICS-specific lines
+call :remove_from_env YARP_DATA_DIRS "%ROBOTOLOGY_SUPERBUILD_INSTALL_PREFIX_LOCAL%\share\human-gazebo"
+call :remove_from_env YARP_DATA_DIRS "%ROBOTOLOGY_SUPERBUILD_INSTALL_PREFIX_LOCAL%\share\HumanDynamicsEstimation"
+@endcmakeif ROBOTOLOGY_ENABLE_HUMAN_DYNAMICS
+
+@cmakeif ROBOTOLOGY_USES_PYTHON
+rem Cleanup the python bindings directory from the PYTHON_PATH
+call :remove_from_env PYTHONPATH "%ROBOTOLOGY_SUPERBUILD_INSTALL_PREFIX_LOCAL%\@ROBOTOLOGY_SUPERBUILD_PYTHON_INSTALL_DIR@"
+rem Remove from the PATH where pure python packages install the scripts
+call :remove_from_path PATH "%ROBOTOLOGY_SUPERBUILD_INSTALL_PREFIX_LOCAL%\@ROBOTOLOGY_SUPERBUILD_PYTHON_INSTALL_DIR@\bin"
+@endcmakeif ROBOTOLOGY_USES_PYTHON
+
+@cmakeif ROBOTOLOGY_USES_MATLAB
+rem Cleanup ROBOTOLOGY_USES_MATLAB-specific lines
+call :remove_from_env YARP_DATA_DIRS "%ROBOTOLOGY_SUPERBUILD_INSTALL_PREFIX_LOCAL%\share\RRbot"
+call :remove_from_env GAZEBO_MODEL_PATH "%ROBOTOLOGY_SUPERBUILD_INSTALL_PREFIX_LOCAL%\share\RRbot\robots"
+call :remove_from_env MATLABPATH "%ROBOTOLOGY_SUPERBUILD_INSTALL_PREFIX_LOCAL%\mex"
+call :remove_from_env MATLABPATH "%ROBOTOLOGY_SUPERBUILD_INSTALL_PREFIX_LOCAL%\mex\+wbc\simulink"
+call :remove_from_env MATLABPATH "%ROBOTOLOGY_SUPERBUILD_INSTALL_PREFIX_LOCAL%\mex\+wbc\simulink\MomentumVelocityControl"
+call :remove_from_env MATLABPATH "%ROBOTOLOGY_SUPERBUILD_INSTALL_PREFIX_LOCAL%\mex\+wbc\examples"
+call :remove_from_env MATLABPATH "%ROBOTOLOGY_SUPERBUILD_INSTALL_PREFIX_LOCAL%\share\WBToolbox"
+call :remove_from_env MATLABPATH "%ROBOTOLOGY_SUPERBUILD_INSTALL_PREFIX_LOCAL%\share\WBToolbox\images"
+@endcmakeif ROBOTOLOGY_USES_MATLAB
+
+@cmakeif ROBOTOLOGY_WITH_MATLAB_AND_MUJOCO
+call :remove_from_env MATLABPATH "%ROBOTOLOGY_SUPERBUILD_INSTALL_PREFIX_LOCAL%\mex\mujoco_simulink_blockset"
+@endcmakeif ROBOTOLOGY_WITH_MATLAB_AND_MUJOCO
+
+goto :eof
+
+rem Function to remove a value from an environment variable
+:remove_from_env
+setlocal enabledelayedexpansion
+set "var_name=%~1"
+set "value_to_remove=%~2"
+call set "current_value=%%%var_name%%%"
+
+if "!current_value!"=="" goto :eof
+
+set "new_value="
+for %%i in ("!current_value:;=" "!") do (
+    set "item=%%~i"
+    if not "!item!"=="!value_to_remove!" (
+        if "!new_value!"=="" (
+            set "new_value=!item!"
+        ) else (
+            set "new_value=!new_value!;!item!"
+        )
+    )
+)
+
+if "!new_value!"=="" (
+    set "%var_name%="
+) else (
+    set "%var_name%=!new_value!"
+)
+endlocal & set "%var_name%=%new_value%"
+goto :eof
+
+rem Function to remove a value from PATH specifically (since PATH is special)
+:remove_from_path
+setlocal enabledelayedexpansion
+set "value_to_remove=%~2"
+set "current_path=%PATH%"
+
+set "new_path="
+for %%i in ("!current_path:;=" "!") do (
+    set "item=%%~i"
+    if not "!item!"=="!value_to_remove!" (
+        if "!new_path!"=="" (
+            set "new_path=!item!"
+        ) else (
+            set "new_path=!new_path!;!item!"
+        )
+    )
+)
+
+endlocal & set "PATH=%new_path%"
+goto :eof

--- a/cmake/template/deactivate.sh.in
+++ b/cmake/template/deactivate.sh.in
@@ -1,0 +1,138 @@
+# Automatically generated deactivate file for @PROJECT_NAME@
+
+# Remove a given environment variable
+remove_env_variable() {
+    local var_name="$1"
+    unset "$var_name"
+}
+
+# Remove a value from a given environment variable (colon-separated list)
+remove_value_from_env_variable() {
+    local var_name="$1"
+    local value="$2"
+
+    # Get current value of the environment variable
+    local curr_var
+    eval "curr_var=\$$var_name"
+
+    # If the env variable is empty, do nothing
+    if [ -z "$curr_var" ]; then
+        return
+    fi
+
+    # Remove the value from the colon-separated list
+    local new_var=""
+    local first=true
+    IFS=':'
+    for item in $curr_var; do
+        if [ "$item" != "$value" ]; then
+            if [ "$first" = "true" ]; then
+                new_var="$item"
+                first=false
+            else
+                new_var="$new_var:$item"
+            fi
+        fi
+    done
+    unset IFS
+
+    # If the resulting variable is empty, unset it, otherwise export the new value
+    if [ -z "$new_var" ]; then
+        unset "$var_name"
+    else
+        export "$var_name"="$new_var"
+    fi
+}
+
+# Check if robotology-superbuild environment is active
+if [ -z "$ROBOTOLOGY_SUPERBUILD_INSTALL_PREFIX" ]; then
+    echo "Warning: robotology-superbuild environment variables not found. Nothing to deactivate."
+    return 0
+fi
+
+remove_env_variable ROBOTOLOGY_SUPERBUILD_SOURCE_DIR
+ROBOTOLOGY_SUPERBUILD_INSTALL_PREFIX_LOCAL="$ROBOTOLOGY_SUPERBUILD_INSTALL_PREFIX"
+remove_env_variable ROBOTOLOGY_SUPERBUILD_INSTALL_PREFIX
+
+# Cleanup PATH
+remove_value_from_env_variable PATH "$ROBOTOLOGY_SUPERBUILD_INSTALL_PREFIX_LOCAL/bin"
+
+# Cleanup YARP related env variables (see http://www.yarp.it/yarp_data_dirs.html )
+remove_value_from_env_variable YARP_DATA_DIRS "$ROBOTOLOGY_SUPERBUILD_INSTALL_PREFIX_LOCAL/share/yarp"
+remove_value_from_env_variable YARP_DATA_DIRS "$ROBOTOLOGY_SUPERBUILD_INSTALL_PREFIX_LOCAL/share/iCub"
+remove_value_from_env_variable YARP_DATA_DIRS "$ROBOTOLOGY_SUPERBUILD_INSTALL_PREFIX_LOCAL/share/ergoCub"
+remove_value_from_env_variable YARP_DATA_DIRS "$ROBOTOLOGY_SUPERBUILD_INSTALL_PREFIX_LOCAL/share/ICUBcontrib"
+
+# Cleanup CMAKE_PREFIX_PATH (see https://cmake.org/cmake/help/v3.8/variable/CMAKE_PREFIX_PATH.html )
+remove_value_from_env_variable CMAKE_PREFIX_PATH "$ROBOTOLOGY_SUPERBUILD_INSTALL_PREFIX_LOCAL"
+
+# Cleanup shared library path
+remove_value_from_env_variable @SHLIB_ENV_VAR@ "$ROBOTOLOGY_SUPERBUILD_INSTALL_PREFIX_LOCAL/lib"
+
+# Cleanup BLOCKFACTORY_PLUGIN_PATH
+remove_value_from_env_variable BLOCKFACTORY_PLUGIN_PATH "$ROBOTOLOGY_SUPERBUILD_INSTALL_PREFIX_LOCAL/@BLOCKFACTORY_PLUGIN_PATH_DIRECTORY@/blockfactory"
+
+# Cleanup variables useful to find resources in URDF and SDF files
+remove_value_from_env_variable ROS_PACKAGE_PATH "$ROBOTOLOGY_SUPERBUILD_INSTALL_PREFIX_LOCAL/share"
+remove_value_from_env_variable AMENT_PREFIX_PATH "$ROBOTOLOGY_SUPERBUILD_INSTALL_PREFIX_LOCAL"
+remove_value_from_env_variable GAZEBO_MODEL_PATH "$ROBOTOLOGY_SUPERBUILD_INSTALL_PREFIX_LOCAL/share/gazebo/models"
+remove_value_from_env_variable GAZEBO_MODEL_PATH "$ROBOTOLOGY_SUPERBUILD_INSTALL_PREFIX_LOCAL/share/iCub/robots"
+remove_value_from_env_variable GAZEBO_MODEL_PATH "$ROBOTOLOGY_SUPERBUILD_INSTALL_PREFIX_LOCAL/share/ergoCub/robots"
+remove_value_from_env_variable GAZEBO_MODEL_PATH "$ROBOTOLOGY_SUPERBUILD_INSTALL_PREFIX_LOCAL/share"
+
+# Cleanup XDG_DATA_DIRS
+remove_value_from_env_variable XDG_DATA_DIRS "$ROBOTOLOGY_SUPERBUILD_INSTALL_PREFIX_LOCAL/share"
+
+@cmakeif ROBOTOLOGY_USES_GAZEBO
+# Cleanup ROBOTOLOGY_USES_GAZEBO-specific lines
+remove_value_from_env_variable GAZEBO_PLUGIN_PATH "$ROBOTOLOGY_SUPERBUILD_INSTALL_PREFIX_LOCAL/lib"
+remove_value_from_env_variable GAZEBO_RESOURCE_PATH "$ROBOTOLOGY_SUPERBUILD_INSTALL_PREFIX_LOCAL/share/gazebo/worlds"
+@endcmakeif ROBOTOLOGY_USES_GAZEBO
+
+@cmakeif ROBOTOLOGY_USES_GZ
+# Cleanup ROBOTOLOGY_USES_GZ-specific lines
+remove_value_from_env_variable GZ_SIM_SYSTEM_PLUGIN_PATH "$ROBOTOLOGY_SUPERBUILD_INSTALL_PREFIX_LOCAL/lib"
+remove_value_from_env_variable GZ_SIM_RESOURCE_PATH "$ROBOTOLOGY_SUPERBUILD_INSTALL_PREFIX_LOCAL/share/gazebo/models"
+remove_value_from_env_variable GZ_SIM_RESOURCE_PATH "$ROBOTOLOGY_SUPERBUILD_INSTALL_PREFIX_LOCAL/share/iCub/robots"
+remove_value_from_env_variable GZ_SIM_RESOURCE_PATH "$ROBOTOLOGY_SUPERBUILD_INSTALL_PREFIX_LOCAL/share/ergoCub/robots"
+remove_value_from_env_variable GZ_SIM_RESOURCE_PATH "$ROBOTOLOGY_SUPERBUILD_INSTALL_PREFIX_LOCAL/share"
+remove_value_from_env_variable GZ_SIM_RESOURCE_PATH "$ROBOTOLOGY_SUPERBUILD_INSTALL_PREFIX_LOCAL/share/gazebo/worlds"
+@endcmakeif ROBOTOLOGY_USES_GZ
+
+@cmakeif ROBOTOLOGY_ENABLE_ROBOT_TESTING
+# Cleanup ROBOTOLOGY_ENABLE_ROBOT_TESTING-specific lines
+remove_value_from_env_variable @SHLIB_ENV_VAR@ "$ROBOTOLOGY_SUPERBUILD_INSTALL_PREFIX_LOCAL/lib/robottestingframework"
+remove_value_from_env_variable YARP_DATA_DIRS "@PROJECT_SOURCE_DIR_SETUP_SH@/src/icub-tests/suites"
+remove_value_from_env_variable BLOCKTEST_RESOURCE_PATH "$ROBOTOLOGY_SUPERBUILD_INSTALL_PREFIX_LOCAL/bin"
+@endcmakeif ROBOTOLOGY_ENABLE_ROBOT_TESTING
+
+@cmakeif ROBOTOLOGY_ENABLE_HUMAN_DYNAMICS
+# Cleanup ROBOTOLOGY_ENABLE_HUMAN_DYNAMICS-specific lines
+remove_value_from_env_variable YARP_DATA_DIRS "$ROBOTOLOGY_SUPERBUILD_INSTALL_PREFIX_LOCAL/share/human-gazebo"
+remove_value_from_env_variable YARP_DATA_DIRS "$ROBOTOLOGY_SUPERBUILD_INSTALL_PREFIX_LOCAL/share/HumanDynamicsEstimation"
+@endcmakeif ROBOTOLOGY_ENABLE_HUMAN_DYNAMICS
+
+@cmakeif ROBOTOLOGY_USES_PYTHON
+# Cleanup the python bindings directory from the PYTHON_PATH
+remove_value_from_env_variable PYTHONPATH "$ROBOTOLOGY_SUPERBUILD_INSTALL_PREFIX_LOCAL/@ROBOTOLOGY_SUPERBUILD_PYTHON_INSTALL_DIR_SETUP_SH@"
+# Remove from the PATH where pure python packages (such as robot-log-visualizer) install the scripts
+remove_value_from_env_variable PATH "$ROBOTOLOGY_SUPERBUILD_INSTALL_PREFIX_LOCAL/@ROBOTOLOGY_SUPERBUILD_PYTHON_INSTALL_DIR_SETUP_SH@/bin"
+@endcmakeif ROBOTOLOGY_USES_PYTHON
+
+@cmakeif ROBOTOLOGY_USES_MATLAB
+# Cleanup ROBOTOLOGY_USES_MATLAB-specific lines
+remove_value_from_env_variable YARP_DATA_DIRS "$ROBOTOLOGY_SUPERBUILD_INSTALL_PREFIX_LOCAL/share/RRbot"
+remove_value_from_env_variable GAZEBO_MODEL_PATH "$ROBOTOLOGY_SUPERBUILD_INSTALL_PREFIX_LOCAL/share/RRbot/robots"
+remove_value_from_env_variable GZ_SIM_RESOURCE_PATH "$ROBOTOLOGY_SUPERBUILD_INSTALL_PREFIX_LOCAL/share/RRbot/robots"
+remove_value_from_env_variable MATLABPATH "$ROBOTOLOGY_SUPERBUILD_INSTALL_PREFIX_LOCAL/mex"
+remove_value_from_env_variable MATLABPATH "$ROBOTOLOGY_SUPERBUILD_INSTALL_PREFIX_LOCAL/mex/+wbc/simulink/MomentumVelocityControl"
+remove_value_from_env_variable MATLABPATH "$ROBOTOLOGY_SUPERBUILD_INSTALL_PREFIX_LOCAL/mex/+wbc/simulink"
+remove_value_from_env_variable MATLABPATH "$ROBOTOLOGY_SUPERBUILD_INSTALL_PREFIX_LOCAL/mex/+wbc/examples"
+remove_value_from_env_variable MATLABPATH "$ROBOTOLOGY_SUPERBUILD_INSTALL_PREFIX_LOCAL/share/WBToolbox"
+remove_value_from_env_variable MATLABPATH "$ROBOTOLOGY_SUPERBUILD_INSTALL_PREFIX_LOCAL/share/WBToolbox/images"
+# Note: JAVA_TOOL_OPTIONS is tricky to clean up properly, so we leave it as is
+@endcmakeif ROBOTOLOGY_USES_MATLAB
+
+@cmakeif ROBOTOLOGY_WITH_MATLAB_AND_MUJOCO
+remove_value_from_env_variable MATLABPATH "$ROBOTOLOGY_SUPERBUILD_INSTALL_PREFIX_LOCAL/mex/mujoco_simulink_blockset"
+@endcmakeif ROBOTOLOGY_WITH_MATLAB_AND_MUJOCO

--- a/cmake/template/setup.sh.in
+++ b/cmake/template/setup.sh.in
@@ -2,6 +2,7 @@
 
 export ROBOTOLOGY_SUPERBUILD_SOURCE_DIR=@PROJECT_SOURCE_DIR_SETUP_SH@
 export ROBOTOLOGY_SUPERBUILD_INSTALL_PREFIX=@YCM_EP_INSTALL_DIR_SETUP_SH@
+
 # Extend PATH (see https://en.wikipedia.org/wiki/PATH_(variable) )
 export PATH=$PATH:$ROBOTOLOGY_SUPERBUILD_INSTALL_PREFIX/bin
 # YARP related env variables (see http://www.yarp.it/yarp_data_dirs.html )

--- a/doc/conda-forge.md
+++ b/doc/conda-forge.md
@@ -264,3 +264,15 @@ On **Windows with cmd prompt**:
 conda activate robsub
 call ./robotology-superbuild/build/install/share/robotology-superbuild/setup.bat
 ~~~
+
+If you need to deactivate the robotology-superbuild environment, you can use the deactivate scripts:
+
+On **Linux**, **macOS** or **Windows with Git Bash**:
+~~~
+source ./robotology-superbuild/build/install/share/robotology-superbuild/deactivate.sh
+~~~
+
+On **Windows with cmd prompt**:
+~~~
+call ./robotology-superbuild/build/install/share/robotology-superbuild/deactivate.bat
+~~~

--- a/doc/deprecated-installation-methods.md
+++ b/doc/deprecated-installation-methods.md
@@ -126,11 +126,18 @@ To check the values of the enviroment variables modified by the powershell scrip
 If you do not want to modify the user enviroment variables permanently, the superbuild provides an automatically generated `setup.bat` batch script in `<directory-where-you-downloaded-robotology-superbuild>/build/install/share/robotology-superbuild/setup.bat`. This script will set
 all the necessary enviromental variables to use the software installed by the robotology-superbuild. However, as in Windows there is no `.bashrc` file-equivalent, you will need to call this script every time you open a batch terminal in which you want to run the software installed by the robotology-superbuild.
 
+If you need to deactivate the robotology-superbuild environment, you can use the automatically generated `deactivate.bat` script in `<directory-where-you-downloaded-robotology-superbuild>/build/install/share/robotology-superbuild/deactivate.bat`.
+
 Another option if you do not want to to modify the user enviroment variables permanently and you use the Git Bash as your main terminal,
 is to use the automatically generated `setup.sh` script,  available in `<directory-where-you-downloaded-robotology-superbuild>/build/install/share/robotology-superbuild/setup.sh`.
 You can source automatically this script for any new Git Bash instance by creating a `.bash_profile` file  in your `C:/Users/<UserName>`  directory, and by adding in it the file:
 ~~~
 source <directory-where-you-downloaded-robotology-superbuild>/build/install/share/robotology-superbuild/setup.sh
+~~~
+
+Similarly, if you are using Git Bash and need to deactivate the robotology-superbuild environment, you can use:
+~~~
+source <directory-where-you-downloaded-robotology-superbuild>/build/install/share/robotology-superbuild/deactivate.sh
 ~~~
 
 If for any reason you do not want to use the provided scripts and you want to manage your enviroment variables manually, for example because you want to cleanup the enviroment variables modified by `addPathsToUserEnvVariables.ps1`  and you delete the corresponding `removePathsFromUserEnvVariables.ps1`, please refer to the documentation available at [`doc/environment-variables-configuration.md `](environment-variables-configuration.md).

--- a/doc/environment-variables-configuration.md
+++ b/doc/environment-variables-configuration.md
@@ -5,6 +5,8 @@ During the configuration process, the robotology-superbuild installs the `setup.
 These scripts can be used to automatically add to the [enviroment variables](https://en.wikipedia.org/wiki/Environment_variable)
 of the process the variables necessary to successfully launch the software installed by the robotology-superbuild, even if it is not installed in the system install prefix.
 
+Additionally, the robotology-superbuild also generates `deactivate.sh` (in Linux and macOS) and `deactivate.bat` (in Windows) scripts that can be used to remove the robotology-superbuild paths from the environment variables. These deactivate scripts are useful when you need to temporarily disable the robotology-superbuild environment and you are in a terminal in which the activation script were already called.
+
 However, for some use cases it may be necessary to manually deal with the necessary enviroment modification, and so all the enviroment variables
 that are needed by the software installed by the robotology-superbuild are documented in this page.
 


### PR DESCRIPTION
Fix https://github.com/robotology/robotology-superbuild/issues/1498 . 

This PR adds a  `./build/install/share/robotology-superbuild/deactivate.sh` and `./build/install/share/robotology-superbuild/deactivate.bat` scripts, to complement the existing `./build/install/share/robotology-superbuild/setup.sh` and `./build/install/share/robotology-superbuild/setup.bat` that are used to set all the env variables required by the superbuild. 

In particular, the new scripts are useful in context where a conda environment + superbuild environment is already activated, for example inside a `.bashrc` with : 

~~~
conda activate robsub
source ./build/install/share/robotology-superbuild/setup.sh
~~~

if you want to activate a new conda environment, to avoid cross-talking your first need to deactivate the conda + superbuild environment, and you can do that with:

~~~
source ./build/install/share/robotology-superbuild/deactivate.sh
conda deactivate
~~~

@Nicogene @martinaxgloria @GiulioRomualdi @isorrentino @S-Dafarra @LoreMoretti @xela-95 @carloscp3009 @giotherobot 