### PR TITLE
Fixed wrong link of Simulink Arsenal

### DIFF
--- a/releases/2025.08.0.yaml
+++ b/releases/2025.08.0.yaml
@@ -137,7 +137,7 @@ repositories:
     version: v1.44.0
   simulink-arsenal:
     type: git
-    url: https://github.com/icub-tech-iit/simunlink-arsenal.git
+    url: https://github.com/icub-tech-iit/simulink-arsenal.git
     version: v1.0.0
   icub-firmware-models:
     type: git

--- a/releases/latest.releases.yaml
+++ b/releases/latest.releases.yaml
@@ -137,7 +137,7 @@ repositories:
     version: v1.44.0
   simulink-arsenal:
     type: git
-    url: https://github.com/icub-tech-iit/simunlink-arsenal.git
+    url: https://github.com/icub-tech-iit/simulink-arsenal.git
     version: v1.0.0
   icub-firmware-models:
     type: git


### PR DESCRIPTION
As per the title.

Once merged, we may want to cherry pick this commit onto `master`, @traversaro 