### PR TITLE
Temporarely skip generation of robot-log-visualizer conda package

### DIFF
--- a/.github/workflows/generate-conda-packages.yaml
+++ b/.github/workflows/generate-conda-packages.yaml
@@ -172,6 +172,8 @@ jobs:
             cat ./generated_recipes/*/recipe.yaml
             cat ./generated_recipes/*/build.bat
             cat ./generated_recipes/*/build.sh
+            # Temporarly avoid building the robot-log-visualizer recipe until https://github.com/ami-iit/robot-log-visualizer/issues/115 is fixed
+            rm -rf ./generated_recipes/robot-log-visualizer
             rattler-build build --recipe-dir ./generated_recipes -m ${CONDA_PREFIX}/conda_build_config.yaml -m ${GITHUB_WORKSPACE}/conda/conda_build_config.yml
 
         - name: Build robotology-distro conda metapackage (if necessary)


### PR DESCRIPTION
Workaround for https://github.com/robotology/robotology-superbuild/issues/1923 while we wait for https://github.com/ami-iit/robot-log-visualizer/issues/115 .