### PR TITLE
Add fmt and spdlog dependencies to walking-controllers

### DIFF
--- a/.github/workflows/generate-conda-packages.yaml
+++ b/.github/workflows/generate-conda-packages.yaml
@@ -203,22 +203,23 @@ jobs:
             pixi auth logout https://prefix.dev
 
         # Only on linux-64 we upload noarch packages (noarch packages need to be uploaded only once, as they can be reused across platforms)
-        - name: Upload conda packages (noarch)
-          shell: bash -l {0}
-          # Upload by default on schedule events, and on workflow dispatch only if input upload_conda_binaries is 'true'
-          if: matrix.conda_platform == 'linux-64' && (github.event_name == 'schedule' || github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && github.event.inputs.upload_conda_binaries == 'true'))
-          env:
-            ANACONDA_API_TOKEN: ${{ secrets.ANACONDA_API_TOKEN }}
-            PREFIX_DEV_TOKEN: ${{ secrets.PREFIX_DEV_TOKEN }}
-          run: |
-            cd ${CONDA_BLD_PATH}/noarch/
-            ls *.conda
-            anaconda upload --skip-existing *.conda
-            pixi auth login https://prefix.dev --token $PREFIX_DEV_TOKEN
-            for condapackage in *.conda; do
-              pixi upload https://prefix.dev/api/v1/upload/robotology "$condapackage"
-            done
-            pixi auth logout https://prefix.dev
+        # This is disable until we re-enable robot-log-visualizer package
+        #- name: Upload conda packages (noarch)
+        #  shell: bash -l {0}
+        #  # Upload by default on schedule events, and on workflow dispatch only if input upload_conda_binaries is 'true'
+        #  if: matrix.conda_platform == 'linux-64' && (github.event_name == 'schedule' || github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && github.event.inputs.upload_conda_binaries == 'true'))
+        #  env:
+        #    ANACONDA_API_TOKEN: ${{ secrets.ANACONDA_API_TOKEN }}
+        #    PREFIX_DEV_TOKEN: ${{ secrets.PREFIX_DEV_TOKEN }}
+        #  run: |
+        #    cd ${CONDA_BLD_PATH}/noarch/
+        #    ls *.conda
+        #    anaconda upload --skip-existing *.conda
+        #    pixi auth login https://prefix.dev --token $PREFIX_DEV_TOKEN
+        #    for condapackage in *.conda; do
+        #      pixi upload https://prefix.dev/api/v1/upload/robotology "$condapackage"
+        #    done
+        #    pixi auth logout https://prefix.dev
 
     # If the  generate-conda-packages completed correctly and binaries are uploaded,
     # bump automatically the CONDA_BUILD_NUMBER in conda/cmake/CondaGenerationOptions.cmake

--- a/cmake/Buildwalking-controllers.cmake
+++ b/cmake/Buildwalking-controllers.cmake
@@ -34,4 +34,7 @@ ycm_ep_helper(walking-controllers TYPE GIT
               FOLDER src
               DEPENDS ${walking-controllers_DEPENDS})
 
-set(walking-controllers_CONDA_DEPENDENCIES eigen tomlplusplus)
+# fmt and spdlog are not direct dependencies but a transitive dep 
+# via blf, they are added as a workaround for
+# https://github.com/robotology/walking-controllers/issues/207
+set(walking-controllers_CONDA_DEPENDENCIES eigen tomlplusplus fmt spdlog)

--- a/conda/cmake/CondaGenerationOptions.cmake
+++ b/conda/cmake/CondaGenerationOptions.cmake
@@ -2,7 +2,7 @@
 # to ensure that binaries belonging to different rebuilds
 # can be distinguished even if the version number is the same
 if(NOT CONDA_BUILD_NUMBER)
-  set(CONDA_BUILD_NUMBER 169)
+  set(CONDA_BUILD_NUMBER 170)
 endif()
 
 # This option is enabled only when the metapackages robotology-distro are


### PR DESCRIPTION
This is done as a workaround for https://github.com/robotology/walking-controllers/issues/207 .

Other changes:
* Comment out the upload of noarch packages, as there are no noarch packages after we commented out robot-log-visualizer in https://github.com/robotology/robotology-superbuild/pull/1924
* Bumped manually CONDA_BUILD_NUMBER, as the automatic bump was not done in https://github.com/robotology/robotology-superbuild/actions/runs/19867427478 as the "Upload conda packages (noarch)" step failed (see previous point).