### PR TITLE
Fix name of qt.conf and qt6.conf files installed as a workaround

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -152,12 +152,12 @@ endif()
 # See https://github.com/robotology/robotology-superbuild/issues/871 and
 # https://github.com/robotology/robotology-superbuild/issues/882
 if(WIN32 AND ROBOTOLOGY_CONFIGURING_UNDER_CONDA AND EXISTS $ENV{CONDA_PREFIX}/qt.conf)
-  configure_file($ENV{CONDA_PREFIX}/qt.conf ${YCM_EP_INSTALL_DIR}/bin/qt6.conf COPYONLY)
+  configure_file($ENV{CONDA_PREFIX}/qt.conf ${YCM_EP_INSTALL_DIR}/bin/qt.conf COPYONLY)
 endif()
 
 # Install qt6.conf on Windows on conda as a workaround for https://github.com/conda-forge/qt-main-feedstock/issues/275
 if(WIN32 AND ROBOTOLOGY_CONFIGURING_UNDER_CONDA AND EXISTS $ENV{CONDA_PREFIX}/Library/bin/qt6.conf)
-  configure_file($ENV{CONDA_PREFIX}/Library/bin/qt6.conf ${YCM_EP_INSTALL_DIR}/bin/qt.conf COPYONLY)
+  configure_file($ENV{CONDA_PREFIX}/Library/bin/qt6.conf ${YCM_EP_INSTALL_DIR}/bin/qt6.conf COPYONLY)
 endif()
 
 ycm_write_dot_file(${CMAKE_CURRENT_BINARY_DIR}/robotology-superbuild.dot)


### PR DESCRIPTION
For some reason, in https://github.com/robotology/robotology-superbuild/pull/1853 we were installing the qt5 one (that is called `qt.conf`) as `qt6.conf` and the qt6 one (that is called `qt6.conf`) as `qt.conf`, so I suspect this may be the reason behind https://github.com/robotology/robotology-superbuild/issues/1915 .