### PR TITLE
Add ros-gz package to pixi.toml

### DIFF
--- a/pixi.lock
+++ b/pixi.lock
@@ -4,8 +4,6 @@ environments:
     channels:
     - url: https://conda.anaconda.org/conda-forge/
     - url: https://conda.anaconda.org/robotology/
-    options:
-      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
@@ -2347,8 +2345,6 @@ environments:
     - url: https://conda.anaconda.org/conda-forge/
     - url: https://conda.anaconda.org/robotology/
     - url: https://conda.anaconda.org/robostack-humble/
-    options:
-      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
@@ -2881,7 +2877,6 @@ environments:
       - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-fastrtps-2.6.9-np126py311h2c3b307_7.conda
       - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-fastrtps-cmake-module-2.2.2-np126py311h2c3b307_7.conda
       - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-foonathan-memory-vendor-1.2.0-np126py311h2c3b307_7.conda
-      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-gazebo-msgs-3.7.0-np126py311h2c3b307_7.conda
       - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-generate-parameter-library-0.3.9-np126py311h2c3b307_7.conda
       - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-generate-parameter-library-py-0.3.9-np126py311h2c3b307_7.conda
       - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-geometric-shapes-2.3.1-np126py311h2c3b307_7.conda
@@ -2983,6 +2978,7 @@ environments:
       - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-ros-base-0.10.0-np126py311h2c3b307_7.conda
       - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-ros-core-0.10.0-np126py311h2c3b307_7.conda
       - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-ros-environment-3.2.2-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-ros-gz-interfaces-0.244.16-np126py311h2c3b307_7.conda
       - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-ros-workspace-1.0.2-np126py311h2c3b307_9.conda
       - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-ros2-control-test-assets-2.47.0-np126py311h2c3b307_7.conda
       - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-ros2action-0.18.11-np126py311h2c3b307_7.conda
@@ -3705,7 +3701,6 @@ environments:
       - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-fastrtps-2.6.9-np126py311h65a17ee_5.conda
       - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-fastrtps-cmake-module-2.2.2-np126py311h65a17ee_5.conda
       - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-foonathan-memory-vendor-1.2.0-np126py311h65a17ee_5.conda
-      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-gazebo-msgs-3.7.0-np126py311h65a17ee_5.conda
       - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-generate-parameter-library-0.3.9-np126py311h65a17ee_5.conda
       - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-generate-parameter-library-py-0.3.9-np126py311h65a17ee_5.conda
       - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-geometric-shapes-2.3.1-np126py311h65a17ee_5.conda
@@ -3807,6 +3802,7 @@ environments:
       - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-ros-base-0.10.0-np126py311h65a17ee_5.conda
       - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-ros-core-0.10.0-np126py311h65a17ee_5.conda
       - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-ros-environment-3.2.2-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-ros-gz-interfaces-0.244.16-np126py311h65a17ee_5.conda
       - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-ros-workspace-1.0.2-np126py311h65a17ee_9.conda
       - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-ros2-control-test-assets-2.47.0-np126py311h65a17ee_5.conda
       - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-ros2action-0.18.11-np126py311h65a17ee_5.conda
@@ -4484,7 +4480,6 @@ environments:
       - conda: https://conda.anaconda.org/robostack-humble/osx-64/ros-humble-fastrtps-2.6.9-np126py311h8a2294f_7.conda
       - conda: https://conda.anaconda.org/robostack-humble/osx-64/ros-humble-fastrtps-cmake-module-2.2.2-np126py311h8a2294f_7.conda
       - conda: https://conda.anaconda.org/robostack-humble/osx-64/ros-humble-foonathan-memory-vendor-1.2.0-np126py311h8a2294f_7.conda
-      - conda: https://conda.anaconda.org/robostack-humble/osx-64/ros-humble-gazebo-msgs-3.7.0-np126py311h8a2294f_7.conda
       - conda: https://conda.anaconda.org/robostack-humble/osx-64/ros-humble-generate-parameter-library-0.3.9-np126py311h8a2294f_7.conda
       - conda: https://conda.anaconda.org/robostack-humble/osx-64/ros-humble-generate-parameter-library-py-0.3.9-np126py311h8a2294f_7.conda
       - conda: https://conda.anaconda.org/robostack-humble/osx-64/ros-humble-geometric-shapes-2.3.1-np126py311h8a2294f_7.conda
@@ -4586,6 +4581,7 @@ environments:
       - conda: https://conda.anaconda.org/robostack-humble/osx-64/ros-humble-ros-base-0.10.0-np126py311h8a2294f_7.conda
       - conda: https://conda.anaconda.org/robostack-humble/osx-64/ros-humble-ros-core-0.10.0-np126py311h8a2294f_7.conda
       - conda: https://conda.anaconda.org/robostack-humble/osx-64/ros-humble-ros-environment-3.2.2-np126py311h8a2294f_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/osx-64/ros-humble-ros-gz-interfaces-0.244.16-np126py311h8a2294f_7.conda
       - conda: https://conda.anaconda.org/robostack-humble/osx-64/ros-humble-ros-workspace-1.0.2-np126py311h8a2294f_9.conda
       - conda: https://conda.anaconda.org/robostack-humble/osx-64/ros-humble-ros2-control-test-assets-2.47.0-np126py311h8a2294f_7.conda
       - conda: https://conda.anaconda.org/robostack-humble/osx-64/ros-humble-ros2action-0.18.11-np126py311h8a2294f_7.conda
@@ -5241,7 +5237,6 @@ environments:
       - conda: https://conda.anaconda.org/robostack-humble/osx-arm64/ros-humble-fastrtps-2.6.9-np126py311h38cf310_6.conda
       - conda: https://conda.anaconda.org/robostack-humble/osx-arm64/ros-humble-fastrtps-cmake-module-2.2.2-np126py311h38cf310_6.conda
       - conda: https://conda.anaconda.org/robostack-humble/osx-arm64/ros-humble-foonathan-memory-vendor-1.2.0-np126py311h38cf310_6.conda
-      - conda: https://conda.anaconda.org/robostack-humble/osx-arm64/ros-humble-gazebo-msgs-3.7.0-np126py311h38cf310_6.conda
       - conda: https://conda.anaconda.org/robostack-humble/osx-arm64/ros-humble-generate-parameter-library-0.3.9-np126py311h38cf310_6.conda
       - conda: https://conda.anaconda.org/robostack-humble/osx-arm64/ros-humble-generate-parameter-library-py-0.3.9-np126py311h38cf310_6.conda
       - conda: https://conda.anaconda.org/robostack-humble/osx-arm64/ros-humble-geometric-shapes-2.3.1-np126py311h38cf310_6.conda
@@ -5343,6 +5338,7 @@ environments:
       - conda: https://conda.anaconda.org/robostack-humble/osx-arm64/ros-humble-ros-base-0.10.0-np126py311h38cf310_6.conda
       - conda: https://conda.anaconda.org/robostack-humble/osx-arm64/ros-humble-ros-core-0.10.0-np126py311h38cf310_6.conda
       - conda: https://conda.anaconda.org/robostack-humble/osx-arm64/ros-humble-ros-environment-3.2.2-np126py311h38cf310_6.conda
+      - conda: https://conda.anaconda.org/robostack-humble/osx-arm64/ros-humble-ros-gz-interfaces-0.244.16-np126py311h38cf310_6.conda
       - conda: https://conda.anaconda.org/robostack-humble/osx-arm64/ros-humble-ros-workspace-1.0.2-np126py311h38cf310_9.conda
       - conda: https://conda.anaconda.org/robostack-humble/osx-arm64/ros-humble-ros2-control-test-assets-2.47.0-np126py311h38cf310_6.conda
       - conda: https://conda.anaconda.org/robostack-humble/osx-arm64/ros-humble-ros2action-0.18.11-np126py311h38cf310_6.conda
@@ -5534,19 +5530,19 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/assimp-5.4.3-hf1e84b2_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/asttokens-3.0.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/attrs-25.3.0-pyh71513ae_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-auth-0.8.0-h2219d47_15.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-cal-0.8.1-h099ea23_3.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-common-0.10.6-h2466b09_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-compression-0.3.0-h099ea23_5.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-event-stream-0.5.0-h85d8506_11.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-http-0.9.2-h3888f84_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-io-0.15.3-hc5a9e45_6.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-mqtt-0.11.0-h2c94728_12.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-s3-0.7.7-h6a38c86_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-sdkutils-0.2.1-h099ea23_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-checksums-0.2.2-h099ea23_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-crt-cpp-0.29.7-h0642867_7.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-sdk-cpp-1.11.458-h5f5f9c4_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-auth-0.9.0-h467f71e_16.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-cal-0.9.2-hef2a5b8_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-common-0.12.4-hfd05255_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-compression-0.3.1-ha8a2810_6.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-event-stream-0.5.5-h16d2062_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-http-0.10.2-h909f643_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-io-0.21.0-h20b9e97_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-mqtt-0.13.1-h8a47558_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-s3-0.8.3-hcc9d52c_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-sdkutils-0.2.4-ha8a2810_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-checksums-0.2.7-ha8a2810_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-crt-cpp-0.32.10-h16ee0b7_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-sdk-cpp-1.11.510-h41ea3a3_14.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/azure-core-cpp-1.14.0-haf5610f_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/azure-identity-cpp-1.10.0-hd6deed7_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/azure-storage-blobs-cpp-12.13.0-h3241184_1.conda
@@ -5562,24 +5558,24 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/cached-property-1.5.2-hd8ed1ab_1.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/cached_property-1.5.2-pyha770c72_1.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/win-64/cairo-1.18.4-h5782bbf_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/capnproto-1.0.2-hb5d7e06_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/capnproto-1.2.0-h3a793f1_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/catch2-3.8.0-hc790b64_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/catkin_pkg-1.0.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/ccache-4.11.3-h12b022e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/cffi-1.17.1-py311he736701_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/cfitsio-4.5.0-h2b45a09_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/cfitsio-4.6.2-h023ae6c_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/cli11-2.5.0-he0c23c2_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/cmake-4.0.3-hff78f93_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/collada-dom-2.5.0-h1bf3522_10.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/console_bridge-1.0.2-h5362a0b_1.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/win-64/contourpy-1.3.2-py311h3257749_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/cppcheck-2.17.1-py311h7219fd6_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/cppcheck-2.18.3-py311he12220e_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/cppzmq-4.10.0-h42135b4_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/cryptography-45.0.4-py311hfd75b31_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/cxx-compiler-1.10.0-h1c1089f_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/cycler-0.12.1-pyhd8ed1ab_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/dartsim-cpp-6.15.0-hd3a921c_6.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/dartsim-cpp-6.15.0-h9d64fd1_10.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/dav1d-1.2.1-hcfcfb64_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/decorator-5.2.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/dirent-1.21-0.tar.bz2
@@ -5592,12 +5588,12 @@ environments:
       - conda: https://conda.anaconda.org/robotology/win-64/esdcan-6.3.0-h57928b3_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.3.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/executing-2.2.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/expat-2.7.0-he0c23c2_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/expat-2.7.3-hac47afa_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/fcl-0.7.0-h16792c9_8.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/ffmpeg-7.1.1-gpl_h37769ee_906.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/flake8-7.3.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/flann-1.9.2-h48fefe0_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/fmt-11.0.2-hf4da5c8_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/flann-1.9.2-hb1d4b56_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/fmt-11.2.0-h1d4551f_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-dejavu-sans-mono-2.37-hab24e00_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-inconsolata-3.000-h77eed37_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-source-code-pro-2.038-h77eed37_0.tar.bz2
@@ -5613,21 +5609,20 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/freexl-2.0.0-hf297d47_2.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/fribidi-1.0.10-h8d14728_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/win-64/frozenlist-1.6.0-py311hc121033_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/gazebo-11.15.1-gzcompatnameh4f5da94_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/gazebo-11.15.1-gzcompatnamehcc919ea_4.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/gdk-pixbuf-2.42.12-hed59a49_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/geos-3.13.0-h5a68840_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/geotiff-1.7.4-h887f4e7_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/geos-3.13.1-h9ea8674_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/getopt-win32-0.1-h6a83c73_3.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/gettext-0.22.5-h5728263_3.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/gettext-tools-0.22.5-h5a7288d_3.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/gl2ps-1.4.2-had7236b_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/glew-2.1.0-h39d44d4_2.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/win-64/glfw-3.4-hcfcfb64_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/glib-2.84.1-h3d4babf_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/glib-2.84.3-h36503ca_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/glib-networking-2.80.0-hb149071_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/glib-tools-2.84.1-h4394cf3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/glib-tools-2.84.3-he647baa_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/glm-1.0.1-hb611fcd_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/gmock-1.15.2-h57928b3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/gmock-1.17.0-h57928b3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/graphite2-1.3.14-he0c23c2_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/graphviz-12.2.1-hf40819d_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/gsl-2.8-h5b8d9c4_1.conda
@@ -5635,18 +5630,18 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/gst-plugins-base-1.24.11-h3fe0a9e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/gst-plugins-good-1.24.11-hc7689c0_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/gstreamer-1.24.11-h233a61a_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/gtest-1.15.2-hc790b64_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/gtest-1.17.0-hc790b64_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/gts-0.7.6-h6b5321d_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/gz-sim9-9.0.0-h1ea47a8_3.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/gz-sim9-python-9.0.0-py311h517b7c6_3.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/h5py-3.13.0-nompi_py311h67016bb_100.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/harfbuzz-11.2.1-h8796e6f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/gz-sim9-9.0.0-h1ea47a8_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/gz-sim9-python-9.0.0-py311h092c819_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/h5py-3.15.1-nompi_py311hc40ba4b_101.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/harfbuzz-11.4.5-h5f2951f_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/hdf4-4.2.15-h5557f11_7.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/hdf5-1.14.3-nompi_hb2c4d47_109.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/hdf5-1.14.6-nompi_he30205f_103.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/icu-75.1-he0c23c2_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/idna-3.10-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/imath-3.1.12-hbb528cf_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/imgui-1.91.9-hecf2515_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/imgui-1.92.0-he134b7a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-8.7.0-pyhe01879c_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/importlib_resources-6.5.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/iniconfig-2.0.0-pyhd8ed1ab_1.conda
@@ -5660,7 +5655,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.6-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/jsoncpp-1.9.6-hda1637e_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/jxrlib-1.1-hcfcfb64_3.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/kealib-1.6.1-hadd4d7f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/kealib-1.6.2-h5949fbd_2.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/khronos-opencl-icd-loader-2024.10.24-h2466b09_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/kiwisolver-1.4.7-py311h3257749_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/krb5-1.21.3-hdf4eb48_0.conda
@@ -5668,9 +5663,9 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/lark-parser-0.12.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/lcms2-2.17-hbcf6048_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/lerc-4.0.0-h6470a55_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libabseil-20240722.0-cxx17_h4eb7d71_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libabseil-20250127.1-cxx17_h4eb7d71_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libaec-1.1.4-h20038f6_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libarchive-3.7.7-h5343c79_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libarchive-3.8.1-gpl_h1ca5a36_100.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libasprintf-0.22.5-h5728263_3.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libasprintf-devel-0.22.5-h5728263_3.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libavif16-1.3.0-hf2698fe_0.conda
@@ -5685,120 +5680,122 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/libbrotlienc-1.1.0-h2466b09_3.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libcblas-3.9.0-8_mkl.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/win-64/libccd-double-2.1-h63175ca_3.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libclang13-20.1.7-default_h6e92b77_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libclang13-21.1.8-default_ha2db4b5_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libcrc32c-1.1.2-h0e60522_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/win-64/libcurl-8.14.1-h88aaa65_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libde265-1.0.15-h91493d7_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libdeflate-1.23-h76ddb4d_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libexpat-2.7.0-he0c23c2_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libdeflate-1.24-h76ddb4d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libexpat-2.7.3-hac47afa_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libffi-3.4.6-h537db12_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libflac-1.4.3-h63175ca_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libfreetype-2.13.3-h57928b3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libfreetype6-2.13.3-h0b5ce68_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libgcc-15.1.0-h1383e82_3.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libgd-2.3.3-h7208af6_11.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-3.10.2-hc25ceda_5.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-core-3.10.2-h095903c_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-fits-3.10.2-h20f9414_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-grib-3.10.2-h9921521_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-hdf4-3.10.2-hf9aff8f_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-hdf5-3.10.2-h7df419c_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-jp2openjpeg-3.10.2-h768cd86_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-kea-3.10.2-hfc54ade_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-netcdf-3.10.2-h3717446_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-pdf-3.10.2-h33ae9eb_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-pg-3.10.2-h5e54256_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-postgisraster-3.10.2-h5e54256_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-tiledb-3.10.2-h8d6a7ae_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-xls-3.10.2-hd0c044b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-3.11.3-hafd5c6c_6.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-core-3.11.3-hddc0a0b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-fits-3.11.3-hcff14e6_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-grib-3.11.3-h8ff101f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-hdf4-3.11.3-ha47b6c4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-hdf5-3.11.3-h0f01001_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-jp2openjpeg-3.11.3-hf58e487_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-kea-3.11.3-hea5172e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-netcdf-3.11.3-hcb0e93c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-pdf-3.11.3-h75c24f8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-pg-3.11.3-h103a44d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-postgisraster-3.11.3-h103a44d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-tiledb-3.11.3-h88e1fbc_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-xls-3.11.3-h93cc17c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libgettextpo-0.22.5-h5728263_3.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libgettextpo-devel-0.22.5-h5728263_3.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libglib-2.84.1-h7025463_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libglib-2.84.3-h1c1036b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libgomp-15.1.0-h1383e82_3.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libgoogle-cloud-2.32.0-h07d40e7_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libgoogle-cloud-storage-2.32.0-he5eb982_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libgrpc-1.67.1-h7aa3b8a_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libgz-cmake3-3.5.3-he0c23c2_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgoogle-cloud-2.36.0-hf249c01_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgoogle-cloud-storage-2.36.0-he5eb982_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgrpc-1.71.0-h8c3449c_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgz-cmake3-3.5.5-h5112557_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libgz-cmake4-4.2.0-he0c23c2_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libgz-common6-6.0.1-hf79d240_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libgz-fuel-tools10-10.0.0-h2cc4d93_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libgz-gui9-9.0.0-h254a4ba_6.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libgz-math8-8.1.0-he0c23c2_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libgz-msgs11-11.0.1-hdde3068_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libgz-physics8-8.1.0-hde7d378_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libgz-plugin3-3.0.0-he0c23c2_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libgz-rendering9-9.0.0-he0c23c2_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libgz-sensors9-9.0.0-h395346c_6.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libgz-sim9-9.0.0-h8fb2a06_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgz-common6-6.1.0-h7e7f190_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgz-fuel-tools10-10.1.0-h55227be_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgz-gui9-9.0.1-h9b04ecd_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgz-math8-8.2.0-h7661bb3_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgz-msgs11-11.1.0-h30b9592_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgz-physics8-8.3.0-ha69dbe0_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgz-plugin3-3.1.0-h5112557_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgz-rendering9-9.4.0-h5112557_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgz-sensors9-9.1.0-h574b0c1_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgz-sim9-9.0.0-ha248be3_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgz-tools-2.0.3-hb268c4e_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libgz-tools2-2.0.1-h9fbcf1e_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libgz-transport14-14.0.0-h0369456_3.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libgz-utils2-2.2.0-he0c23c2_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libgz-utils3-3.1.0-hb990982_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libheif-1.19.7-gpl_h2684147_100.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgz-transport14-14.1.0-py313h7b44034_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgz-utils2-2.2.1-h5112557_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgz-utils3-3.1.1-h3ca27b7_2.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libhiredis-1.0.2-h0e60522_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/win-64/libhwloc-2.11.2-default_ha69328c_1001.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libhwy-1.3.0-ha71e874_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libiconv-1.18-h135ad9c_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libignition-cmake2-2.17.2-he0c23c2_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libignition-common3-3.15.1-h3fb02f2_5.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libignition-fuel-tools4-4.6.0-h78cb115_12.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libignition-math6-6.15.1-py311h1e2dbc3_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libignition-msgs5-5.11.0-hddf5caf_11.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libignition-common3-3.17.1-hd7a2a08_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libignition-fuel-tools4-4.6.0-h7dbd45c_15.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libignition-math6-6.15.1-py311hffe65ed_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libignition-msgs5-5.11.0-h16a6c16_14.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libignition-tools1-1.5.0-hf5993cb_3.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libignition-transport8-8.4.0-h6173c75_13.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libignition-transport8-8.4.0-h7824680_15.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libintl-0.22.5-h5728263_3.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libintl-devel-0.22.5-h5728263_3.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libjpeg-turbo-3.1.0-h2466b09_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libjxl-0.11.1-hb7713f0_4.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libkml-1.3.0-h538826c_1021.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/liblapack-3.9.0-8_mkl.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/win-64/liblapacke-3.9.0-8_mkl.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/win-64/liblzma-5.8.1-h2466b09_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libmatio-1.5.28-he9c0ad6_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libnetcdf-4.9.2-nompi_h008f77d_116.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/liblzma-devel-5.8.1-h2466b09_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libmatio-1.5.30-hbeb426f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libnetcdf-4.9.2-nompi_ha45073a_118.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libnghttp2-1.64.0-he0c23c2_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libode-0.16.5-hef77347_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libogg-1.3.5-h2466b09_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libopenblas-0.3.30-openmp_h96ad2b0_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libopencv-4.10.0-qt6_py311h375890f_613.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libopenvino-2024.5.0-hfe1841e_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libopenvino-auto-batch-plugin-2024.5.0-h04f32e0_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libopenvino-auto-plugin-2024.5.0-h04f32e0_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libopenvino-hetero-plugin-2024.5.0-h372dad0_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libopenvino-intel-cpu-plugin-2024.5.0-hfe1841e_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libopenvino-intel-gpu-plugin-2024.5.0-hfe1841e_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libopenvino-ir-frontend-2024.5.0-h372dad0_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libopenvino-onnx-frontend-2024.5.0-h7d5e7ba_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libopenvino-paddle-frontend-2024.5.0-h7d5e7ba_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libopenvino-pytorch-frontend-2024.5.0-he0c23c2_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libopenvino-tensorflow-frontend-2024.5.0-h7d689a8_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libopenvino-tensorflow-lite-frontend-2024.5.0-he0c23c2_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libopencv-4.12.0-qt6_py311hf39e5f2_600.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libopenvino-2025.0.0-hb1d9b14_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libopenvino-auto-batch-plugin-2025.0.0-h04f32e0_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libopenvino-auto-plugin-2025.0.0-h04f32e0_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libopenvino-hetero-plugin-2025.0.0-hb61b842_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libopenvino-intel-cpu-plugin-2025.0.0-hb1d9b14_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libopenvino-intel-gpu-plugin-2025.0.0-hb1d9b14_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libopenvino-ir-frontend-2025.0.0-hb61b842_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libopenvino-onnx-frontend-2025.0.0-hf9c6bd6_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libopenvino-paddle-frontend-2025.0.0-hf9c6bd6_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libopenvino-pytorch-frontend-2025.0.0-he0c23c2_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libopenvino-tensorflow-frontend-2025.0.0-hd51e7bd_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libopenvino-tensorflow-lite-frontend-2025.0.0-he0c23c2_3.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libopus-1.5.2-h2466b09_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libpng-1.6.49-h7a4582a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libpng-1.6.53-h7351971_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libpq-17.5-h9087029_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libprotobuf-5.28.2-hcaed137_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libprotobuf-5.29.3-hd33f5f0_3.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libpsl-0.21.5-h33682d5_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libraw-0.21.4-h866491b_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libre2-11-2024.07.02-h4eb7d71_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libre2-11-2025.06.26-habfad5f_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/librsvg-2.58.4-h5ce5fed_3.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/librttopo-1.1.0-hd4c2148_17.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/librttopo-1.1.0-hbfc9ebc_18.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libsdformat-9.8.0-h9776664_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libsdformat15-15.1.1-hf143461_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libsdformat15-15.3.0-py314h3ff8ef8_3.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libsndfile-1.2.2-h81429f1_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libsodium-1.0.20-hc70643c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libsoup-3.4.4-hde36b1d_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libspatialite-5.1.0-h939089a_12.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libsqlite-3.50.2-hf5d6505_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libspatialite-5.1.0-h378fb81_14.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libsqlite-3.51.2-hf5d6505_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libssh2-1.11.1-h9aa295b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libtheora-1.1.1-hc70643c_1006.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libtiff-4.7.0-h797046b_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libtiff-4.7.1-h550210a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libusb-1.0.29-h1839187_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libuv-1.51.0-h2466b09_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libvorbis-1.3.7-h0e60522_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libwebp-1.5.0-h3b0e114_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libwebp-base-1.5.0-h3b0e114_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libwebp-1.6.0-h4d5522a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libwebp-base-1.6.0-h4d5522a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libwinpthread-12.0.0.r4.gg4f2fc60ca-h57928b3_9.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libxcb-1.17.0-h0e4246c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libxml2-2.13.8-h442d1da_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libxslt-1.1.39-h3df6e99_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libxslt-1.1.43-h25c3957_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libzip-1.11.2-h3135430_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libzlib-1.3.1-h2466b09_2.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/llvm-openmp-20.1.7-h30eaf37_0.conda
@@ -5820,33 +5817,34 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/multidict-6.6.0-py311h3f79411_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/mumps-seq-5.7.3-hbaa6519_10.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/munkres-1.1.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/muparser-2.3.5-he0c23c2_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/netifaces-0.11.0-py311he736701_3.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/ninja-1.13.0-h79cd779_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/nlohmann_json-3.12.0-he0c23c2_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/nlopt-2.10.0-py311h996f8db_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/numpy-1.26.4-py311h0b4df5a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/octomap-1.10.0-hc790b64_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/ogre-1.10.12.1-h58a323e_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/ogre-1.10.12.1-h4fc3f74_7.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/ogre-next-2.3.3-hb2de451_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/ompl-1.6.0-py311h8ee540d_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/ompl-1.7.0-py311h24c37c6_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/onnxruntime-cpp-1.22.0-h50ebc8d_0_cpu.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/openal-soft-1.23.1-h91493d7_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/openal-soft-1.24.3-h79cd779_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/openblas-0.3.30-openmp_h07df79e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/opencl-headers-2025.06.13-he0c23c2_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/opencv-4.10.0-qt6_py311h4ed4151_613.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/openexr-3.3.3-h1acc403_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/opencv-4.12.0-qt6_py311h50c7551_600.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/openexr-3.3.5-h4750f91_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/openh264-2.6.0-hb17fa0b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/openjpeg-2.5.3-h4d64b90_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/openscenegraph-3.6.5-hf7c1acd_20.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/openssl-3.5.0-ha4e3fda_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/openssl-3.6.0-h725018a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/orocos-kdl-1.5.1-he0c23c2_8.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-25.0-pyh29332c3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/pagmo-2.19.1-h4b96e25_6.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/pango-1.56.3-h0c53d3b_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/parso-0.8.4-pyhd8ed1ab_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/pcl-1.14.1-hcec6b29_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pcl-1.15.0-hd388526_2.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/pcre-8.45-h0e60522_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/win-64/pcre2-10.44-h99c9b8b_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pcre2-10.45-h99c9b8b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pickleshare-0.7.5-pyhd8ed1ab_1004.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/pillow-11.2.1-py311h43e43bb_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pip-25.1.1-pyh8b19718_0.conda
@@ -5858,17 +5856,17 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/poppler-data-0.4.12-hd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/portaudio-19.7.0-he0c23c2_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/postgresql-17.5-h176b716_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/proj-9.5.1-h4f671f6_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/proj-9.6.2-h7990399_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.51-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/propcache-0.3.1-py311h5082efb_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/psutil-7.0.0-py311he736701_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/pthread-stubs-0.4-h0e40799_1002.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/pugixml-1.14-h63175ca_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pugixml-1.15-h372dad0_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pure_eval-0.2.3-pyhd8ed1ab_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/py-opencv-4.10.0-qt6_py311h955f2ee_613.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pybind11-2.13.6-pyhc790b64_3.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pybind11-abi-4-hd8ed1ab_3.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pybind11-global-2.13.6-pyh6a1d191_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/py-opencv-4.12.0-qt6_py311h336b8d4_600.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pybind11-3.0.1-pyh7a1b43c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pybind11-abi-11-hc364b38_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pybind11-global-3.0.1-pyh5e4992e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/pybullet-3.25-py311h42043a9_4.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pycodestyle-2.14.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyh29332c3_1.conda
@@ -5881,290 +5879,296 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/pyqtgraph-0.13.7-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/pyqtwebengine-5.15.11-py311hd90e686_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/pyside2-5.15.15-py311h4238720_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/pyside6-6.8.3-py311h4238720_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pyside6-6.9.2-py311h5d1a980_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-8.4.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/python-3.11.13-h3f84c4b_0_cpython.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0.post0-pyhe01879c_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/python-orocos-kdl-1.5.3-py311h3e6a449_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.11-7_cp311.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/pyyaml-6.0.2-py311h5082efb_2.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/pyzmq-27.0.0-py311h484c95c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/qhull-2020.2-hc790b64_5.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/qt-main-5.15.15-h9151539_4.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/qt-webengine-5.15.15-h087ee03_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/qt6-main-6.8.3-h72a539a_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/qt6-main-6.9.2-h236c7cd_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/qtpy-2.4.3-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/qwt-6.3.0-h9417a65_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/rav1e-0.7.1-ha073cba_3.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/re2-2024.07.02-haf4117d_2.conda
-      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-action-msgs-1.2.1-np126py311h7d8ee0e_8.conda
-      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-actionlib-msgs-4.2.4-np126py311h7d8ee0e_8.conda
-      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-ament-cmake-1.3.11-np126py311h7d8ee0e_8.conda
-      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-ament-cmake-auto-1.3.11-np126py311h7d8ee0e_8.conda
-      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-ament-cmake-copyright-0.12.11-np126py311h7d8ee0e_8.conda
-      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-ament-cmake-core-1.3.11-np126py311h7d8ee0e_8.conda
-      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-ament-cmake-cppcheck-0.12.11-np126py311h7d8ee0e_8.conda
-      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-ament-cmake-cpplint-0.12.11-np126py311h7d8ee0e_8.conda
-      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-ament-cmake-export-definitions-1.3.11-np126py311h7d8ee0e_8.conda
-      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-ament-cmake-export-dependencies-1.3.11-np126py311h7d8ee0e_8.conda
-      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-ament-cmake-export-include-directories-1.3.11-np126py311h7d8ee0e_8.conda
-      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-ament-cmake-export-interfaces-1.3.11-np126py311h7d8ee0e_8.conda
-      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-ament-cmake-export-libraries-1.3.11-np126py311h7d8ee0e_8.conda
-      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-ament-cmake-export-link-flags-1.3.11-np126py311h7d8ee0e_8.conda
-      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-ament-cmake-export-targets-1.3.11-np126py311h7d8ee0e_8.conda
-      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-ament-cmake-flake8-0.12.11-np126py311h7d8ee0e_8.conda
-      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-ament-cmake-gen-version-h-1.3.11-np126py311h7d8ee0e_8.conda
-      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-ament-cmake-gmock-1.3.11-np126py311h7d8ee0e_8.conda
-      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-ament-cmake-gtest-1.3.11-np126py311h7d8ee0e_8.conda
-      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-ament-cmake-include-directories-1.3.11-np126py311h7d8ee0e_8.conda
-      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-ament-cmake-libraries-1.3.11-np126py311h7d8ee0e_8.conda
-      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-ament-cmake-lint-cmake-0.12.11-np126py311h7d8ee0e_8.conda
-      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-ament-cmake-pep257-0.12.11-np126py311h7d8ee0e_8.conda
-      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-ament-cmake-pytest-1.3.11-np126py311h7d8ee0e_8.conda
-      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-ament-cmake-python-1.3.11-np126py311h7d8ee0e_8.conda
-      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-ament-cmake-ros-0.10.0-np126py311h7d8ee0e_8.conda
-      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-ament-cmake-target-dependencies-1.3.11-np126py311h7d8ee0e_8.conda
-      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-ament-cmake-test-1.3.11-np126py311h7d8ee0e_8.conda
-      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-ament-cmake-uncrustify-0.12.11-np126py311h7d8ee0e_8.conda
-      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-ament-cmake-version-1.3.11-np126py311h7d8ee0e_8.conda
-      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-ament-cmake-xmllint-0.12.11-np126py311h7d8ee0e_8.conda
-      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-ament-copyright-0.12.11-np126py311h7d8ee0e_8.conda
-      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-ament-cppcheck-0.12.11-np126py311h7d8ee0e_8.conda
-      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-ament-cpplint-0.12.11-np126py311h7d8ee0e_8.conda
-      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-ament-flake8-0.12.11-np126py311h7d8ee0e_8.conda
-      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-ament-index-cpp-1.4.0-np126py311h7d8ee0e_8.conda
-      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-ament-index-python-1.4.0-np126py311h7d8ee0e_8.conda
-      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-ament-lint-0.12.11-np126py311h7d8ee0e_8.conda
-      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-ament-lint-auto-0.12.11-np126py311h7d8ee0e_8.conda
-      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-ament-lint-cmake-0.12.11-np126py311h7d8ee0e_8.conda
-      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-ament-lint-common-0.12.11-np126py311h7d8ee0e_8.conda
-      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-ament-package-0.14.0-np126py311h7d8ee0e_8.conda
-      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-ament-pep257-0.12.11-np126py311h7d8ee0e_8.conda
-      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-ament-uncrustify-0.12.11-np126py311h7d8ee0e_8.conda
-      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-ament-xmllint-0.12.11-np126py311h7d8ee0e_8.conda
-      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-angles-1.15.0-np126py311h7d8ee0e_8.conda
-      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-backward-ros-1.0.6-np126py311h7d8ee0e_8.conda
-      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-builtin-interfaces-1.2.1-np126py311h7d8ee0e_8.conda
-      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-class-loader-2.2.0-np126py311h7d8ee0e_8.conda
-      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-common-interfaces-4.2.4-np126py311h7d8ee0e_8.conda
-      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-composition-interfaces-1.2.1-np126py311h7d8ee0e_8.conda
-      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-console-bridge-vendor-1.4.1-np126py311h7d8ee0e_8.conda
-      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-control-msgs-4.7.0-np126py311h7d8ee0e_8.conda
-      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-controller-interface-2.47.0-np126py311h7d8ee0e_8.conda
-      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-controller-manager-2.47.0-np126py311h7d8ee0e_8.conda
-      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-controller-manager-msgs-2.47.0-np126py311h7d8ee0e_8.conda
-      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-cyclonedds-0.10.5-np126py311h7d8ee0e_8.conda
-      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-diagnostic-msgs-4.2.4-np126py311h7d8ee0e_8.conda
-      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-domain-coordinator-0.10.0-np126py311h7d8ee0e_8.conda
-      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-eigen-stl-containers-1.0.0-np126py311h7d8ee0e_8.conda
-      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-eigen3-cmake-module-0.1.1-np126py311h7d8ee0e_8.conda
-      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-fastcdr-1.0.24-np126py311h7d8ee0e_8.conda
-      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-fastrtps-2.6.9-np126py311h7d8ee0e_8.conda
-      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-fastrtps-cmake-module-2.2.2-np126py311h7d8ee0e_8.conda
-      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-foonathan-memory-vendor-1.2.0-np126py311h7d8ee0e_8.conda
-      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-gazebo-msgs-3.7.0-np126py311h7d8ee0e_8.conda
-      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-generate-parameter-library-0.3.9-np126py311h7d8ee0e_8.conda
-      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-generate-parameter-library-py-0.3.9-np126py311h7d8ee0e_8.conda
-      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-geometric-shapes-2.3.1-np126py311h7d8ee0e_8.conda
-      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-geometry-msgs-4.2.4-np126py311h7d8ee0e_8.conda
-      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-geometry2-0.25.10-np126py311h7d8ee0e_8.conda
-      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-gmock-vendor-1.10.9006-np126py311h7d8ee0e_8.conda
-      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-graph-msgs-0.2.0-np126py311h7d8ee0e_8.conda
-      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-gtest-vendor-1.10.9006-np126py311h7d8ee0e_8.conda
-      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-hardware-interface-2.47.0-np126py311h7d8ee0e_8.conda
-      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-iceoryx-binding-c-2.0.5-np126py311h7d8ee0e_8.conda
-      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-iceoryx-hoofs-2.0.5-np126py311h7d8ee0e_8.conda
-      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-iceoryx-posh-2.0.5-np126py311h7d8ee0e_8.conda
-      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-ignition-cmake2-vendor-0.0.2-np126py311h7d8ee0e_8.conda
-      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-ignition-math6-vendor-0.0.2-np126py311h7d8ee0e_8.conda
-      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-image-transport-3.1.10-np126py311h7d8ee0e_8.conda
-      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-interactive-markers-2.3.2-np126py311h7d8ee0e_8.conda
-      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-kdl-parser-2.6.4-np126py311h7d8ee0e_8.conda
-      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-keyboard-handler-0.0.5-np126py311h7d8ee0e_8.conda
-      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-laser-geometry-2.4.0-np126py311h7d8ee0e_8.conda
-      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-launch-1.0.7-np126py311h7d8ee0e_8.conda
-      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-launch-param-builder-0.1.1-np126py311h7d8ee0e_8.conda
-      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-launch-ros-0.19.8-np126py311h7d8ee0e_8.conda
-      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-launch-testing-1.0.7-np126py311h7d8ee0e_8.conda
-      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-launch-testing-ament-cmake-1.0.7-np126py311h7d8ee0e_8.conda
-      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-launch-testing-ros-0.19.8-np126py311h7d8ee0e_8.conda
-      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-launch-xml-1.0.7-np126py311h7d8ee0e_8.conda
-      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-launch-yaml-1.0.7-np126py311h7d8ee0e_8.conda
-      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-libcurl-vendor-3.1.2-np126py311h7d8ee0e_8.conda
-      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-libstatistics-collector-1.3.4-np126py311h7d8ee0e_8.conda
-      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-libyaml-vendor-1.2.2-np126py311h7d8ee0e_8.conda
-      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-lifecycle-msgs-1.2.1-np126py311h7d8ee0e_8.conda
-      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-map-msgs-2.1.0-np126py311h7d8ee0e_8.conda
-      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-message-filters-4.3.5-np126py311h7d8ee0e_8.conda
-      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-moveit-2.5.7-np126py311h7d8ee0e_8.conda
-      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-moveit-common-2.5.7-np126py311h7d8ee0e_8.conda
-      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-moveit-configs-utils-2.5.7-np126py311h7d8ee0e_8.conda
-      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-moveit-core-2.5.7-np126py311h7d8ee0e_8.conda
-      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-moveit-kinematics-2.5.7-np126py311h7d8ee0e_8.conda
-      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-moveit-msgs-2.2.1-np126py311h7d8ee0e_8.conda
-      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-moveit-planners-2.5.7-np126py311h7d8ee0e_8.conda
-      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-moveit-planners-ompl-2.5.7-np126py311h7d8ee0e_8.conda
-      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-moveit-plugins-2.5.7-np126py311h7d8ee0e_8.conda
-      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-moveit-ros-2.5.7-np126py311h7d8ee0e_8.conda
-      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-moveit-ros-benchmarks-2.5.7-np126py311h7d8ee0e_8.conda
-      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-moveit-ros-move-group-2.5.7-np126py311h7d8ee0e_8.conda
-      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-moveit-ros-occupancy-map-monitor-2.5.7-np126py311h7d8ee0e_8.conda
-      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-moveit-ros-planning-2.5.7-np126py311h7d8ee0e_8.conda
-      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-moveit-ros-planning-interface-2.5.7-np126py311h7d8ee0e_8.conda
-      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-moveit-ros-robot-interaction-2.5.7-np126py311h7d8ee0e_8.conda
-      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-moveit-ros-visualization-2.5.7-np126py311h7d8ee0e_8.conda
-      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-moveit-ros-warehouse-2.5.7-np126py311h7d8ee0e_8.conda
-      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-moveit-setup-app-plugins-2.5.7-np126py311h7d8ee0e_8.conda
-      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-moveit-setup-assistant-2.5.7-np126py311h7d8ee0e_8.conda
-      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-moveit-setup-controllers-2.5.7-np126py311h7d8ee0e_8.conda
-      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-moveit-setup-core-plugins-2.5.7-np126py311h7d8ee0e_8.conda
-      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-moveit-setup-framework-2.5.7-np126py311h7d8ee0e_8.conda
-      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-moveit-setup-srdf-plugins-2.5.7-np126py311h7d8ee0e_8.conda
-      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-moveit-simple-controller-manager-2.5.7-np126py311h7d8ee0e_8.conda
-      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-moveit-visual-tools-4.1.1-np126py311h7d8ee0e_8.conda
-      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-nav-msgs-4.2.4-np126py311h7d8ee0e_8.conda
-      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-object-recognition-msgs-2.0.0-np126py311h7d8ee0e_8.conda
-      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-octomap-msgs-2.0.1-np126py311h7d8ee0e_8.conda
-      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-ompl-1.6.0-np126py311h7d8ee0e_8.conda
-      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-orocos-kdl-vendor-0.2.5-np126py311h7d8ee0e_8.conda
-      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-osrf-pycommon-2.1.4-np126py311h7d8ee0e_8.conda
-      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-parameter-traits-0.3.9-np126py311h7d8ee0e_8.conda
-      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-pluginlib-5.1.0-np126py311h7d8ee0e_8.conda
-      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-pybind11-vendor-2.4.2-np126py311h7d8ee0e_8.conda
-      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-python-cmake-module-0.10.0-np126py311h7d8ee0e_8.conda
-      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-random-numbers-2.0.1-np126py311h7d8ee0e_8.conda
-      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-rcl-5.3.9-np126py311h7d8ee0e_8.conda
-      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-rcl-action-5.3.9-np126py311h7d8ee0e_8.conda
-      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-rcl-interfaces-1.2.1-np126py311h7d8ee0e_8.conda
-      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-rcl-lifecycle-5.3.9-np126py311h7d8ee0e_8.conda
-      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-rcl-logging-interface-2.3.1-np126py311h7d8ee0e_8.conda
-      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-rcl-logging-spdlog-2.3.1-np126py311h1c95eb5_8.conda
-      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-rcl-yaml-param-parser-5.3.9-np126py311h7d8ee0e_8.conda
-      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-rclcpp-16.0.11-np126py311h7d8ee0e_8.conda
-      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-rclcpp-action-16.0.11-np126py311h7d8ee0e_8.conda
-      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-rclcpp-components-16.0.11-np126py311h7d8ee0e_8.conda
-      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-rclcpp-lifecycle-16.0.11-np126py311h7d8ee0e_8.conda
-      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-rclpy-3.3.15-np126py311h7d8ee0e_8.conda
-      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-rcpputils-2.4.4-np126py311h7d8ee0e_8.conda
-      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-rcutils-5.1.6-np126py311h7d8ee0e_8.conda
-      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-realtime-tools-2.10.0-np126py311h7d8ee0e_8.conda
-      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-resource-retriever-3.1.2-np126py311h7d8ee0e_8.conda
-      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-rmw-6.1.2-np126py311h7d8ee0e_8.conda
-      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-rmw-connextdds-0.11.3-np126py311h7d8ee0e_8.conda
-      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-rmw-connextdds-common-0.11.3-np126py311h7d8ee0e_8.conda
-      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-rmw-cyclonedds-cpp-1.3.4-np126py311h7d8ee0e_8.conda
-      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-rmw-dds-common-1.6.0-np126py311h7d8ee0e_8.conda
-      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-rmw-fastrtps-cpp-6.2.7-np126py311h7d8ee0e_8.conda
-      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-rmw-fastrtps-dynamic-cpp-6.2.7-np126py311h7d8ee0e_8.conda
-      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-rmw-fastrtps-shared-cpp-6.2.7-np126py311h7d8ee0e_8.conda
-      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-rmw-implementation-2.8.4-np126py311h7d8ee0e_8.conda
-      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-rmw-implementation-cmake-6.1.2-np126py311h7d8ee0e_8.conda
-      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-robot-state-publisher-3.0.3-np126py311h7d8ee0e_8.conda
-      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-ros-base-0.10.0-np126py311h7d8ee0e_8.conda
-      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-ros-core-0.10.0-np126py311h7d8ee0e_8.conda
-      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-ros-environment-3.2.2-np126py311h7d8ee0e_8.conda
-      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-ros-workspace-1.0.2-np126py311h7d8ee0e_9.conda
-      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-ros2-control-test-assets-2.47.0-np126py311h7d8ee0e_8.conda
-      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-ros2action-0.18.11-np126py311h7d8ee0e_8.conda
-      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-ros2bag-0.15.13-np126py311h7d8ee0e_8.conda
-      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-ros2cli-0.18.11-np126py311h7d8ee0e_9.conda
-      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-ros2cli-common-extensions-0.1.1-np126py311h7d8ee0e_8.conda
-      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-ros2component-0.18.11-np126py311h7d8ee0e_8.conda
-      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-ros2doctor-0.18.11-np126py311h7d8ee0e_8.conda
-      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-ros2interface-0.18.11-np126py311h7d8ee0e_8.conda
-      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-ros2launch-0.19.8-np126py311h7d8ee0e_8.conda
-      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-ros2lifecycle-0.18.11-np126py311h7d8ee0e_8.conda
-      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-ros2multicast-0.18.11-np126py311h7d8ee0e_8.conda
-      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-ros2node-0.18.11-np126py311h7d8ee0e_8.conda
-      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-ros2param-0.18.11-np126py311h7d8ee0e_8.conda
-      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-ros2pkg-0.18.11-np126py311h7d8ee0e_8.conda
-      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-ros2run-0.18.11-np126py311h7d8ee0e_8.conda
-      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-ros2service-0.18.11-np126py311h7d8ee0e_8.conda
-      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-ros2topic-0.18.11-np126py311h7d8ee0e_8.conda
-      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-rosbag2-0.15.13-np126py311h7d8ee0e_8.conda
-      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-rosbag2-compression-0.15.13-np126py311h7d8ee0e_8.conda
-      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-rosbag2-compression-zstd-0.15.13-np126py311h7d8ee0e_8.conda
-      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-rosbag2-cpp-0.15.13-np126py311h7d8ee0e_8.conda
-      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-rosbag2-interfaces-0.15.13-np126py311h7d8ee0e_8.conda
-      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-rosbag2-py-0.15.13-np126py311h7d8ee0e_8.conda
-      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-rosbag2-storage-0.15.13-np126py311h7d8ee0e_8.conda
-      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-rosbag2-storage-default-plugins-0.15.13-np126py311h7d8ee0e_8.conda
-      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-rosbag2-transport-0.15.13-np126py311h7d8ee0e_8.conda
-      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-rosgraph-msgs-1.2.1-np126py311h7d8ee0e_8.conda
-      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-rosidl-adapter-3.1.6-np126py311h7d8ee0e_8.conda
-      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-rosidl-cli-3.1.6-np126py311h7d8ee0e_9.conda
-      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-rosidl-cmake-3.1.6-np126py311h7d8ee0e_8.conda
-      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-rosidl-default-generators-1.2.0-np126py311h7d8ee0e_8.conda
-      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-rosidl-default-runtime-1.2.0-np126py311h7d8ee0e_8.conda
-      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-rosidl-generator-c-3.1.6-np126py311h7d8ee0e_8.conda
-      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-rosidl-generator-cpp-3.1.6-np126py311h7d8ee0e_8.conda
-      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-rosidl-generator-py-0.14.4-np126py311h7d8ee0e_8.conda
-      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-rosidl-parser-3.1.6-np126py311h7d8ee0e_8.conda
-      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-rosidl-runtime-c-3.1.6-np126py311h7d8ee0e_8.conda
-      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-rosidl-runtime-cpp-3.1.6-np126py311h7d8ee0e_8.conda
-      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-rosidl-runtime-py-0.9.3-np126py311h7d8ee0e_8.conda
-      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-rosidl-typesupport-c-2.0.2-np126py311h7d8ee0e_8.conda
-      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-rosidl-typesupport-cpp-2.0.2-np126py311h7d8ee0e_8.conda
-      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-rosidl-typesupport-fastrtps-c-2.2.2-np126py311h7d8ee0e_8.conda
-      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-rosidl-typesupport-fastrtps-cpp-2.2.2-np126py311h7d8ee0e_8.conda
-      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-rosidl-typesupport-interface-3.1.6-np126py311h7d8ee0e_8.conda
-      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-rosidl-typesupport-introspection-c-3.1.6-np126py311h7d8ee0e_8.conda
-      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-rosidl-typesupport-introspection-cpp-3.1.6-np126py311h7d8ee0e_8.conda
-      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-rpyutils-0.2.1-np126py311h7d8ee0e_8.conda
-      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-rsl-1.1.0-np126py311h7d8ee0e_8.conda
-      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-rti-connext-dds-cmake-module-0.11.3-np126py311h7d8ee0e_8.conda
-      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-ruckig-0.9.2-np126py311h7d8ee0e_8.conda
-      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-rviz-assimp-vendor-11.2.15-np126py311h7d8ee0e_8.conda
-      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-rviz-common-11.2.15-np126py311h7d8ee0e_8.conda
-      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-rviz-default-plugins-11.2.15-np126py311h7d8ee0e_8.conda
-      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-rviz-ogre-vendor-11.2.15-np126py311h7d8ee0e_8.conda
-      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-rviz-rendering-11.2.15-np126py311h7d8ee0e_8.conda
-      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-rviz-visual-tools-4.1.4-np126py311h7d8ee0e_8.conda
-      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-rviz2-11.2.15-np126py311h7d8ee0e_8.conda
-      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-sensor-msgs-4.2.4-np126py311h7d8ee0e_8.conda
-      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-sensor-msgs-py-4.2.4-np126py311h7d8ee0e_8.conda
-      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-shape-msgs-4.2.4-np126py311h7d8ee0e_8.conda
-      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-shared-queues-vendor-0.15.13-np126py311h7d8ee0e_8.conda
-      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-spdlog-vendor-1.3.1-np126py311h1c95eb5_8.conda
-      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-sqlite3-vendor-0.15.13-np126py311h7d8ee0e_8.conda
-      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-srdfdom-2.0.5-np126py311h7d8ee0e_8.conda
-      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-sros2-0.10.5-np126py311h7d8ee0e_8.conda
-      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-sros2-cmake-0.10.5-np126py311h7d8ee0e_8.conda
-      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-statistics-msgs-1.2.1-np126py311h7d8ee0e_8.conda
-      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-std-msgs-4.2.4-np126py311h7d8ee0e_8.conda
-      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-std-srvs-4.2.4-np126py311h7d8ee0e_8.conda
-      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-stereo-msgs-4.2.4-np126py311h7d8ee0e_8.conda
-      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-tcb-span-1.0.2-np126py311h7d8ee0e_8.conda
-      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-test-msgs-1.2.1-np126py311h7d8ee0e_8.conda
-      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-tf2-0.25.10-np126py311h7d8ee0e_8.conda
-      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-tf2-bullet-0.25.10-np126py311h7d8ee0e_8.conda
-      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-tf2-eigen-0.25.10-np126py311h7d8ee0e_8.conda
-      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-tf2-eigen-kdl-0.25.10-np126py311h7d8ee0e_8.conda
-      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-tf2-geometry-msgs-0.25.10-np126py311h7d8ee0e_8.conda
-      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-tf2-kdl-0.25.10-np126py311h7d8ee0e_8.conda
-      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-tf2-msgs-0.25.10-np126py311h7d8ee0e_8.conda
-      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-tf2-py-0.25.10-np126py311h7d8ee0e_8.conda
-      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-tf2-ros-0.25.10-np126py311h7d8ee0e_8.conda
-      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-tf2-ros-py-0.25.10-np126py311h7d8ee0e_8.conda
-      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-tf2-sensor-msgs-0.25.10-np126py311h7d8ee0e_8.conda
-      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-tf2-tools-0.25.10-np126py311h7d8ee0e_8.conda
-      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-tinyxml-vendor-0.8.3-np126py311h7d8ee0e_8.conda
-      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-tinyxml2-vendor-0.7.6-np126py311h7d8ee0e_8.conda
-      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-tl-expected-1.0.2-np126py311h7d8ee0e_8.conda
-      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-tracetools-4.1.1-np126py311h7d8ee0e_8.conda
-      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-trajectory-msgs-4.2.4-np126py311h7d8ee0e_8.conda
-      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-uncrustify-vendor-2.0.2-np126py311h7d8ee0e_8.conda
-      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-unique-identifier-msgs-2.2.1-np126py311h7d8ee0e_8.conda
-      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-urdf-2.6.1-np126py311h7d8ee0e_8.conda
-      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-urdf-parser-plugin-2.6.1-np126py311h7d8ee0e_8.conda
-      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-urdfdom-3.0.2-np126py311h7d8ee0e_8.conda
-      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-urdfdom-headers-1.0.6-np126py311h7d8ee0e_8.conda
-      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-urdfdom-py-1.2.1-np126py311h7d8ee0e_8.conda
-      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-visualization-msgs-4.2.4-np126py311h7d8ee0e_8.conda
-      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-warehouse-ros-2.0.5-np126py311h7d8ee0e_8.conda
-      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-xacro-2.0.8-np126py311h7d8ee0e_8.conda
-      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-yaml-cpp-vendor-8.0.2-np126py311h7d8ee0e_8.conda
-      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-zstd-vendor-0.15.13-np126py311h7d8ee0e_8.conda
-      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros2-distro-mutex-0.6.0-humble_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/re2-2025.06.26-h3dd2b4f_0.conda
+      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-action-msgs-1.2.1-np126py311hd5de103_13.conda
+      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-actionlib-msgs-4.9.0-np126py311hd5de103_13.conda
+      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-ament-cmake-1.3.12-np126py311hd5de103_13.conda
+      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-ament-cmake-auto-1.3.12-np126py311hd5de103_13.conda
+      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-ament-cmake-copyright-0.12.12-np126py311hd5de103_13.conda
+      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-ament-cmake-core-1.3.12-np126py311hd5de103_13.conda
+      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-ament-cmake-cppcheck-0.12.12-np126py311hd5de103_13.conda
+      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-ament-cmake-cpplint-0.12.12-np126py311hd5de103_13.conda
+      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-ament-cmake-export-definitions-1.3.12-np126py311hd5de103_13.conda
+      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-ament-cmake-export-dependencies-1.3.12-np126py311hd5de103_13.conda
+      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-ament-cmake-export-include-directories-1.3.12-np126py311hd5de103_13.conda
+      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-ament-cmake-export-interfaces-1.3.12-np126py311hd5de103_13.conda
+      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-ament-cmake-export-libraries-1.3.12-np126py311hd5de103_13.conda
+      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-ament-cmake-export-link-flags-1.3.12-np126py311hd5de103_13.conda
+      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-ament-cmake-export-targets-1.3.12-np126py311hd5de103_13.conda
+      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-ament-cmake-flake8-0.12.12-np126py311hd5de103_13.conda
+      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-ament-cmake-gen-version-h-1.3.12-np126py311hd5de103_13.conda
+      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-ament-cmake-gmock-1.3.12-np126py311hd5de103_13.conda
+      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-ament-cmake-gtest-1.3.12-np126py311hd5de103_13.conda
+      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-ament-cmake-include-directories-1.3.12-np126py311hd5de103_13.conda
+      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-ament-cmake-libraries-1.3.12-np126py311hd5de103_13.conda
+      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-ament-cmake-lint-cmake-0.12.12-np126py311hd5de103_13.conda
+      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-ament-cmake-pep257-0.12.12-np126py311hd5de103_13.conda
+      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-ament-cmake-pytest-1.3.12-np126py311hd5de103_13.conda
+      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-ament-cmake-python-1.3.12-np126py311hd5de103_13.conda
+      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-ament-cmake-ros-0.10.0-np126py311hd5de103_13.conda
+      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-ament-cmake-target-dependencies-1.3.12-np126py311hd5de103_13.conda
+      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-ament-cmake-test-1.3.12-np126py311hd5de103_13.conda
+      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-ament-cmake-uncrustify-0.12.12-np126py311hd5de103_13.conda
+      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-ament-cmake-version-1.3.12-np126py311hd5de103_13.conda
+      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-ament-cmake-xmllint-0.12.12-np126py311hd5de103_13.conda
+      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-ament-copyright-0.12.12-np126py311hd5de103_13.conda
+      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-ament-cppcheck-0.12.12-np126py311hd5de103_13.conda
+      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-ament-cpplint-0.12.12-np126py311hd5de103_13.conda
+      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-ament-flake8-0.12.12-np126py311hd5de103_13.conda
+      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-ament-index-cpp-1.4.0-np126py311hd5de103_13.conda
+      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-ament-index-python-1.4.0-np126py311hd5de103_13.conda
+      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-ament-lint-0.12.12-np126py311hd5de103_13.conda
+      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-ament-lint-auto-0.12.12-np126py311hd5de103_13.conda
+      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-ament-lint-cmake-0.12.12-np126py311hd5de103_13.conda
+      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-ament-lint-common-0.12.12-np126py311hd5de103_13.conda
+      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-ament-package-0.14.1-np126py311hd5de103_13.conda
+      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-ament-pep257-0.12.12-np126py311hd5de103_13.conda
+      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-ament-uncrustify-0.12.12-np126py311hd5de103_13.conda
+      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-ament-xmllint-0.12.12-np126py311hd5de103_13.conda
+      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-angles-1.15.0-np126py311hd5de103_13.conda
+      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-backward-ros-1.0.8-np126py311hd5de103_13.conda
+      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-builtin-interfaces-1.2.1-np126py311hd5de103_13.conda
+      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-chomp-motion-planner-2.5.9-np126py311hd5de103_13.conda
+      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-class-loader-2.2.0-np126py311hd5de103_13.conda
+      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-common-interfaces-4.9.0-np126py311hd5de103_13.conda
+      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-composition-interfaces-1.2.1-np126py311hd5de103_13.conda
+      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-console-bridge-vendor-1.4.1-np126py311hd5de103_13.conda
+      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-control-msgs-4.8.0-np126py311hd5de103_13.conda
+      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-controller-interface-2.51.0-np126py311hd5de103_13.conda
+      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-controller-manager-2.51.0-np126py311hd5de103_13.conda
+      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-controller-manager-msgs-2.51.0-np126py311hd5de103_13.conda
+      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-cyclonedds-0.10.5-np126py311hd5de103_13.conda
+      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-diagnostic-msgs-4.9.0-np126py311hd5de103_13.conda
+      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-domain-coordinator-0.10.0-np126py311hd5de103_13.conda
+      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-eigen-stl-containers-1.1.0-np126py311hd5de103_13.conda
+      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-eigen3-cmake-module-0.1.1-np126py311hd5de103_13.conda
+      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-fastcdr-1.0.24-np126py311hd5de103_13.conda
+      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-fastrtps-2.6.10-np126py311hd5de103_13.conda
+      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-fastrtps-cmake-module-2.2.2-np126py311hd5de103_13.conda
+      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-foonathan-memory-vendor-1.2.0-np126py311hd5de103_13.conda
+      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-generate-parameter-library-0.5.0-np126py311hd5de103_13.conda
+      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-generate-parameter-library-py-0.5.0-np126py311hd5de103_13.conda
+      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-geometric-shapes-2.3.2-np126py311hd5de103_13.conda
+      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-geometry-msgs-4.9.0-np126py311hd5de103_13.conda
+      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-geometry2-0.25.14-np126py311hd5de103_13.conda
+      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-gmock-vendor-1.10.9006-np126py311hd5de103_13.conda
+      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-graph-msgs-0.2.0-np126py311hd5de103_13.conda
+      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-gtest-vendor-1.10.9006-np126py311hd5de103_13.conda
+      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-hardware-interface-2.51.0-np126py311hd5de103_13.conda
+      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-iceoryx-binding-c-2.0.5-np126py311hd5de103_13.conda
+      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-iceoryx-hoofs-2.0.5-np126py311hd5de103_13.conda
+      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-iceoryx-posh-2.0.5-np126py311hd5de103_13.conda
+      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-ignition-cmake2-vendor-0.0.2-np126py311h4715f36_13.conda
+      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-ignition-math6-vendor-0.0.2-np126py311hd5de103_13.conda
+      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-image-transport-3.1.12-np126py311hd5de103_13.conda
+      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-interactive-markers-2.3.2-np126py311hd5de103_13.conda
+      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-kdl-parser-2.6.4-np126py311hd5de103_13.conda
+      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-keyboard-handler-0.0.5-np126py311hd5de103_13.conda
+      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-laser-geometry-2.4.0-np126py311hd5de103_13.conda
+      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-launch-1.0.9-np126py311hd5de103_13.conda
+      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-launch-param-builder-0.1.1-np126py311hd5de103_13.conda
+      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-launch-ros-0.19.10-np126py311hd5de103_13.conda
+      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-launch-testing-1.0.9-np126py311hd5de103_13.conda
+      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-launch-testing-ament-cmake-1.0.9-np126py311hd5de103_13.conda
+      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-launch-testing-ros-0.19.10-np126py311hd5de103_13.conda
+      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-launch-xml-1.0.9-np126py311hd5de103_13.conda
+      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-launch-yaml-1.0.9-np126py311hd5de103_13.conda
+      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-libcurl-vendor-3.1.3-np126py311hd5de103_13.conda
+      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-libstatistics-collector-1.3.4-np126py311hd5de103_13.conda
+      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-libyaml-vendor-1.2.2-np126py311hd5de103_13.conda
+      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-lifecycle-msgs-1.2.1-np126py311hd5de103_13.conda
+      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-map-msgs-2.1.0-np126py311hd5de103_13.conda
+      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-message-filters-4.3.7-np126py311hd5de103_13.conda
+      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-moveit-2.5.9-np126py311hd5de103_13.conda
+      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-moveit-common-2.5.9-np126py311hd5de103_13.conda
+      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-moveit-configs-utils-2.5.9-np126py311hd5de103_13.conda
+      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-moveit-core-2.5.9-np126py311hd5de103_13.conda
+      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-moveit-kinematics-2.5.9-np126py311hd5de103_13.conda
+      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-moveit-msgs-2.2.1-np126py311hd5de103_13.conda
+      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-moveit-planners-2.5.9-np126py311hd5de103_13.conda
+      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-moveit-planners-chomp-2.5.9-np126py311hd5de103_13.conda
+      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-moveit-planners-ompl-2.5.9-np126py311hd5de103_13.conda
+      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-moveit-plugins-2.5.9-np126py311hd5de103_13.conda
+      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-moveit-ros-2.5.9-np126py311hd5de103_13.conda
+      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-moveit-ros-benchmarks-2.5.9-np126py311hd5de103_13.conda
+      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-moveit-ros-move-group-2.5.9-np126py311hd5de103_13.conda
+      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-moveit-ros-occupancy-map-monitor-2.5.9-np126py311hd5de103_13.conda
+      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-moveit-ros-planning-2.5.9-np126py311hd5de103_13.conda
+      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-moveit-ros-planning-interface-2.5.9-np126py311hd5de103_13.conda
+      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-moveit-ros-robot-interaction-2.5.9-np126py311hd5de103_13.conda
+      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-moveit-ros-visualization-2.5.9-np126py311hd5de103_13.conda
+      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-moveit-ros-warehouse-2.5.9-np126py311hd5de103_13.conda
+      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-moveit-setup-app-plugins-2.5.9-np126py311hd5de103_13.conda
+      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-moveit-setup-assistant-2.5.9-np126py311hd5de103_13.conda
+      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-moveit-setup-controllers-2.5.9-np126py311hd5de103_13.conda
+      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-moveit-setup-core-plugins-2.5.9-np126py311hd5de103_13.conda
+      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-moveit-setup-framework-2.5.9-np126py311hd5de103_13.conda
+      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-moveit-setup-srdf-plugins-2.5.9-np126py311hd5de103_13.conda
+      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-moveit-simple-controller-manager-2.5.9-np126py311hd5de103_13.conda
+      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-moveit-visual-tools-4.1.2-np126py311hd5de103_13.conda
+      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-nav-msgs-4.9.0-np126py311hd5de103_13.conda
+      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-object-recognition-msgs-2.0.0-np126py311hd5de103_13.conda
+      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-octomap-1.10.0-py311hb04609a_13.conda
+      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-octomap-msgs-2.0.1-np126py311hd5de103_13.conda
+      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-ompl-1.7.0-py311h2efc760_13.conda
+      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-orocos-kdl-vendor-0.2.5-np126py311hd5de103_13.conda
+      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-osrf-pycommon-2.1.6-np126py311hd5de103_13.conda
+      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-parameter-traits-0.5.0-np126py311hd5de103_13.conda
+      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-pilz-industrial-motion-planner-2.5.9-np126py311hd5de103_13.conda
+      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-pluginlib-5.1.0-np126py311hd5de103_13.conda
+      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-pybind11-vendor-2.4.2-np126py311hd5de103_13.conda
+      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-python-cmake-module-0.10.0-np126py311hd5de103_13.conda
+      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-python-orocos-kdl-vendor-0.2.5-np126py311hd5de103_13.conda
+      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-random-numbers-2.0.1-np126py311hd5de103_13.conda
+      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-rcl-5.3.9-np126py311hd5de103_13.conda
+      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-rcl-action-5.3.9-np126py311hd5de103_13.conda
+      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-rcl-interfaces-1.2.1-np126py311hd5de103_13.conda
+      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-rcl-lifecycle-5.3.9-np126py311hd5de103_13.conda
+      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-rcl-logging-interface-2.3.1-np126py311hd5de103_13.conda
+      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-rcl-logging-spdlog-2.3.1-np126py311hc120487_13.conda
+      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-rcl-yaml-param-parser-5.3.9-np126py311hd5de103_13.conda
+      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-rclcpp-16.0.13-np126py311hd5de103_13.conda
+      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-rclcpp-action-16.0.13-np126py311hd5de103_13.conda
+      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-rclcpp-components-16.0.13-np126py311hd5de103_13.conda
+      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-rclcpp-lifecycle-16.0.13-np126py311hd5de103_13.conda
+      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-rclpy-3.3.16-np126py311hd5de103_13.conda
+      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-rcpputils-2.4.5-np126py311hd5de103_13.conda
+      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-rcutils-5.1.6-np126py311hd5de103_13.conda
+      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-realtime-tools-2.14.0-np126py311hd5de103_13.conda
+      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-resource-retriever-3.1.3-np126py311hd5de103_13.conda
+      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-rmw-6.1.2-np126py311hd5de103_13.conda
+      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-rmw-connextdds-0.11.3-np126py311hd5de103_13.conda
+      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-rmw-connextdds-common-0.11.3-np126py311hd5de103_13.conda
+      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-rmw-cyclonedds-cpp-1.3.4-np126py311hd5de103_13.conda
+      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-rmw-dds-common-1.6.0-np126py311hd5de103_13.conda
+      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-rmw-fastrtps-cpp-6.2.7-np126py311hd5de103_13.conda
+      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-rmw-fastrtps-dynamic-cpp-6.2.7-np126py311hd5de103_13.conda
+      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-rmw-fastrtps-shared-cpp-6.2.7-np126py311hd5de103_13.conda
+      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-rmw-implementation-2.8.4-np126py311hd5de103_13.conda
+      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-rmw-implementation-cmake-6.1.2-np126py311hd5de103_13.conda
+      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-robot-state-publisher-3.0.3-np126py311hd5de103_13.conda
+      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-ros-base-0.10.0-np126py311hd5de103_13.conda
+      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-ros-core-0.10.0-np126py311hd5de103_13.conda
+      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-ros-environment-3.2.2-np126py311hd5de103_13.conda
+      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-ros-gz-interfaces-0.244.20-np126py311hd5de103_13.conda
+      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-ros-workspace-1.0.2-np126py311hd5de103_13.conda
+      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-ros2-control-test-assets-2.51.0-np126py311hd5de103_13.conda
+      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-ros2action-0.18.12-np126py311hd5de103_13.conda
+      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-ros2bag-0.15.14-np126py311hd5de103_13.conda
+      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-ros2cli-0.18.12-np126py311hd5de103_13.conda
+      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-ros2cli-common-extensions-0.1.1-np126py311hd5de103_13.conda
+      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-ros2component-0.18.12-np126py311hd5de103_13.conda
+      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-ros2doctor-0.18.12-np126py311hd5de103_13.conda
+      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-ros2interface-0.18.12-np126py311hd5de103_13.conda
+      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-ros2launch-0.19.10-np126py311hd5de103_13.conda
+      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-ros2lifecycle-0.18.12-np126py311hd5de103_13.conda
+      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-ros2multicast-0.18.12-np126py311hd5de103_13.conda
+      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-ros2node-0.18.12-np126py311hd5de103_13.conda
+      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-ros2param-0.18.12-np126py311hd5de103_13.conda
+      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-ros2pkg-0.18.12-np126py311hd5de103_13.conda
+      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-ros2run-0.18.12-np126py311hd5de103_13.conda
+      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-ros2service-0.18.12-np126py311hd5de103_13.conda
+      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-ros2topic-0.18.12-np126py311hd5de103_13.conda
+      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-rosbag2-0.15.14-np126py311hd5de103_13.conda
+      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-rosbag2-compression-0.15.14-np126py311hd5de103_13.conda
+      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-rosbag2-compression-zstd-0.15.14-np126py311hd5de103_13.conda
+      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-rosbag2-cpp-0.15.14-np126py311hd5de103_13.conda
+      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-rosbag2-interfaces-0.15.14-np126py311hd5de103_13.conda
+      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-rosbag2-py-0.15.14-np126py311hd5de103_13.conda
+      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-rosbag2-storage-0.15.14-np126py311hd5de103_13.conda
+      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-rosbag2-storage-default-plugins-0.15.14-np126py311hd5de103_13.conda
+      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-rosbag2-transport-0.15.14-np126py311hd5de103_13.conda
+      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-rosgraph-msgs-1.2.1-np126py311hd5de103_13.conda
+      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-rosidl-adapter-3.1.6-np126py311hd5de103_13.conda
+      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-rosidl-cli-3.1.6-np126py311hd5de103_13.conda
+      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-rosidl-cmake-3.1.6-np126py311hd5de103_13.conda
+      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-rosidl-default-generators-1.2.0-np126py311hd5de103_13.conda
+      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-rosidl-default-runtime-1.2.0-np126py311hd5de103_13.conda
+      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-rosidl-generator-c-3.1.6-np126py311hd5de103_13.conda
+      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-rosidl-generator-cpp-3.1.6-np126py311hd5de103_14.conda
+      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-rosidl-generator-py-0.14.4-np126py311hd5de103_13.conda
+      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-rosidl-parser-3.1.6-np126py311hd5de103_13.conda
+      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-rosidl-runtime-c-3.1.6-np126py311hd5de103_13.conda
+      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-rosidl-runtime-cpp-3.1.6-np126py311hd5de103_14.conda
+      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-rosidl-runtime-py-0.9.3-np126py311hd5de103_13.conda
+      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-rosidl-typesupport-c-2.0.2-np126py311hd5de103_13.conda
+      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-rosidl-typesupport-cpp-2.0.2-np126py311hd5de103_13.conda
+      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-rosidl-typesupport-fastrtps-c-2.2.2-np126py311hd5de103_13.conda
+      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-rosidl-typesupport-fastrtps-cpp-2.2.2-np126py311hd5de103_13.conda
+      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-rosidl-typesupport-interface-3.1.6-np126py311hd5de103_13.conda
+      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-rosidl-typesupport-introspection-c-3.1.6-np126py311hd5de103_13.conda
+      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-rosidl-typesupport-introspection-cpp-3.1.6-np126py311hd5de103_13.conda
+      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-rpyutils-0.2.1-np126py311hd5de103_13.conda
+      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-rsl-1.2.0-np126py311h4715f36_13.conda
+      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-rti-connext-dds-cmake-module-0.11.3-np126py311hd5de103_13.conda
+      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-ruckig-0.9.2-np126py311hd5de103_13.conda
+      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-rviz-assimp-vendor-11.2.18-np126py311hd5de103_13.conda
+      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-rviz-common-11.2.18-np126py311hd5de103_13.conda
+      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-rviz-default-plugins-11.2.18-np126py311hd5de103_13.conda
+      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-rviz-ogre-vendor-11.2.18-np126py311hcdf5458_13.conda
+      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-rviz-rendering-11.2.18-np126py311hd5de103_13.conda
+      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-rviz-visual-tools-4.1.4-np126py311hd5de103_13.conda
+      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-rviz2-11.2.18-np126py311hd5de103_13.conda
+      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-sensor-msgs-4.9.0-np126py311hd5de103_13.conda
+      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-sensor-msgs-py-4.9.0-np126py311hd5de103_13.conda
+      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-shape-msgs-4.9.0-np126py311hd5de103_13.conda
+      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-shared-queues-vendor-0.15.14-np126py311hd5de103_13.conda
+      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-spdlog-vendor-1.3.1-np126py311hc120487_13.conda
+      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-sqlite3-vendor-0.15.14-np126py311hd5de103_13.conda
+      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-srdfdom-2.0.7-np126py311hd5de103_13.conda
+      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-sros2-0.10.6-np126py311hd5de103_13.conda
+      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-sros2-cmake-0.10.6-np126py311hd5de103_13.conda
+      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-statistics-msgs-1.2.1-np126py311hd5de103_13.conda
+      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-std-msgs-4.9.0-np126py311hd5de103_13.conda
+      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-std-srvs-4.9.0-np126py311hd5de103_13.conda
+      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-stereo-msgs-4.9.0-np126py311hd5de103_13.conda
+      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-tcb-span-1.0.2-np126py311hd5de103_13.conda
+      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-test-msgs-1.2.1-np126py311hd5de103_13.conda
+      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-tf2-0.25.14-np126py311hd5de103_13.conda
+      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-tf2-bullet-0.25.14-np126py311hd5de103_13.conda
+      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-tf2-eigen-0.25.14-np126py311hd5de103_13.conda
+      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-tf2-eigen-kdl-0.25.14-np126py311hd5de103_13.conda
+      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-tf2-geometry-msgs-0.25.14-np126py311hd5de103_13.conda
+      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-tf2-kdl-0.25.14-np126py311hd5de103_13.conda
+      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-tf2-msgs-0.25.14-np126py311hd5de103_13.conda
+      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-tf2-py-0.25.14-np126py311hd5de103_13.conda
+      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-tf2-ros-0.25.14-np126py311hd5de103_13.conda
+      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-tf2-ros-py-0.25.14-np126py311hd5de103_13.conda
+      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-tf2-sensor-msgs-0.25.14-np126py311hd5de103_13.conda
+      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-tf2-tools-0.25.14-np126py311hd5de103_13.conda
+      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-tinyxml-vendor-0.8.3-np126py311hd5de103_13.conda
+      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-tinyxml2-vendor-0.7.6-np126py311hd5de103_14.conda
+      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-tl-expected-1.0.2-np126py311hd5de103_13.conda
+      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-tracetools-4.1.1-np126py311hd5de103_13.conda
+      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-trajectory-msgs-4.9.0-np126py311hd5de103_13.conda
+      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-uncrustify-vendor-2.0.2-np126py311hd5de103_13.conda
+      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-unique-identifier-msgs-2.2.1-np126py311hd5de103_13.conda
+      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-urdf-2.6.1-np126py311hd5de103_13.conda
+      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-urdf-parser-plugin-2.6.1-np126py311hd5de103_13.conda
+      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-urdfdom-4.0.1-py311hb04609a_13.conda
+      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-urdfdom-headers-1.0.6-py311hb04609a_13.conda
+      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-urdfdom-py-1.2.1-py311hb04609a_13.conda
+      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-visualization-msgs-4.9.0-np126py311hd5de103_13.conda
+      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-warehouse-ros-2.0.5-np126py311hd5de103_13.conda
+      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-xacro-2.0.13-np126py311hd5de103_13.conda
+      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-yaml-cpp-vendor-8.0.2-np126py311hd5de103_13.conda
+      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-zstd-vendor-0.15.14-np126py311hd5de103_13.conda
+      - conda: https://conda.anaconda.org/robostack-humble/win-64/ros2-distro-mutex-0.7.0-humble_13.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/rosdistro-1.0.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/rospkg-1.6.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/ruby-3.4.2-h79e22a9_0.conda
@@ -6178,17 +6182,17 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/snappy-1.2.1-h500f7fa_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/snowballstemmer-3.0.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/soxr-0.1.3-hcfcfb64_3.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/spdlog-1.14.1-h9f2357e_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/sqlite-3.50.2-hdb435a2_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/spdlog-1.15.3-h430ee68_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/sqlite-3.51.2-hdb435a2_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/stack_data-0.6.3-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/svt-av1-3.0.2-he0c23c2_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/swig-4.3.1-h51fbe9b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/swig-4.3.1-hf4c94c2_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/tbb-2022.1.0-ha82c486_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/tbb-devel-2022.1.0-h47441b3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/tiledb-2.27.0-ha5813de_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/tiledb-2.28.0-h7c9f11d_6.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/tiny-process-library-2.0.4-he0c23c2_2.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/tinyxml-2.6.2-h2d74725_2.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/win-64/tinyxml2-10.0.0-he0c23c2_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/tinyxml2-11.0.0-he0c23c2_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/tk-8.6.13-h2c6b04d_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/toml-0.10.2-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.2.1-pyhd8ed1ab_1.conda
@@ -6201,10 +6205,11 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025b-h78e105d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/u-msgpack-python-2.8.0-pyhff2d567_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/ucrt-10.0.22621.0-h57928b3_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/uncrustify-0.74.0-h57928b3_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/uncrustify-0.81.0-he0c23c2_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/unicodedata2-16.0.0-py311he736701_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/urdfdom-4.0.1-h4358a7e_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/urdfdom_headers-1.1.2-hc790b64_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/urdfdom-4.0.1-h9d4477b_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/urdfdom-py-1.2.1-py311h5da1550_6.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/urdfdom_headers-1.0.6-h5362a0b_2.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/win-64/uriparser-0.9.8-h5a68840_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/utfcpp-4.0.6-hc1507ef_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/vc-14.3-h41ae7f8_26.conda
@@ -6212,8 +6217,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/vs2015_runtime-14.44.35208-h38c0c73_26.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/vs2022_win-64-19.44.35207-ha74f236_33.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/vswhere-3.1.7-h40126e0_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/vtk-9.3.1-qt_py311h85ceb33_215.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/vtk-base-9.3.1-qt_py311h86964fa_215.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/vtk-9.4.2-hbdaaff1_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/vtk-base-9.4.2-py311h0d49f04_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.2.13-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/wheel-0.45.1-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/win32_setctime-1.2.0-pyhd8ed1ab_0.conda
@@ -7050,22 +7055,25 @@ packages:
   license_family: APACHE
   size: 106828
   timestamp: 1750291414287
-- conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-auth-0.8.0-h2219d47_15.conda
-  sha256: 77dd27caf1ce46c195f4ae9fae3e45cbb3b113c5418b2426db95038912178206
-  md5: d8aa3355ad0360a42b5c57fedb1ad87e
+- conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-auth-0.9.0-h467f71e_16.conda
+  sha256: 207f569837c623e16580c66f539a4b675b7bc23f6f7e593bd4d8a131424e1b94
+  md5: 208c8ab5e2a49ed43b3fbda91a55f60d
   depends:
-  - aws-c-cal >=0.8.1,<0.8.2.0a0
-  - aws-c-common >=0.10.6,<0.10.7.0a0
-  - aws-c-http >=0.9.2,<0.9.3.0a0
-  - aws-c-io >=0.15.3,<0.15.4.0a0
-  - aws-c-sdkutils >=0.2.1,<0.2.2.0a0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  - ucrt >=10.0.20348.0
+  - aws-c-http >=0.10.2,<0.10.3.0a0
+  - aws-c-common >=0.12.4,<0.12.5.0a0
+  - aws-c-io >=0.21.0,<0.21.1.0a0
+  - aws-c-sdkutils >=0.2.4,<0.2.5.0a0
+  - aws-c-cal >=0.9.2,<0.9.3.0a0
   license: Apache-2.0
-  license_family: Apache
-  size: 102644
-  timestamp: 1734022070771
+  license_family: APACHE
+  size: 115922
+  timestamp: 1752261105048
 - conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-auth-0.9.0-hd490b63_15.conda
   sha256: 27b1557a502890992950db65ba9414277baec74130042034ba449e71d4b36275
   md5: 41c6aba02d07f6419a01210b5c7398bc
@@ -7173,19 +7181,6 @@ packages:
   license_family: Apache
   size: 41549
   timestamp: 1749095729253
-- conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-cal-0.8.1-h099ea23_3.conda
-  sha256: e345717c4cbef8472b3f4f90b75d326ad66a84574bfb02740a860d8de6414c44
-  md5: 767b18a469cf18d7476cab915f9fe207
-  depends:
-  - aws-c-common >=0.10.6,<0.10.7.0a0
-  - openssl >=3.3.1,<4.0a0
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  license: Apache-2.0
-  license_family: Apache
-  size: 47436
-  timestamp: 1733991914197
 - conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-cal-0.9.2-hd8a8e38_0.conda
   sha256: 49582f0e8f9d0d39532f7c7521ce909679bca765b05fa126c0c5d1419bec5906
   md5: 31e1c0f53295a59e35dfc62ae5299ff4
@@ -7198,6 +7193,18 @@ packages:
   license_family: Apache
   size: 48875
   timestamp: 1749095719946
+- conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-cal-0.9.2-hef2a5b8_1.conda
+  sha256: cd396607f5ffdbdae6995ea135904f6efe7eaac19346aec07359684424819a16
+  md5: 096193e01d32724a835517034a6926a2
+  depends:
+  - aws-c-common >=0.12.4,<0.12.5.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  license: Apache-2.0
+  license_family: Apache
+  size: 49125
+  timestamp: 1752241167516
 - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-common-0.10.6-hb9d3cd8_0.conda
   sha256: 496e92f2150fdc351eacf6e236015deedb3d0d3114f8e5954341cbf9f3dda257
   md5: d7d4680337a14001b0e043e96529409b
@@ -7272,17 +7279,6 @@ packages:
   license_family: Apache
   size: 222023
   timestamp: 1747101294224
-- conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-common-0.10.6-h2466b09_0.conda
-  sha256: 348af25291f2b4106d8453fddb8dcbfed452067bddfa0eeadd24f1c710617a4a
-  md5: 44a7e180f2054340401499de93ae39ba
-  depends:
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  license: Apache-2.0
-  license_family: Apache
-  size: 235514
-  timestamp: 1733975788721
 - conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-common-0.12.3-h2466b09_0.conda
   sha256: a9bc739694679ff32fc455a85130e43165a97e64513908ce906f3d7191f11dcf
   md5: d6ef6f814f88fcb499c72d194f708a35
@@ -7294,6 +7290,17 @@ packages:
   license_family: Apache
   size: 235248
   timestamp: 1747101598043
+- conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-common-0.12.4-hfd05255_0.conda
+  sha256: c818a09c4d9fe228bb6c94a02c0b05f880ead16ca9f0f59675ae862479ea631a
+  md5: dcac61b0681b4a2c8e74772415f9e490
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  license: Apache-2.0
+  license_family: Apache
+  size: 235039
+  timestamp: 1752193765837
 - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-compression-0.3.0-h4e1184b_5.conda
   sha256: 62ca84da83585e7814a40240a1e750b1563b2680b032a471464eccc001c3309b
   md5: 3f4c1197462a6df2be6dc8241828fe93
@@ -7376,18 +7383,6 @@ packages:
   license_family: APACHE
   size: 21264
   timestamp: 1747144987400
-- conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-compression-0.3.0-h099ea23_5.conda
-  sha256: f30956b5c450e0a21adc3d523fdbe2d0dcc79125b135f5ccc4497d97f8733891
-  md5: b4303abff1423285a2e5063d796e1614
-  depends:
-  - aws-c-common >=0.10.6,<0.10.7.0a0
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  license: Apache-2.0
-  license_family: Apache
-  size: 22364
-  timestamp: 1733991973284
 - conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-compression-0.3.1-h5d0e663_5.conda
   sha256: 5f387d438f81047f566112d533c86b04cb7c059bace25df28c0afd72f668d506
   md5: fef493108acbe504dcc49bbf9759ccea
@@ -7403,6 +7398,21 @@ packages:
   license_family: APACHE
   size: 22690
   timestamp: 1747145057422
+- conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-compression-0.3.1-ha8a2810_6.conda
+  sha256: 760d399e54d5f9e86fdc76633e15e00e1b60fc90b15a446b9dce6f79443dcfd7
+  md5: f00789373bfeb808ca267a34982352de
+  depends:
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  - ucrt >=10.0.20348.0
+  - aws-c-common >=0.12.4,<0.12.5.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 22931
+  timestamp: 1752240036957
 - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-event-stream-0.5.0-h7959bf6_11.conda
   sha256: 10d7240c7db0c941fb1a59c4f8ea6689a434b03309ee7b766fa15a809c553c02
   md5: 9b3fb60fe57925a92f399bc3fc42eccf
@@ -7510,20 +7520,6 @@ packages:
   license_family: APACHE
   size: 50678
   timestamp: 1750287918055
-- conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-event-stream-0.5.0-h85d8506_11.conda
-  sha256: bd7d3849ae0a12e170d4d442f7d2db7de98827d8d3505d0a60d12b1170b1ab0d
-  md5: a32c029b7e933cf93c5066b186560e62
-  depends:
-  - aws-c-common >=0.10.6,<0.10.7.0a0
-  - aws-c-io >=0.15.3,<0.15.4.0a0
-  - aws-checksums >=0.2.2,<0.2.3.0a0
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  license: Apache-2.0
-  license_family: Apache
-  size: 54426
-  timestamp: 1734024881523
 - conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-event-stream-0.5.4-ha416645_12.conda
   sha256: 89efca036d37a8392f3220ef65e5205f03eae6330dcc121d258b298eae4b2795
   md5: 51269fa3c4b226f6b40aacb72dedb195
@@ -7541,6 +7537,23 @@ packages:
   license_family: APACHE
   size: 55990
   timestamp: 1750287899566
+- conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-event-stream-0.5.5-h16d2062_1.conda
+  sha256: 7814bb28393192cf7b6e5df80776f362555153888fb4d02b394d3041211a9d5c
+  md5: d9314ff31bd6abde788f0d9565b294ac
+  depends:
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  - ucrt >=10.0.20348.0
+  - aws-c-io >=0.21.0,<0.21.1.0a0
+  - aws-checksums >=0.2.7,<0.2.8.0a0
+  - aws-c-common >=0.12.4,<0.12.5.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 56299
+  timestamp: 1752252571885
 - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-http-0.10.2-h015de20_2.conda
   sha256: ca0268cead19e985f9b153613f0f6cdb46e0ca32e1647466c506f256269bcdd9
   md5: ad05d594704926ba7c0c894a02ea98f1
@@ -7665,21 +7678,24 @@ packages:
   license_family: APACHE
   size: 204438
   timestamp: 1750289208536
-- conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-http-0.9.2-h3888f84_4.conda
-  sha256: ce0cedbe65e36f6e6dc9a8e07336f9c6ceecb09f0ed8eebdd01d74d261b59d16
-  md5: 4e7cf9b498fcc5dee5abcdf24e64a96d
+- conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-http-0.10.2-h909f643_3.conda
+  sha256: ee80d0cf7e0a2096b2180384f983d329c0e0cfb63e4de92cbc4eeb0eb937a623
+  md5: 823ecde288edb76638b675e4db01a632
   depends:
-  - aws-c-cal >=0.8.1,<0.8.2.0a0
-  - aws-c-common >=0.10.6,<0.10.7.0a0
-  - aws-c-compression >=0.3.0,<0.3.1.0a0
-  - aws-c-io >=0.15.3,<0.15.4.0a0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  - ucrt >=10.0.20348.0
+  - aws-c-io >=0.21.0,<0.21.1.0a0
+  - aws-c-common >=0.12.4,<0.12.5.0a0
+  - aws-c-cal >=0.9.2,<0.9.3.0a0
+  - aws-c-compression >=0.3.1,<0.3.2.0a0
   license: Apache-2.0
-  license_family: Apache
-  size: 182269
-  timestamp: 1734008780813
+  license_family: APACHE
+  size: 204598
+  timestamp: 1752252517689
 - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-io-0.15.3-h173a860_6.conda
   sha256: 335d822eead0a097ffd23677a288e1f18ea22f47a92d4f877419debb93af0e81
   md5: 9a063178f1af0a898526cc24ba7be486
@@ -7774,19 +7790,6 @@ packages:
   license_family: APACHE
   size: 175443
   timestamp: 1749844502601
-- conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-io-0.15.3-hc5a9e45_6.conda
-  sha256: 0cbf3ddd55835ba99726ffcc0118124fc8430fec41e81bb7b1d8c0c6e0d272e0
-  md5: 48a9b0c65a94282ffa149ea7c0a53239
-  depends:
-  - aws-c-cal >=0.8.1,<0.8.2.0a0
-  - aws-c-common >=0.10.6,<0.10.7.0a0
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  license: Apache-2.0
-  license_family: Apache
-  size: 159815
-  timestamp: 1737207711320
 - conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-io-0.20.1-hddf4d6c_0.conda
   sha256: f494ad2f99ab6a5b5bec2beb92c914ba2f51c01ffe092f4322c42c5fdafe09fe
   md5: 43b20ab02a0ad5a0f2069868579f8f3c
@@ -7803,6 +7806,22 @@ packages:
   license_family: APACHE
   size: 179601
   timestamp: 1749844514070
+- conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-io-0.21.0-h20b9e97_1.conda
+  sha256: bdabad1692a1f4931f9b1af399bbf6226aebdf79931d7ad45a0d77df884ff6d2
+  md5: 690fd1c04f350318a0cf115ac871fd32
+  depends:
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  - ucrt >=10.0.20348.0
+  - aws-c-common >=0.12.4,<0.12.5.0a0
+  - aws-c-cal >=0.9.2,<0.9.3.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 180873
+  timestamp: 1752246192671
 - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-mqtt-0.11.0-h11f4f37_12.conda
   sha256: 512d3969426152d9d5fd886e27b13706122dc3fa90eb08c37b0d51a33d7bb14a
   md5: 96c3e0221fa2da97619ee82faa341a73
@@ -7901,20 +7920,6 @@ packages:
   license_family: APACHE
   size: 149876
   timestamp: 1750291922527
-- conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-mqtt-0.11.0-h2c94728_12.conda
-  sha256: bfe3e2c5de01e285e67ac8119de58a11e594d202b3ebcfaa55ffd138a3b28279
-  md5: bad2afca289f8854d431acdcc8f1cea8
-  depends:
-  - aws-c-common >=0.10.6,<0.10.7.0a0
-  - aws-c-http >=0.9.2,<0.9.3.0a0
-  - aws-c-io >=0.15.3,<0.15.4.0a0
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  license: Apache-2.0
-  license_family: Apache
-  size: 186987
-  timestamp: 1734025825190
 - conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-mqtt-0.13.1-h5c1ae27_3.conda
   sha256: 6d8ec3659cc03c02ce90e83f0818686f013f3190ec5b82bf5f6c1977902c2c34
   md5: b45b5124b91147887f4670e2e9b017b8
@@ -7932,6 +7937,23 @@ packages:
   license_family: APACHE
   size: 206081
   timestamp: 1750291938128
+- conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-mqtt-0.13.1-h8a47558_4.conda
+  sha256: f1727c7fa35cc74576e4ca324f69c398ddc7da971a494abfc756f1c7316abc36
+  md5: 9828419c9537c9b34366bbf1b434c612
+  depends:
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  - ucrt >=10.0.20348.0
+  - aws-c-io >=0.21.0,<0.21.1.0a0
+  - aws-c-http >=0.10.2,<0.10.3.0a0
+  - aws-c-common >=0.12.4,<0.12.5.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 205789
+  timestamp: 1752261711544
 - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-s3-0.7.7-hf454442_0.conda
   sha256: c2f205a7bf64c5f40eea373b3a0a7c363c9aa9246a13dd7f3d9c6a4434c4fe2d
   md5: 947c82025693bebd557f782bb5d6b469
@@ -8054,23 +8076,6 @@ packages:
   license: Apache-2.0
   size: 116611
   timestamp: 1750831825090
-- conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-s3-0.7.7-h6a38c86_0.conda
-  sha256: 6698400778ddf56c3dabd44b8fbe567242bb82d50957fb35794ecaea40b0d74a
-  md5: 1263ee7d4211e4e0e1e3a313c4118601
-  depends:
-  - aws-c-auth >=0.8.0,<0.8.1.0a0
-  - aws-c-cal >=0.8.1,<0.8.2.0a0
-  - aws-c-common >=0.10.6,<0.10.7.0a0
-  - aws-c-http >=0.9.2,<0.9.3.0a0
-  - aws-c-io >=0.15.3,<0.15.4.0a0
-  - aws-checksums >=0.2.2,<0.2.3.0a0
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  license: Apache-2.0
-  license_family: Apache
-  size: 109362
-  timestamp: 1734146367350
 - conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-s3-0.8.3-h1e843c7_0.conda
   sha256: cf3d2a87289e1d16504fd6908ddd067c16d7b08a893b753d690cc745f79cc462
   md5: e36c53272fa10d95afead65623efa261
@@ -8090,6 +8095,26 @@ packages:
   license: Apache-2.0
   size: 126871
   timestamp: 1750831846697
+- conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-s3-0.8.3-hcc9d52c_1.conda
+  sha256: 705d3005977a5d30ccea5db08edcdbc033f51f36e2ceef9e1eddd4908e5f6b67
+  md5: e9a4d70e029973e58e73399a8b92efaa
+  depends:
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  - ucrt >=10.0.20348.0
+  - aws-c-common >=0.12.4,<0.12.5.0a0
+  - aws-c-http >=0.10.2,<0.10.3.0a0
+  - aws-checksums >=0.2.7,<0.2.8.0a0
+  - aws-c-cal >=0.9.2,<0.9.3.0a0
+  - aws-c-auth >=0.9.0,<0.9.1.0a0
+  - aws-c-io >=0.21.0,<0.21.1.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 126946
+  timestamp: 1752271938540
 - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-sdkutils-0.2.1-h4e1184b_4.conda
   sha256: df586f42210af1134b1c88ff4c278c3cb6d6c807c84eac48860062464b28554d
   md5: a5126a90e74ac739b00564a4c7ddcc36
@@ -8172,18 +8197,6 @@ packages:
   license_family: APACHE
   size: 53372
   timestamp: 1747308310688
-- conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-sdkutils-0.2.1-h099ea23_4.conda
-  sha256: 41dc53b95bc426e591bf294aaa844d81acec7033ab4586c25b56b7ed4e2c7254
-  md5: 9b209470fc80add34e822f4abeade3a3
-  depends:
-  - aws-c-common >=0.10.6,<0.10.7.0a0
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  license: Apache-2.0
-  license_family: Apache
-  size: 55419
-  timestamp: 1733994591200
 - conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-sdkutils-0.2.4-h5d0e663_0.conda
   sha256: 2d79cca232fe0af6299399b7435620326c9d5b3d3e7f2460d850315d4a83463b
   md5: 9c6103d829b015925b2eb2ef148b4519
@@ -8199,6 +8212,21 @@ packages:
   license_family: APACHE
   size: 55722
   timestamp: 1747308370540
+- conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-sdkutils-0.2.4-ha8a2810_1.conda
+  sha256: b8c7637ad8069ace0f79cc510275b01787c9d478888d4e548980ef2ca61f19c5
+  md5: afbb1a7d671fc81c97daeac8ff6c54e0
+  depends:
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  - ucrt >=10.0.20348.0
+  - aws-c-common >=0.12.4,<0.12.5.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 56289
+  timestamp: 1752240989872
 - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-checksums-0.2.2-h4e1184b_4.conda
   sha256: 1ed9a332d06ad595694907fad2d6d801082916c27cd5076096fda4061e6d24a8
   md5: 74e8c3e4df4ceae34aa2959df4b28101
@@ -8281,18 +8309,6 @@ packages:
   license_family: APACHE
   size: 74064
   timestamp: 1747141754096
-- conda: https://conda.anaconda.org/conda-forge/win-64/aws-checksums-0.2.2-h099ea23_4.conda
-  sha256: 577e62dbf1750219cfb017d36c9022f40d7dc287b597fd7dec1ca04cade0108c
-  md5: 5a8ce497f17cf1e6ae745f122b6a2bc3
-  depends:
-  - aws-c-common >=0.10.6,<0.10.7.0a0
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  license: Apache-2.0
-  license_family: Apache
-  size: 91909
-  timestamp: 1733994821424
 - conda: https://conda.anaconda.org/conda-forge/win-64/aws-checksums-0.2.7-h5d0e663_1.conda
   sha256: ace5e1f7accc03187cd6b507230d0f1e51e03ac86b6f0b2d8213722a2e0dd9dd
   md5: 10a0ef46b1cd76a01638b3cd72967d16
@@ -8308,6 +8324,21 @@ packages:
   license_family: APACHE
   size: 92710
   timestamp: 1747141831325
+- conda: https://conda.anaconda.org/conda-forge/win-64/aws-checksums-0.2.7-ha8a2810_2.conda
+  sha256: 2c2f5b176fb8c0f15c6bc5edea0b2dd3d56b58e8b1124eb0f592665cec5dfc35
+  md5: d6342b48cb2f43df847ee39e0858813a
+  depends:
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  - ucrt >=10.0.20348.0
+  - aws-c-common >=0.12.4,<0.12.5.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 92982
+  timestamp: 1752241099189
 - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-crt-cpp-0.29.7-hd92328a_7.conda
   sha256: 094cd81f1e5ba713e9e7a272ee52b5dde3ccc4842ea90f19c0354a00bbdac3d9
   md5: 02b95564257d5c3db9c06beccf711f95
@@ -8458,26 +8489,29 @@ packages:
   license: Apache-2.0
   size: 264551
   timestamp: 1750855472341
-- conda: https://conda.anaconda.org/conda-forge/win-64/aws-crt-cpp-0.29.7-h0642867_7.conda
-  sha256: dfd3375bc197e5cd2221dcddd0d8d6c42344ad9ea7c22112adcc94ec0ba43994
-  md5: ff9d226385f7b626b1db36120a1fa36b
+- conda: https://conda.anaconda.org/conda-forge/win-64/aws-crt-cpp-0.32.10-h16ee0b7_3.conda
+  sha256: b6296041601468020b851e7ce002243c890e6b29bda7a9a0a967d872ebfedaa0
+  md5: dd7c1e9f9a0930549e9e1eed0cca0c72
   depends:
-  - aws-c-auth >=0.8.0,<0.8.1.0a0
-  - aws-c-cal >=0.8.1,<0.8.2.0a0
-  - aws-c-common >=0.10.6,<0.10.7.0a0
-  - aws-c-event-stream >=0.5.0,<0.5.1.0a0
-  - aws-c-http >=0.9.2,<0.9.3.0a0
-  - aws-c-io >=0.15.3,<0.15.4.0a0
-  - aws-c-mqtt >=0.11.0,<0.11.1.0a0
-  - aws-c-s3 >=0.7.7,<0.7.8.0a0
-  - aws-c-sdkutils >=0.2.1,<0.2.2.0a0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  - ucrt >=10.0.20348.0
+  - aws-c-mqtt >=0.13.1,<0.13.2.0a0
+  - aws-c-cal >=0.9.2,<0.9.3.0a0
+  - aws-c-common >=0.12.4,<0.12.5.0a0
+  - aws-c-s3 >=0.8.3,<0.8.4.0a0
+  - aws-c-sdkutils >=0.2.4,<0.2.5.0a0
+  - aws-c-http >=0.10.2,<0.10.3.0a0
+  - aws-c-io >=0.21.0,<0.21.1.0a0
+  - aws-c-event-stream >=0.5.5,<0.5.6.0a0
+  - aws-c-auth >=0.9.0,<0.9.1.0a0
   license: Apache-2.0
-  license_family: Apache
-  size: 262833
-  timestamp: 1734178062584
+  license_family: APACHE
+  size: 298057
+  timestamp: 1752278435721
 - conda: https://conda.anaconda.org/conda-forge/win-64/aws-crt-cpp-0.32.10-h1aa98f0_1.conda
   sha256: 19a13db5eb2d73fd528f02d5f45732cfb6d6048cede06ea9008a24dacbd43c1b
   md5: e8d9e6d7f3c8539783de298728b776c6
@@ -8626,22 +8660,24 @@ packages:
   license: Apache-2.0
   size: 3066397
   timestamp: 1751089146517
-- conda: https://conda.anaconda.org/conda-forge/win-64/aws-sdk-cpp-1.11.458-h5f5f9c4_4.conda
-  sha256: 89d285f1f0878900150487686d7471a6f98563a03b9754f819e08a1c5df292c0
-  md5: bf0f2ff816f47326f932c66badef8192
+- conda: https://conda.anaconda.org/conda-forge/win-64/aws-sdk-cpp-1.11.510-h41ea3a3_14.conda
+  sha256: a9942cd453a3f1cc95a9448be0d789c4eddb6f52a482b89f9efca76e2714cb95
+  md5: 36fc9d2039e4c20397ebfc1e88360981
   depends:
-  - aws-c-common >=0.10.6,<0.10.7.0a0
-  - aws-c-event-stream >=0.5.0,<0.5.1.0a0
-  - aws-checksums >=0.2.2,<0.2.3.0a0
-  - aws-crt-cpp >=0.29.7,<0.29.8.0a0
-  - libzlib >=1.3.1,<2.0a0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  - ucrt >=10.0.20348.0
+  - libzlib >=1.3.1,<2.0a0
+  - aws-c-common >=0.12.4,<0.12.5.0a0
+  - aws-c-event-stream >=0.5.5,<0.5.6.0a0
+  - aws-crt-cpp >=0.32.10,<0.32.11.0a0
   license: Apache-2.0
-  license_family: Apache
-  size: 2969711
-  timestamp: 1734094848306
+  license_family: APACHE
+  size: 3335173
+  timestamp: 1752300942166
 - conda: https://conda.anaconda.org/conda-forge/win-64/aws-sdk-cpp-1.11.510-hd13e2d4_12.conda
   sha256: 537f2c0751c7b7e59fb55b69ce736fb203f510ea0b9761917ed8256a52753140
   md5: c65de3f2c8364602aab241e735ca516e
@@ -9710,19 +9746,6 @@ packages:
   license_family: MIT
   size: 2890950
   timestamp: 1750171270223
-- conda: https://conda.anaconda.org/conda-forge/win-64/capnproto-1.0.2-hb5d7e06_3.conda
-  sha256: 3f105d2e1591543cb3749e4f6d256d539783eb88231852d05fd431da521df109
-  md5: c40f782e2c06150a1da3d690eae2c480
-  depends:
-  - libzlib >=1.3.1,<2.0a0
-  - openssl >=3.3.2,<4.0a0
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  license: MIT
-  license_family: MIT
-  size: 8491858
-  timestamp: 1730915546343
 - conda: https://conda.anaconda.org/conda-forge/win-64/capnproto-1.2.0-h3a793f1_0.conda
   sha256: 68d03e9fa7a99d07ec482dc9846e9e6217bf0526726444ad2e4ceac4bc2f8312
   md5: c17f27064ac3449424a46404bcfa4b11
@@ -10083,18 +10106,18 @@ packages:
   license: LicenseRef-fitsio
   size: 604450
   timestamp: 1743648753956
-- conda: https://conda.anaconda.org/conda-forge/win-64/cfitsio-4.5.0-h2b45a09_0.conda
-  sha256: 5675d7c6aa577a796000370690b34235d6d5718eb08b723c68154d03c3c18b8b
-  md5: b9d111756e45cee15f48d8d45ae9321d
+- conda: https://conda.anaconda.org/conda-forge/win-64/cfitsio-4.6.2-h023ae6c_1.conda
+  sha256: 91199204c642ad9adccda1e7945d6cda1567494cafdf551599389e3b95c2afaa
+  md5: afa7f28ec7439e1ec288a1c9ec32d82b
   depends:
-  - libcurl >=8.11.1,<9.0a0
+  - libcurl >=8.14.1,<9.0a0
   - libzlib >=1.3.1,<2.0a0
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   license: LicenseRef-fitsio
-  size: 600300
-  timestamp: 1734915518512
+  size: 620647
+  timestamp: 1753287420283
 - conda: https://conda.anaconda.org/conda-forge/win-64/cfitsio-4.6.2-h2b45a09_0.conda
   sha256: d552b0232eff99bf3d96cae6a17c29302faf08b53a0635f63a45a0a4e774f997
   md5: 5cbab21073fd5eea27cebbfa28ef3a33
@@ -10761,25 +10784,25 @@ packages:
   license_family: GPL
   size: 2551398
   timestamp: 1744009766652
-- conda: https://conda.anaconda.org/conda-forge/win-64/cppcheck-2.17.1-py311h7219fd6_0.conda
-  sha256: a523b304e5cf8fac55c0defadca6e695d4071369f951e72b15429eab928f7494
-  md5: d92d5ae47fea6390e38f31421fff4e47
+- conda: https://conda.anaconda.org/conda-forge/win-64/cppcheck-2.18.3-py311he12220e_1.conda
+  sha256: 904c5ed11fa6a481d56ddab2c86aaa188632af5eddc52165b79eeeb3520b3007
+  md5: 7333281fb2e0f5ecd462e6e8051523f3
   depends:
   - pygments
   - python
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
+  - tinyxml2 >=11.0.0,<11.1.0a0
   - pcre >=8.45,<9.0a0
-  - tinyxml2 >=10.0.0,<10.1.0a0
   - python_abi 3.11.* *_cp311
   license: GPL-3.0-or-later
   license_family: GPL
-  size: 20404
-  timestamp: 1744009739777
+  size: 2404937
+  timestamp: 1757440313815
 - conda: https://conda.anaconda.org/conda-forge/linux-64/cppzmq-4.10.0-h2e2a08d_1.conda
   sha256: 68da3b05fc2de16c28ed7dbd2a7c2eff05de308996eaa0f21f74618fe3afa52f
   md5: 2ed8fb92772e2a7265b261e0885d3549
@@ -11234,6 +11257,33 @@ packages:
   license_family: BSD
   size: 13348737
   timestamp: 1747763252027
+- conda: https://conda.anaconda.org/conda-forge/win-64/dartsim-cpp-6.15.0-h9d64fd1_10.conda
+  sha256: d35503cd81ffe02f01aac438382c44c5e21f13a2eb056ccd8ab081481a2770a6
+  md5: 3c68b0efd93386ddf07b4876b4cd39c1
+  depends:
+  - assimp >=5.4.3,<5.4.4.0a0
+  - bullet-cpp >=3.25,<3.26.0a0
+  - eigen
+  - fcl >=0.7.0,<0.8.0a0
+  - fmt >=11.2.0,<11.3.0a0
+  - freeglut >=3.2.2,<4.0a0
+  - imgui >=1.92.0,<1.92.1.0a0
+  - ipopt >=3.14.17,<3.14.18.0a0
+  - libboost >=1.86.0,<1.87.0a0
+  - libode >=0.16.5,<0.16.6.0a0
+  - nlopt >=2.10.0,<2.11.0a0
+  - octomap >=1.10.0,<1.11.0a0
+  - openscenegraph >=3.6.5,<3.7.0a0
+  - pagmo >=2.19.1,<2.20.0a0
+  - tinyxml2 >=11.0.0,<11.1.0a0
+  - ucrt >=10.0.20348.0
+  - urdfdom >=4.0.1,<4.1.0a0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 29153643
+  timestamp: 1751414061481
 - conda: https://conda.anaconda.org/conda-forge/win-64/dartsim-cpp-6.15.0-hc0ec675_9.conda
   sha256: 0bcc7394c0203079c10181112593c08498d08e93759ff03339e20eed56d188c0
   md5: 17a136a2357a65073747f2e4058b1adb
@@ -11261,33 +11311,6 @@ packages:
   license_family: BSD
   size: 29045096
   timestamp: 1747765809228
-- conda: https://conda.anaconda.org/conda-forge/win-64/dartsim-cpp-6.15.0-hd3a921c_6.conda
-  sha256: 05a7df35fe102873b6a0efa66a37faca5529d3105b5cf1025725ab69eb9b261b
-  md5: ff8a243be011aa17ae61dcd24d773031
-  depends:
-  - assimp >=5.4.3,<5.4.4.0a0
-  - bullet-cpp >=3.25,<3.26.0a0
-  - eigen
-  - fcl >=0.7.0,<0.8.0a0
-  - fmt >=11.0.2,<11.1a0
-  - freeglut >=3.2.2,<4.0a0
-  - imgui >=1.91.9,<1.91.10.0a0
-  - ipopt >=3.14.17,<3.14.18.0a0
-  - libboost >=1.86.0,<1.87.0a0
-  - libode >=0.16.5,<0.16.6.0a0
-  - nlopt >=2.10.0,<2.11.0a0
-  - octomap >=1.10.0,<1.11.0a0
-  - openscenegraph >=3.6.5,<3.7.0a0
-  - pagmo >=2.19.1,<2.20.0a0
-  - tinyxml2 >=10.0.0,<10.1.0a0
-  - ucrt >=10.0.20348.0
-  - urdfdom >=4.0.1,<4.1.0a0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  license: BSD-2-Clause
-  license_family: BSD
-  size: 29151634
-  timestamp: 1742672818074
 - conda: https://conda.anaconda.org/conda-forge/linux-64/dav1d-1.2.1-hd590300_0.conda
   sha256: 22053a5842ca8ee1cf8e1a817138cdb5e647eb2c46979f84153f6ad7bde73020
   md5: 418c6ca5929a611cbd69204907a83995
@@ -11725,6 +11748,18 @@ packages:
   license_family: MIT
   size: 233759
   timestamp: 1743432150740
+- conda: https://conda.anaconda.org/conda-forge/win-64/expat-2.7.3-hac47afa_0.conda
+  sha256: b91490d9ac1b8e1f7eb45b36746c21c71ad7f751c2ea2dd4e9e80a229952f1b8
+  md5: c55cee28229fcbcd132d900db283650f
+  depends:
+  - libexpat 2.7.3 hac47afa_0
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  license: MIT
+  license_family: MIT
+  size: 128638
+  timestamp: 1763550100961
 - conda: https://conda.anaconda.org/conda-forge/linux-64/fcl-0.7.0-h543440a_8.conda
   sha256: b082e91c7309ffed0aa01d97aa7c7acc8deddad152211153dce381817a4ef4f6
   md5: eb7214feba07f44bff77a3ad510231a9
@@ -12338,19 +12373,6 @@ packages:
   license_family: BSD
   size: 1468161
   timestamp: 1747942874136
-- conda: https://conda.anaconda.org/conda-forge/win-64/flann-1.9.2-h48fefe0_4.conda
-  sha256: 1966826bc297c735f4dc9e83d2daedc55670191bb37f00eb482539b7aeee14e6
-  md5: ca1da882e87e06d283d6795e3682ef31
-  depends:
-  - hdf5 >=1.14.3,<1.14.4.0a0
-  - lz4-c >=1.10.0,<1.11.0a0
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 4202486
-  timestamp: 1733525099562
 - conda: https://conda.anaconda.org/conda-forge/win-64/flann-1.9.2-hb1d4b56_5.conda
   sha256: 42d8c71118271023dfc34d23e8757e4661502a345e12b2355b8860a6e40bba67
   md5: 3f51bb7ae675f3d519c2576fcc46e8e6
@@ -12446,17 +12468,6 @@ packages:
   license_family: MIT
   size: 178005
   timestamp: 1742833557859
-- conda: https://conda.anaconda.org/conda-forge/win-64/fmt-11.0.2-hf4da5c8_1.conda
-  sha256: ecadffd95f09614aff9d520db9f7ccd677c90c3bfb4d3b2981c36ce61562f81b
-  md5: bde3a8f593f24929b8a6e4be0ff009cf
-  depends:
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  license: MIT
-  license_family: MIT
-  size: 190055
-  timestamp: 1743031131636
 - conda: https://conda.anaconda.org/conda-forge/win-64/fmt-11.1.4-h5f12afc_1.conda
   sha256: fd88cd4796572d649da4d249ffb91bd387558c75ab14ad344b7ac45f714079b6
   md5: 65be2289e596e757fc03a5383072a2e7
@@ -12468,6 +12479,17 @@ packages:
   license_family: MIT
   size: 184746
   timestamp: 1742833874774
+- conda: https://conda.anaconda.org/conda-forge/win-64/fmt-11.2.0-h1d4551f_0.conda
+  sha256: 890f2789e55b509ff1f14592a5b20a0d0ec19f6da463eff96e378a5d70f882da
+  md5: 15b63c3fb5b7d67b1cb63553a33e6090
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  license: MIT
+  license_family: MIT
+  size: 185995
+  timestamp: 1751277236879
 - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-dejavu-sans-mono-2.37-hab24e00_0.tar.bz2
   sha256: 58d7f40d2940dd0a8aa28651239adbf5613254df0f75789919c4e6762054403b
   md5: 0c96522c6bdaed4b1566d11387caaf45
@@ -13623,40 +13645,40 @@ packages:
   license_family: APACHE
   size: 57791277
   timestamp: 1749943890489
-- conda: https://conda.anaconda.org/conda-forge/win-64/gazebo-11.15.1-gzcompatnameh4f5da94_0.conda
-  sha256: 0b2f7fe46748a9dc9a7d228aa05e0774ee156ccea57ec75db6f288200916dcde
-  md5: 47b5259c87893d0792a059a7129a484f
+- conda: https://conda.anaconda.org/conda-forge/win-64/gazebo-11.15.1-gzcompatnamehcc919ea_4.conda
+  sha256: feddd25803e945700b315fb493f37facb15bfc5a6f785bb25894777be5a9e2dd
+  md5: 4c4c9e9b245029eae784f39e62588486
   depends:
   - assimp >=5.4.3,<5.4.4.0a0
   - dartsim-cpp >=6.15.0,<6.16.0a0
   - dlfcn-win32 >=1.4.1,<2.0a0
-  - ffmpeg >=7.1.0,<8.0a0
+  - ffmpeg >=7.1.1,<8.0a0
   - freeimage >=3.18.0,<3.19.0a0
-  - graphviz >=12.0.0,<13.0a0
-  - hdf5 >=1.14.3,<1.14.4.0a0
+  - graphviz >=12.2.1,<13.0a0
+  - hdf5 >=1.14.6,<1.14.7.0a0
   - libabseil * cxx17*
-  - libabseil >=20240722.0,<20240723.0a0
+  - libabseil >=20250127.1,<20250128.0a0
   - libblas >=3.9.0,<4.0a0
   - libboost >=1.86.0,<1.87.0a0
   - libboost-devel
   - libcblas >=3.9.0,<4.0a0
   - libccd-double >=2.1,<2.2.0a0
-  - libcurl >=8.10.1,<9.0a0
-  - libgdal >=3.10.0,<3.11.0a0
-  - libgdal-core >=3.10.0,<3.11.0a0
+  - libcurl >=8.13.0,<9.0a0
+  - libgdal >=3.11.0,<3.12.0a0
+  - libgdal-core >=3.11.0,<3.12.0a0
   - libignition-cmake2 >=2.17.2,<3.0a0
-  - libignition-common3 >=3.15.1,<4.0a0
+  - libignition-common3 >=3.17.1,<4.0a0
   - libignition-fuel-tools4 >=4.6.0,<5.0a0
   - libignition-math6 >=6.15.1,<7.0a0
   - libignition-msgs5 >=5.11.0,<6.0a0
   - libignition-transport8 >=8.4.0,<9.0a0
   - libode >=0.16.5,<0.16.6.0a0
-  - libprotobuf >=5.28.2,<5.28.3.0a0
+  - libprotobuf >=5.29.3,<5.29.4.0a0
   - libsdformat >=9.8.0,<10.0a0
-  - libusb >=1.0.27,<2.0a0
+  - libusb >=1.0.28,<2.0a0
   - ogre >=1.10.12.1
   - ogre >=1.10.12.1,<1.11.0a0
-  - openal-soft >=1.23.1,<1.24.0a0
+  - openal-soft >=1.24.3,<1.25.0a0
   - qt-main >=5.15.15,<5.16.0a0
   - qwt >=6.3.0,<6.4.0a0
   - simbody >=3.7,<3.8.0a0
@@ -13664,15 +13686,15 @@ packages:
   - tbb-devel
   - tiny-process-library >=2.0.4,<2.1.0a0
   - tinyxml
-  - tinyxml2 >=10.0.0,<10.1.0a0
+  - tinyxml2 >=11.0.0,<11.1.0a0
   - ucrt >=10.0.20348.0
   - urdfdom >=4.0.1,<4.1.0a0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
   license: Apache-2.0
   license_family: APACHE
-  size: 60344089
-  timestamp: 1733283266176
+  size: 58619983
+  timestamp: 1748020143515
 - conda: https://conda.anaconda.org/conda-forge/win-64/gazebo-11.15.1-gzcompatnamehda58bb1_5.conda
   sha256: 30dd3cf2149b93855358ce6f5cf1f39af03a99cbe4d0f5ac8eb6ab5b896991d5
   md5: c74cc9730cb507c17b6b2fa6605ba699
@@ -13956,16 +13978,6 @@ packages:
   license: LGPL-2.1-only
   size: 1470335
   timestamp: 1741051878236
-- conda: https://conda.anaconda.org/conda-forge/win-64/geos-3.13.0-h5a68840_0.conda
-  sha256: 2b46d6f304f70dfca304169299908b558bd1e83992acb5077766eefa3d3fe35f
-  md5: 08a30fe29a645fc5c768c0968db116d3
-  depends:
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  license: LGPL-2.1-only
-  size: 1665961
-  timestamp: 1725676536384
 - conda: https://conda.anaconda.org/conda-forge/win-64/geos-3.13.1-h9ea8674_0.conda
   sha256: 8b2dd4b831ddac64584d49b50f0547c90f5b352a7ec62f941686bb59c21d6055
   md5: 2ebe8eb886545cdc287324d41186a698
@@ -14037,22 +14049,6 @@ packages:
   license_family: MIT
   size: 112457
   timestamp: 1739974826028
-- conda: https://conda.anaconda.org/conda-forge/win-64/geotiff-1.7.4-h887f4e7_0.conda
-  sha256: f0435dd63c97ad9e8d35a2c1d55c823c50dac82a8dffd8d41c79c0305fa0cc2b
-  md5: d5edee34ab83553450b1225cf0a14273
-  depends:
-  - libjpeg-turbo >=3.0.0,<4.0a0
-  - libtiff >=4.7.0,<4.8.0a0
-  - libzlib >=1.3.1,<2.0a0
-  - proj >=9.5.1,<9.6.0a0
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  - zlib
-  license: MIT
-  license_family: MIT
-  size: 123341
-  timestamp: 1739975151946
 - conda: https://conda.anaconda.org/conda-forge/win-64/getopt-win32-0.1-h6a83c73_3.conda
   sha256: d04c4a6c11daa72c4a0242602e1d00c03291ef66ca2d7cd0e171088411d57710
   md5: 49c36fcad2e9af6b91e91f2ce5be8ebd
@@ -14492,23 +14488,6 @@ packages:
   license: LGPL-2.1-or-later
   size: 591283
   timestamp: 1747837135361
-- conda: https://conda.anaconda.org/conda-forge/win-64/glib-2.84.1-h3d4babf_0.conda
-  sha256: 6b13549cecd8c97f817c617ce4dfeea1443f9a78897a36b9650b13ac441afef9
-  md5: 46ea90576304035d1b6f8d70683b4e18
-  depends:
-  - glib-tools 2.84.1 h4394cf3_0
-  - libffi >=3.4.6,<3.5.0a0
-  - libglib 2.84.1 h7025463_0
-  - libintl >=0.22.5,<1.0a0
-  - libintl-devel
-  - packaging
-  - python *
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  license: LGPL-2.1-or-later
-  size: 578531
-  timestamp: 1743774341949
 - conda: https://conda.anaconda.org/conda-forge/win-64/glib-2.84.2-he8f994d_0.conda
   sha256: 0c54bf4eb6ba33ff1daa4c3253f312cd5e8ea7712658da1715f06b981ceb292a
   md5: 9ee1a3bd16512c6bc565d436e7f5ccf8
@@ -14526,6 +14505,23 @@ packages:
   license: LGPL-2.1-or-later
   size: 579053
   timestamp: 1747837510188
+- conda: https://conda.anaconda.org/conda-forge/win-64/glib-2.84.3-h36503ca_0.conda
+  sha256: c86d4ca8c3084d9cd33d18a9b13f484722d6a5eb306e5b77aa1087603c9c62b0
+  md5: 5f92085cb2bc2cc516df14d76e6b6c0f
+  depends:
+  - glib-tools 2.84.3 he647baa_0
+  - libffi >=3.4.6,<3.5.0a0
+  - libglib 2.84.3 h1c1036b_0
+  - libintl >=0.22.5,<1.0a0
+  - libintl-devel
+  - packaging
+  - python *
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  license: LGPL-2.1-or-later
+  size: 574659
+  timestamp: 1754315482929
 - conda: https://conda.anaconda.org/conda-forge/linux-64/glib-networking-2.80.0-h2ef3c98_0.conda
   sha256: 9aecd58fe3f3f8179fe7fe8b08c6494d5ea35ccf44ec42b58d5a0d25d782708c
   md5: 3081eba855a71319a77a5325a43d755a
@@ -14674,18 +14670,6 @@ packages:
   license: LGPL-2.1-or-later
   size: 101786
   timestamp: 1747837093760
-- conda: https://conda.anaconda.org/conda-forge/win-64/glib-tools-2.84.1-h4394cf3_0.conda
-  sha256: 48dd6d1b46595be7295ada6f10d2e44f03c6295d9922113efec1f7b8d3886d6c
-  md5: ad2deb7544fcd1325b2c47173c1082f4
-  depends:
-  - libglib 2.84.1 h7025463_0
-  - libintl >=0.22.5,<1.0a0
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  license: LGPL-2.1-or-later
-  size: 97449
-  timestamp: 1743774304927
 - conda: https://conda.anaconda.org/conda-forge/win-64/glib-tools-2.84.2-h4394cf3_0.conda
   sha256: 7f6a9912fbc8da4c54f71d214d232e76dd9569dbd9d7935a995cbec0e8f1297e
   md5: 005261b72de4f05b6322733c178f1b56
@@ -14698,6 +14682,18 @@ packages:
   license: LGPL-2.1-or-later
   size: 97601
   timestamp: 1747837459018
+- conda: https://conda.anaconda.org/conda-forge/win-64/glib-tools-2.84.3-he647baa_0.conda
+  sha256: 3cda9c0aadfff70be2f7b48b1a13aae2bbcc6bcda4ef7784d3d94364575746c7
+  md5: 0c4c0fe0c2da1a192268ef7beab8b3e9
+  depends:
+  - libglib 2.84.3 h1c1036b_0
+  - libintl >=0.22.5,<1.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  license: LGPL-2.1-or-later
+  size: 98161
+  timestamp: 1754315429043
 - conda: https://conda.anaconda.org/conda-forge/linux-64/glm-1.0.1-hdd259ec_0.conda
   sha256: 5ad4c30a20b4a3600fc88ffa5c5a90b925091a87188d9cbf70c45ff7e5e0275c
   md5: ed0ddc674dd6581b57229f4a19d2ba94
@@ -14786,15 +14782,15 @@ packages:
   license_family: BSD
   size: 7030
   timestamp: 1722458155746
-- conda: https://conda.anaconda.org/conda-forge/win-64/gmock-1.15.2-h57928b3_0.conda
-  sha256: 88b0582c94c433fe929e32dc88ddb38a24973e07c4f0e35345b257fe62b00290
-  md5: 1f94ef86a939ec4db1939186c002a621
+- conda: https://conda.anaconda.org/conda-forge/win-64/gmock-1.17.0-h57928b3_1.conda
+  sha256: 833b2320a8f9e2742114342070634e002ca2b094d8cadcfe03a6e8339938df26
+  md5: 6c8e74d3fd2b75971e931b3b8e37b4cb
   depends:
-  - gtest 1.15.2 hc790b64_0
+  - gtest 1.17.0 hc790b64_1
   license: BSD-3-Clause
   license_family: BSD
-  size: 7364
-  timestamp: 1722458392601
+  size: 8054
+  timestamp: 1748320557126
 - conda: https://conda.anaconda.org/conda-forge/linux-64/gmp-6.3.0-hac33072_2.conda
   sha256: 309cf4f04fec0c31b6771a5809a1909b4b3154a2208f52351e1ada006f4c750c
   md5: c94a5994ef49749880a8139cf9afcbe1
@@ -15751,19 +15747,6 @@ packages:
   license_family: BSD
   size: 378391
   timestamp: 1748320218212
-- conda: https://conda.anaconda.org/conda-forge/win-64/gtest-1.15.2-hc790b64_0.conda
-  sha256: d2f8f770ad40c1e5857fd79d2cfdb087d45f3e7fdc922a0c81bdd215c350a8ad
-  md5: d3be2a4f511c28dc626bdb3c5dc297c6
-  depends:
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  constrains:
-  - gmock 1.15.2
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 502351
-  timestamp: 1722458363989
 - conda: https://conda.anaconda.org/conda-forge/win-64/gtest-1.17.0-hc790b64_1.conda
   sha256: 6738f3af9fe0cff9b8bd54eab34544e0334f2932c4314e1cb1b322ba7a5f26b7
   md5: 0314c047c9d7ffc19cfd13457d82e254
@@ -16104,16 +16087,16 @@ packages:
   license_family: APACHE
   size: 12773
   timestamp: 1743933013428
-- conda: https://conda.anaconda.org/conda-forge/win-64/gz-sim9-9.0.0-h1ea47a8_3.conda
-  sha256: ea3483d45bec1a3aa127b7ace057d251fe5e309a74652837dbbe05d522e5a01c
-  md5: a9b2ce473754bc7f3e51aced34c859a8
+- conda: https://conda.anaconda.org/conda-forge/win-64/gz-sim9-9.0.0-h1ea47a8_7.conda
+  sha256: 353e5bf6a1c669a45576e10bc52f51bf099c0e6dfb9bd3c83f0186511e9c62a0
+  md5: 94ffa29ab03aac5eb2dd0797cc16a632
   depends:
   - gz-sim9-python >=9.0.0,<9.0.1.0a0
-  - libgz-sim9 9.0.0 h8fb2a06_3
+  - libgz-sim9 9.0.0 ha248be3_7
   license: Apache-2.0
   license_family: APACHE
-  size: 12661
-  timestamp: 1733420188141
+  size: 13054
+  timestamp: 1753372072605
 - conda: https://conda.anaconda.org/conda-forge/win-64/gz-sim9-9.0.0-hcbf5309_7.conda
   sha256: 7670132b3b0974df42d526a841f3236a679c13886114ed42560ff4974c259d1b
   md5: 24c9c712a6ae84d0b0ce3fe3e3c59c67
@@ -16290,26 +16273,26 @@ packages:
   license_family: APACHE
   size: 169429
   timestamp: 1733419933368
-- conda: https://conda.anaconda.org/conda-forge/win-64/gz-sim9-python-9.0.0-py311h517b7c6_3.conda
-  sha256: e3dd7382a52ee6b61deaef238a67dbf042603df850d546ec21ef3e9267677151
-  md5: 6781cce59de46d541c6dd4bcfefb6028
+- conda: https://conda.anaconda.org/conda-forge/win-64/gz-sim9-python-9.0.0-py311h092c819_7.conda
+  sha256: 15b397a22ab791edf72b30f71d5adf07b3457aaee3b73b22b4694aa7d8c7c65c
+  md5: 66dc2ad3e539f4aab0d976420818f377
   depends:
   - libabseil * cxx17*
-  - libabseil >=20240722.0,<20240723.0a0
-  - libgz-common6 >=6.0.0,<7.0a0
-  - libgz-msgs11 >=11.0.1,<12.0a0
-  - libgz-sim9 9.0.0 h8fb2a06_3
-  - libprotobuf >=5.28.2,<5.28.3.0a0
-  - pybind11-abi 4
+  - libabseil >=20250127.1,<20250128.0a0
+  - libgz-common6 >=6.1.0,<7.0a0
+  - libgz-msgs11 >=11.1.0,<12.0a0
+  - libgz-sim9 9.0.0 ha248be3_7
+  - libprotobuf >=5.29.3,<5.29.4.0a0
+  - pybind11-abi 11
   - python >=3.11,<3.12.0a0
   - python_abi 3.11.* *_cp311
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   license: Apache-2.0
   license_family: APACHE
-  size: 150306
-  timestamp: 1733420181404
+  size: 158929
+  timestamp: 1753372067302
 - conda: https://conda.anaconda.org/conda-forge/win-64/gz-sim9-python-9.0.0-py39h5eec5bb_7.conda
   sha256: 7e73a5cc8025388b5dfcc36b9431d95fcfad30eff080601a8f66b1f35493e120
   md5: 55b77eb15b7a0cf171e11be6bb0d8e8f
@@ -16448,22 +16431,6 @@ packages:
   license_family: BSD
   size: 1166678
   timestamp: 1749299603570
-- conda: https://conda.anaconda.org/conda-forge/win-64/h5py-3.13.0-nompi_py311h67016bb_100.conda
-  sha256: 5d36e278a6eeeca22e7d882b4d5e98ee23b900994eb1902aa95f8c582a2a6200
-  md5: 2e6c03df40daaaceb2f8229eff48a22a
-  depends:
-  - cached-property
-  - hdf5 >=1.14.3,<1.14.4.0a0
-  - numpy >=1.19,<3
-  - python >=3.11,<3.12.0a0
-  - python_abi 3.11.* *_cp311
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 1125573
-  timestamp: 1739953000819
 - conda: https://conda.anaconda.org/conda-forge/win-64/h5py-3.14.0-nompi_py39ha907541_100.conda
   sha256: b82a50bd3e4059e1c524848ebfd39f65e39f4eb33c9cac1a1e8f39f2b43a0867
   md5: 8031790ea7aa6628d16290137f93b4a7
@@ -16480,6 +16447,22 @@ packages:
   license_family: BSD
   size: 960550
   timestamp: 1749300074226
+- conda: https://conda.anaconda.org/conda-forge/win-64/h5py-3.15.1-nompi_py311hc40ba4b_101.conda
+  sha256: 98488241676ffb248b9614054d5458d298398377c76f214de737200e77d5e754
+  md5: cf3bc5405710829ee8bec294c2a4b9bc
+  depends:
+  - cached-property
+  - hdf5 >=1.14.6,<1.14.7.0a0
+  - numpy >=1.23,<3
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1072830
+  timestamp: 1764016795703
 - conda: https://conda.anaconda.org/conda-forge/linux-64/harfbuzz-11.2.1-h3beb420_0.conda
   sha256: 5bd0f3674808862838d6e2efc0b3075e561c34309c5c2f4c976f7f1f57c91112
   md5: 0e6e192d4b3d95708ad192d957cf3163
@@ -16611,6 +16594,25 @@ packages:
   license_family: MIT
   size: 1126103
   timestamp: 1747093237683
+- conda: https://conda.anaconda.org/conda-forge/win-64/harfbuzz-11.4.5-h5f2951f_0.conda
+  sha256: e1aaf8cf922cb7c7dabc12ddcad16c218b926c5e43d845288a4a8a0910df1b18
+  md5: e9f9b4c46f6bc9b51adf57909b4d4652
+  depends:
+  - cairo >=1.18.4,<2.0a0
+  - graphite2 >=1.3.14,<2.0a0
+  - icu >=75.1,<76.0a0
+  - libexpat >=2.7.1,<3.0a0
+  - libfreetype >=2.13.3
+  - libfreetype6 >=2.13.3
+  - libglib >=2.84.3,<3.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 1134542
+  timestamp: 1756738659278
 - conda: https://conda.anaconda.org/conda-forge/linux-64/hdf4-4.2.15-h2a13503_7.conda
   sha256: 0d09b6dc1ce5c4005ae1c6a19dc10767932ef9a5e9c755cfdbb5189ac8fb0684
   md5: bd77f8da987968ec3927990495dc22e4
@@ -16802,21 +16804,6 @@ packages:
   license_family: BSD
   size: 3300518
   timestamp: 1745297588690
-- conda: https://conda.anaconda.org/conda-forge/win-64/hdf5-1.14.3-nompi_hb2c4d47_109.conda
-  sha256: d5ada33e119cdd62371c06f60eae6f545de7cea793ab83da2fba428bb1d2f813
-  md5: ebb61f3e8b35cc15e78876649b7246f7
-  depends:
-  - libaec >=1.1.3,<2.0a0
-  - libcurl >=8.11.1,<9.0a0
-  - libzlib >=1.3.1,<2.0a0
-  - openssl >=3.4.0,<4.0a0
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 2045101
-  timestamp: 1737516177829
 - conda: https://conda.anaconda.org/conda-forge/win-64/hdf5-1.14.6-nompi_hd5d9e70_101.conda
   sha256: 64d0ed35edefab9a912084f2806b9c4c4ffe2adcf5225a583088abbaafe5dbae
   md5: ea68eb3a15c51875468475c2647a2d23
@@ -16832,6 +16819,21 @@ packages:
   license_family: BSD
   size: 2021539
   timestamp: 1745297528030
+- conda: https://conda.anaconda.org/conda-forge/win-64/hdf5-1.14.6-nompi_he30205f_103.conda
+  sha256: 0a90263b97e9860cec6c2540160ff1a1fff2a609b3d96452f8716ae63489dac5
+  md5: f1f7aaf642cefd2190582550eaca4658
+  depends:
+  - libaec >=1.1.4,<2.0a0
+  - libcurl >=8.14.1,<9.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.5.1,<4.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 2031491
+  timestamp: 1753357255237
 - conda: https://conda.anaconda.org/conda-forge/linux-64/hicolor-icon-theme-0.17-ha770c72_2.tar.bz2
   sha256: 336f29ceea9594f15cc8ec4c45fdc29e10796573c697ee0d57ebb7edd7e92043
   md5: bbf6f174dcd3254e19a2f5d2295ce808
@@ -17044,6 +17046,22 @@ packages:
   license_family: MIT
   size: 786210
   timestamp: 1742199787019
+- conda: https://conda.anaconda.org/conda-forge/win-64/imgui-1.92.0-he134b7a_0.conda
+  sha256: 36b193154e0b420eb394416744d2c7964b34c41edb462ff195955086d9d10ba2
+  md5: 48b29b2ccebaa23f89cf333fbbc1bc57
+  depends:
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  - ucrt >=10.0.20348.0
+  - sdl2 >=2.32.54,<3.0a0
+  - glfw >=3.4,<4.0a0
+  license: MIT
+  license_family: MIT
+  size: 816204
+  timestamp: 1750923446901
 - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-8.7.0-pyhe01879c_1.conda
   sha256: c18ab120a0613ada4391b15981d86ff777b5690ca461ea7e9e49531e8f374745
   md5: 63ccfdc3a3ce25b027b8767eb722fca8
@@ -17651,18 +17669,18 @@ packages:
   license_family: MIT
   size: 147239
   timestamp: 1746052137696
-- conda: https://conda.anaconda.org/conda-forge/win-64/kealib-1.6.1-hadd4d7f_0.conda
-  sha256: db576ebbd5b12d7666116f8e64b94df1315fa0448b4bd01f1f9234137f604d33
-  md5: b8fbf289fc3c8f201c269c2546f42c1b
+- conda: https://conda.anaconda.org/conda-forge/win-64/kealib-1.6.2-h5949fbd_2.conda
+  sha256: 49051712fc0723f10afbfe4c6355412b2b211e429d88e1caf860958a01738fa9
+  md5: 0b59a4724f1ac048cc7fed0b413d35b7
   depends:
-  - hdf5 >=1.14.3,<1.14.4.0a0
+  - hdf5 >=1.14.6,<1.14.7.0a0
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   license: MIT
   license_family: MIT
-  size: 139352
-  timestamp: 1735703930237
+  size: 143750
+  timestamp: 1762561355218
 - conda: https://conda.anaconda.org/conda-forge/win-64/kealib-1.6.2-h9df79d9_0.conda
   sha256: caa5f2dac72fdb9b3569807d712e2e674f613c60fd929bf0c7515ad1ea7a39b5
   md5: 37eed0b7a610fb0976d147d7ff941435
@@ -18248,20 +18266,6 @@ packages:
   license_family: Apache
   size: 1192962
   timestamp: 1742369814061
-- conda: https://conda.anaconda.org/conda-forge/win-64/libabseil-20240722.0-cxx17_h4eb7d71_4.conda
-  sha256: 846eacff96d36060fe5f7b351e4df6fafae56bf34cc6426497f12b5c13f317cf
-  md5: c57ee7f404d1aa84deb3e15852bec6fa
-  depends:
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  constrains:
-  - abseil-cpp =20240722.0
-  - libabseil-static =20240722.0=cxx17*
-  license: Apache-2.0
-  license_family: Apache
-  size: 1784929
-  timestamp: 1736008778245
 - conda: https://conda.anaconda.org/conda-forge/win-64/libabseil-20250127.1-cxx17_h4eb7d71_0.conda
   sha256: 61ece8d3768604eae2c7c869a5c032a61fbfb8eb86cc85dc39cc2de48d3827b4
   md5: 9619870922c18fa283a3ee703a14cfcc
@@ -18460,25 +18464,6 @@ packages:
   license_family: BSD
   size: 774033
   timestamp: 1745335663024
-- conda: https://conda.anaconda.org/conda-forge/win-64/libarchive-3.7.7-h5343c79_4.conda
-  sha256: fd947dfdcf70b56dad679ec4053cc76cc69b208fb1220072d543482640f56c57
-  md5: 3bb78f661ec0ac3cdbae48c880545f41
-  depends:
-  - bzip2 >=1.0.8,<2.0a0
-  - liblzma >=5.8.1,<6.0a0
-  - libxml2 >=2.13.7,<2.14.0a0
-  - libzlib >=1.3.1,<2.0a0
-  - lz4-c >=1.10.0,<1.11.0a0
-  - lzo >=2.10,<3.0a0
-  - openssl >=3.5.0,<4.0a0
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  - zstd >=1.5.7,<1.6.0a0
-  license: BSD-2-Clause
-  license_family: BSD
-  size: 1085438
-  timestamp: 1745336188302
 - conda: https://conda.anaconda.org/conda-forge/win-64/libarchive-3.8.1-gpl_h1ca5a36_100.conda
   sha256: 7efe65c7ab7056f1a84d5f234584e60ba3cc55b487ba4065a29d23aacb4c5ef6
   md5: d8f4c086758bbf52b30750550cd38b1a
@@ -19635,6 +19620,19 @@ packages:
   license_family: Apache
   size: 28343316
   timestamp: 1749881763774
+- conda: https://conda.anaconda.org/conda-forge/win-64/libclang13-21.1.8-default_ha2db4b5_1.conda
+  sha256: a2e28d6196f83eddb1c62f19ec9c0a95c3ff74660bc732a54ab00332a4b59318
+  md5: 2dfbc5aaac3424065eb81ec9a9f49761
+  depends:
+  - libzlib >=1.3.1,<2.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  - zstd >=1.5.7,<1.6.0a0
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 28993550
+  timestamp: 1767841215595
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libcrc32c-1.1.2-h9c3ff4c_0.tar.bz2
   sha256: fd1d153962764433fe6233f34a72cdeed5dcf8a883a85769e8295ce940b5b0c5
   md5: c965a5aa0d5c1c37ffc62dff36e28400
@@ -19878,17 +19876,6 @@ packages:
   license_family: LGPL
   size: 277861
   timestamp: 1703089176970
-- conda: https://conda.anaconda.org/conda-forge/win-64/libde265-1.0.15-h91493d7_0.conda
-  sha256: f52c603151743486d2faec37e161c60731001d9c955e0f12ac9ad334c1119116
-  md5: 9dc3c1fbc1c7bc6204e8a603f45e156b
-  depends:
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  license: LGPL-3.0-or-later
-  license_family: LGPL
-  size: 252968
-  timestamp: 1703089151021
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libdeflate-1.23-h86f0d12_0.conda
   sha256: 4db2f70a1441317d964e84c268e388110ad9cf75ca98994d1336d670e62e6f07
   md5: 27fe770decaf469a53f3e3a6d593067f
@@ -19963,17 +19950,6 @@ packages:
   license_family: MIT
   size: 54790
   timestamp: 1747040549847
-- conda: https://conda.anaconda.org/conda-forge/win-64/libdeflate-1.23-h76ddb4d_0.conda
-  sha256: 881244050587dc658078ee45dfc792ecb458bbb1fdc861da67948d747b117dc2
-  md5: 34f03138e46543944d4d7f8538048842
-  depends:
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  license: MIT
-  license_family: MIT
-  size: 155548
-  timestamp: 1745260818985
 - conda: https://conda.anaconda.org/conda-forge/win-64/libdeflate-1.24-h76ddb4d_0.conda
   sha256: 65347475c0009078887ede77efe60db679ea06f2b56f7853b9310787fe5ad035
   md5: 08d988e266c6ae77e03d164b83786dc4
@@ -20178,6 +20154,19 @@ packages:
   license_family: MIT
   size: 140896
   timestamp: 1743432122520
+- conda: https://conda.anaconda.org/conda-forge/win-64/libexpat-2.7.3-hac47afa_0.conda
+  sha256: 844ab708594bdfbd7b35e1a67c379861bcd180d6efe57b654f482ae2f7f5c21e
+  md5: 8c9e4f1a0e688eef2e95711178061a0f
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  constrains:
+  - expat 2.7.3.*
+  license: MIT
+  license_family: MIT
+  size: 70137
+  timestamp: 1763550049107
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libffi-3.4.6-h2dba641_1.conda
   sha256: 764432d32db45466e87f10621db5b74363a9f847d2b8b1f9743746cd160f06ab
   md5: ede4673863426c0883c0063d853bbd85
@@ -20754,27 +20743,6 @@ packages:
   license_family: MIT
   size: 427168
   timestamp: 1747849819111
-- conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-3.10.2-hc25ceda_5.conda
-  sha256: 6ddee3b64ce7e923739474a24d307faa1d3f6fc2c2e0d0b081ee61aea8cdb048
-  md5: 8ee5923466019d4a2a8548a8d8cd7312
-  depends:
-  - libgdal-core 3.10.2.*
-  - libgdal-fits 3.10.2.*
-  - libgdal-grib 3.10.2.*
-  - libgdal-hdf4 3.10.2.*
-  - libgdal-hdf5 3.10.2.*
-  - libgdal-jp2openjpeg 3.10.2.*
-  - libgdal-kea 3.10.2.*
-  - libgdal-netcdf 3.10.2.*
-  - libgdal-pdf 3.10.2.*
-  - libgdal-pg 3.10.2.*
-  - libgdal-postgisraster 3.10.2.*
-  - libgdal-tiledb 3.10.2.*
-  - libgdal-xls 3.10.2.*
-  license: MIT
-  license_family: MIT
-  size: 424104
-  timestamp: 1742985864929
 - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-3.11.0-hafd5c6c_5.conda
   sha256: d82bfbe5ed76078068d33c25749b8fc4211bd3c13e79c23606684a38655bd906
   md5: 4c4aca667174745bd2d1244f6ea67601
@@ -20796,6 +20764,27 @@ packages:
   license_family: MIT
   size: 427747
   timestamp: 1749487074816
+- conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-3.11.3-hafd5c6c_6.conda
+  sha256: 79f886be921a89da38d080c5c235028e36798fa3e7822bcc0f5af38f461a7c70
+  md5: cb85acdc811b0c12422ae51ac082478c
+  depends:
+  - libgdal-core 3.11.3.*
+  - libgdal-fits 3.11.3.*
+  - libgdal-grib 3.11.3.*
+  - libgdal-hdf4 3.11.3.*
+  - libgdal-hdf5 3.11.3.*
+  - libgdal-jp2openjpeg 3.11.3.*
+  - libgdal-kea 3.11.3.*
+  - libgdal-netcdf 3.11.3.*
+  - libgdal-pdf 3.11.3.*
+  - libgdal-pg 3.11.3.*
+  - libgdal-postgisraster 3.11.3.*
+  - libgdal-tiledb 3.11.3.*
+  - libgdal-xls 3.11.3.*
+  license: MIT
+  license_family: MIT
+  size: 427527
+  timestamp: 1756992557711
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-adbc-3.11.0-hbf74d7f_4.conda
   sha256: 3ca90e3ab248871a13c860a4dae1ae655d0208dd34210c08ea758beacf10c972
   md5: 2a11b4ff9c27f8db01eb4d7f8891bb23
@@ -21165,45 +21154,6 @@ packages:
   license_family: MIT
   size: 9224742
   timestamp: 1747846167209
-- conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-core-3.10.2-h095903c_0.conda
-  sha256: e387998eee0468570dd87764d0c78d94f7d9d5846cdfa050f71f3fe01f8941b9
-  md5: 91f3b8afc65762e8710b50bdda8116c7
-  depends:
-  - blosc >=1.21.6,<2.0a0
-  - geos >=3.13.0,<3.13.1.0a0
-  - geotiff >=1.7.3,<1.8.0a0
-  - lerc >=4.0.0,<5.0a0
-  - libarchive >=3.7.7,<3.8.0a0
-  - libcurl >=8.12.1,<9.0a0
-  - libdeflate >=1.23,<1.24.0a0
-  - libexpat >=2.6.4,<3.0a0
-  - libheif >=1.19.5,<1.20.0a0
-  - libiconv >=1.17,<2.0a0
-  - libjpeg-turbo >=3.0.0,<4.0a0
-  - libkml >=1.3.0,<1.4.0a0
-  - liblzma >=5.6.4,<6.0a0
-  - libpng >=1.6.46,<1.7.0a0
-  - libspatialite >=5.1.0,<5.2.0a0
-  - libsqlite >=3.48.0,<4.0a0
-  - libtiff >=4.7.0,<4.8.0a0
-  - libwebp-base >=1.5.0,<2.0a0
-  - libxml2 >=2.13.5,<2.14.0a0
-  - libzlib >=1.3.1,<2.0a0
-  - lz4-c >=1.10.0,<1.11.0a0
-  - openssl >=3.4.1,<4.0a0
-  - pcre2 >=10.44,<10.45.0a0
-  - proj >=9.5.1,<9.6.0a0
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  - xerces-c >=3.2.5,<3.3.0a0
-  - zstd >=1.5.6,<1.6.0a0
-  constrains:
-  - libgdal 3.10.2.*
-  license: MIT
-  license_family: MIT
-  size: 8392331
-  timestamp: 1739628560888
 - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-core-3.11.0-hc18f78f_5.conda
   sha256: 7b235f584286e70acd8c43673f29b0d3a980e5f2a66f1ab97602382727e6af91
   md5: 430f27f4a5f708bcd80c14bb252600dd
@@ -21242,6 +21192,44 @@ packages:
   license_family: MIT
   size: 9115000
   timestamp: 1749482056782
+- conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-core-3.11.3-hddc0a0b_0.conda
+  sha256: 3427e93fabc1ba36f08e40dbc4e5ba4f36f8745db683bffa36077c16856ee0f9
+  md5: e485347cc82c77c59f921cf0bd34bf5c
+  depends:
+  - blosc >=1.21.6,<2.0a0
+  - geos >=3.13.1,<3.13.2.0a0
+  - lerc >=4.0.0,<5.0a0
+  - libarchive >=3.8.1,<3.9.0a0
+  - libcurl >=8.14.1,<9.0a0
+  - libdeflate >=1.24,<1.25.0a0
+  - libexpat >=2.7.0,<3.0a0
+  - libiconv >=1.18,<2.0a0
+  - libjpeg-turbo >=3.1.0,<4.0a0
+  - libjxl >=0.11,<0.12.0a0
+  - libkml >=1.3.0,<1.4.0a0
+  - liblzma >=5.8.1,<6.0a0
+  - libpng >=1.6.50,<1.7.0a0
+  - libspatialite >=5.1.0,<5.2.0a0
+  - libsqlite >=3.50.2,<4.0a0
+  - libwebp-base >=1.6.0,<2.0a0
+  - libxml2 >=2.13.8,<2.14.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - lz4-c >=1.10.0,<1.11.0a0
+  - muparser >=2.3.5,<2.4.0a0
+  - openssl >=3.5.1,<4.0a0
+  - pcre2 >=10.45,<10.46.0a0
+  - proj >=9.6.2,<9.7.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  - xerces-c >=3.2.5,<3.3.0a0
+  - zstd >=1.5.7,<1.6.0a0
+  constrains:
+  - libgdal 3.11.3.*
+  license: MIT
+  license_family: MIT
+  size: 9235942
+  timestamp: 1752349975077
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-fits-3.10.2-h872822d_0.conda
   sha256: 2ce2418716fd1f94f26ad269eb9285e1d293d4c26124b7d2325a86e773a49c3a
   md5: 14bc7ec4cb683a0694f3a717777c7ff0
@@ -21348,21 +21336,6 @@ packages:
   license_family: MIT
   size: 469379
   timestamp: 1747848122789
-- conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-fits-3.10.2-h20f9414_0.conda
-  sha256: a3920822201e963fdfc0a35a9ce1d198c6e5cceadba6fecc30a7ec78c5beda2f
-  md5: cac882a9d86c931ac9bbe892fa369b9e
-  depends:
-  - cfitsio >=4.5.0,<4.5.1.0a0
-  - libgdal-core 3.10.2 h095903c_0
-  - libkml >=1.3.0,<1.4.0a0
-  - liblzma >=5.6.4,<6.0a0
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  license: MIT
-  license_family: MIT
-  size: 504991
-  timestamp: 1739632286392
 - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-fits-3.11.0-hd840048_5.conda
   sha256: 39f02c00011b412d01a8577974868b27a908411821353eba591fd9a650aaa119
   md5: f626d49cdbd6d9377cbcc9bddf1cab2d
@@ -21376,6 +21349,19 @@ packages:
   license_family: MIT
   size: 509211
   timestamp: 1749484755057
+- conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-fits-3.11.3-hcff14e6_0.conda
+  sha256: 7feb2ba43a3b6910bbdfc6613c64099335e55d6df15047ab65d66c59cc5cae12
+  md5: 97221916a2c4e941b027d27e92a7ac3c
+  depends:
+  - cfitsio >=4.6.2,<4.6.3.0a0
+  - libgdal-core 3.11.3 hddc0a0b_0
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  license: MIT
+  license_family: MIT
+  size: 508910
+  timestamp: 1752352292856
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-grib-3.10.2-h724c1be_0.conda
   sha256: 810da872d2a9990b15a9c83a773ec4473f449b3b66b72eaec149e10d065b25ba
   md5: 76245c4d4c567ed5c5193c02494106d4
@@ -21482,21 +21468,6 @@ packages:
   license_family: MIT
   size: 658604
   timestamp: 1747848270951
-- conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-grib-3.10.2-h9921521_0.conda
-  sha256: 6d3e3d0e6b71f190df135610ae4bb23b55bd1eb9ddf79c28068f9b6a62ca832a
-  md5: 7551f2bbc2d24c9a65d7865b8ca429a6
-  depends:
-  - libaec >=1.1.3,<2.0a0
-  - libgdal-core 3.10.2 h095903c_0
-  - libkml >=1.3.0,<1.4.0a0
-  - liblzma >=5.6.4,<6.0a0
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  license: MIT
-  license_family: MIT
-  size: 687089
-  timestamp: 1739632527108
 - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-grib-3.11.0-h79060df_5.conda
   sha256: 91480c3ceff641c25b15a13f5cd28ceb418054a5f5924c92ac83dce0ff95c581
   md5: be3d6e2f7ab563f0748a10618c5ea194
@@ -21510,6 +21481,19 @@ packages:
   license_family: MIT
   size: 692694
   timestamp: 1749484954676
+- conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-grib-3.11.3-h8ff101f_0.conda
+  sha256: 1c742835ffb9df883104ae5c5afc5e84e7e8e899cd3849c4622b9ccac57a8bbd
+  md5: fb8e32a727ced3eb1d0afa3e3b48cd36
+  depends:
+  - libaec >=1.1.4,<2.0a0
+  - libgdal-core 3.11.3 hddc0a0b_0
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  license: MIT
+  license_family: MIT
+  size: 691660
+  timestamp: 1752352436368
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-hdf4-3.10.2-h05c48c5_0.conda
   sha256: e731958616c4936abe8bd375784889c3e04f6f09ec954038f0fe51fa00e955b8
   md5: 602812f26baa05e961d0dcf4d068281d
@@ -21624,22 +21608,6 @@ packages:
   license_family: MIT
   size: 543618
   timestamp: 1747848419490
-- conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-hdf4-3.10.2-hf9aff8f_0.conda
-  sha256: 21e015cb3826b738007dc880d91d86ebe7860bc268db1779d6de469d740198b4
-  md5: 12e96b52c768ce0a0e4f216ce5c23695
-  depends:
-  - hdf4 >=4.2.15,<4.2.16.0a0
-  - libaec >=1.1.3,<2.0a0
-  - libgdal-core 3.10.2 h095903c_0
-  - libkml >=1.3.0,<1.4.0a0
-  - liblzma >=5.6.4,<6.0a0
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  license: MIT
-  license_family: MIT
-  size: 562869
-  timestamp: 1739632792486
 - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-hdf4-3.11.0-h0de24e7_5.conda
   sha256: cc5d6bb5acef8c6d893874bd06b75a26397e02fc3bbeb6798d70532c939f940b
   md5: ced9c9ccc671f63825b18b6907cff8bf
@@ -21654,6 +21622,20 @@ packages:
   license_family: MIT
   size: 566398
   timestamp: 1749485137411
+- conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-hdf4-3.11.3-ha47b6c4_0.conda
+  sha256: 55255c285dc268e756a149d2fdfdc4a869aa7d931058e4e08a248eb9fd69a0a2
+  md5: 36156e05468394d75e47b956e5112417
+  depends:
+  - hdf4 >=4.2.15,<4.2.16.0a0
+  - libaec >=1.1.4,<2.0a0
+  - libgdal-core 3.11.3 hddc0a0b_0
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  license: MIT
+  license_family: MIT
+  size: 565394
+  timestamp: 1752352569928
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-hdf5-3.10.2-hf0b1780_0.conda
   sha256: f307231a1f51d35d607deca6ab7ba8ca96c23f5d2e7b79577c5d40a8e20187d6
   md5: 26e72a85f42f769832b01547705893b8
@@ -21760,21 +21742,6 @@ packages:
   license_family: MIT
   size: 597537
   timestamp: 1747848578086
-- conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-hdf5-3.10.2-h7df419c_0.conda
-  sha256: d4d3488eb4df85da85d35ee71928b70e1ffb1a2c597cbfb376ed97e3972b58f0
-  md5: db919d61fd1f8818d227f4a0950e3242
-  depends:
-  - hdf5 >=1.14.3,<1.14.4.0a0
-  - libgdal-core 3.10.2 h095903c_0
-  - libkml >=1.3.0,<1.4.0a0
-  - liblzma >=5.6.4,<6.0a0
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  license: MIT
-  license_family: MIT
-  size: 621556
-  timestamp: 1739633056121
 - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-hdf5-3.11.0-h527b061_5.conda
   sha256: 492ade68170fc1c090ef0358448361fca06d4bda1110b9b967a775efe8a11ef5
   md5: e03f1c337a2972beb964f11775d31d5c
@@ -21788,6 +21755,19 @@ packages:
   license_family: MIT
   size: 625856
   timestamp: 1749485340273
+- conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-hdf5-3.11.3-h0f01001_0.conda
+  sha256: 5afbef169e577d1974d0731ce07d4008f7205c09c1df825de57a222a56d57339
+  md5: c94be9121e8ceaf0610523d7dca93880
+  depends:
+  - hdf5 >=1.14.6,<1.14.7.0a0
+  - libgdal-core 3.11.3 hddc0a0b_0
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  license: MIT
+  license_family: MIT
+  size: 628749
+  timestamp: 1752352754821
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-jp2openjpeg-3.10.2-ha1d2769_0.conda
   sha256: 42bb824edf5cf9b2d6015c2ad2686b5dabf1749b176ed4540fa03e8cafc2ab37
   md5: 857f9bd823c6f3257b750a2d4ca79633
@@ -21894,21 +21874,6 @@ packages:
   license_family: MIT
   size: 467157
   timestamp: 1747848814729
-- conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-jp2openjpeg-3.10.2-h768cd86_0.conda
-  sha256: 8efed418d92a5b8e1188f310e66d51a5610119357ccbdd8bbd7608d052bd564f
-  md5: 56cb0cdcf7b6ac48ad14289c22fc9cd2
-  depends:
-  - libgdal-core 3.10.2 h095903c_0
-  - libkml >=1.3.0,<1.4.0a0
-  - liblzma >=5.6.4,<6.0a0
-  - openjpeg >=2.5.3,<3.0a0
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  license: MIT
-  license_family: MIT
-  size: 505340
-  timestamp: 1739633528457
 - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-jp2openjpeg-3.11.0-h95c5499_5.conda
   sha256: 2bd34b4cf9ffeeeeb2873e8302974eb04d268e1744b70e8aa7f4d29ed94ededf
   md5: 78ad57d8bd5b811e96182b13f33b8ccd
@@ -21922,6 +21887,19 @@ packages:
   license_family: MIT
   size: 509321
   timestamp: 1749485690063
+- conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-jp2openjpeg-3.11.3-hf58e487_0.conda
+  sha256: 297fc1a87f5336542955a13e2adc6abc621e7c89aa56955111176e7d749fd43f
+  md5: 50ea2e7aba9eedc0cc1b89a665346f43
+  depends:
+  - libgdal-core 3.11.3 hddc0a0b_0
+  - openjpeg >=2.5.3,<3.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  license: MIT
+  license_family: MIT
+  size: 510442
+  timestamp: 1752353021164
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-kea-3.10.2-h41c5bbd_0.conda
   sha256: 2aaf3ccb74635ae56d810a42944505d74d774138ada6e445c1d66b8b4c77d08e
   md5: 087ce3645442e920b32093285ef6a238
@@ -22044,23 +22022,6 @@ packages:
   license_family: MIT
   size: 473917
   timestamp: 1747849684636
-- conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-kea-3.10.2-hfc54ade_0.conda
-  sha256: 8cb465618b03c266ff3f775d03a09ffad5f8006acde497559cd5202b4af7f0d1
-  md5: e41b5d0f49fed9c7852c2d91a65a5d11
-  depends:
-  - hdf5 >=1.14.3,<1.14.4.0a0
-  - kealib >=1.6.1,<1.7.0a0
-  - libgdal-core 3.10.2 h095903c_0
-  - libgdal-hdf5 3.10.2.*
-  - libkml >=1.3.0,<1.4.0a0
-  - liblzma >=5.6.4,<6.0a0
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  license: MIT
-  license_family: MIT
-  size: 524967
-  timestamp: 1739635190661
 - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-kea-3.11.0-h6b3a253_5.conda
   sha256: 6821b58690c21e771956eb77ddfaaf9f2d9afc028f5f587986aeff1672843556
   md5: fe2b216c38f6b44bf0dd6fdafa8d16fe
@@ -22076,6 +22037,21 @@ packages:
   license_family: MIT
   size: 529730
   timestamp: 1749486867989
+- conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-kea-3.11.3-hea5172e_0.conda
+  sha256: b4f50fcca71216cc5de0a35e822bcc34a78c392dc1461bbfa2bd783fcf49c512
+  md5: 69c0549f6df2f1e062920ac4a3875356
+  depends:
+  - hdf5 >=1.14.6,<1.14.7.0a0
+  - kealib >=1.6.2,<1.7.0a0
+  - libgdal-core 3.11.3 hddc0a0b_0
+  - libgdal-hdf5 3.11.3.*
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  license: MIT
+  license_family: MIT
+  size: 529281
+  timestamp: 1752353944355
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-netcdf-3.10.2-ha1d9371_0.conda
   sha256: cef58933d0e3e03e929e5a889bc9aadb736e7c9ccf436ff37eb6e8ddb693df88
   md5: a7ccdad7c4d28fb844cadb11bff811ed
@@ -22214,25 +22190,6 @@ packages:
   license_family: MIT
   size: 673885
   timestamp: 1747849812911
-- conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-netcdf-3.10.2-h3717446_0.conda
-  sha256: cdd3bd11563987a820aae1057f2b14f351572fb78ced5208f4eabc38e847bb21
-  md5: 468ce510f027842e2daa202723b9c90d
-  depends:
-  - hdf4 >=4.2.15,<4.2.16.0a0
-  - hdf5 >=1.14.3,<1.14.4.0a0
-  - libgdal-core 3.10.2 h095903c_0
-  - libgdal-hdf4 3.10.2.*
-  - libgdal-hdf5 3.10.2.*
-  - libkml >=1.3.0,<1.4.0a0
-  - liblzma >=5.6.4,<6.0a0
-  - libnetcdf >=4.9.2,<4.9.3.0a0
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  license: MIT
-  license_family: MIT
-  size: 674055
-  timestamp: 1739635472073
 - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-netcdf-3.11.0-h1b8416b_5.conda
   sha256: 8e1fc6a227112a04be3791f67281b722e00f5fab88e552bc4dcbd461ce0bc864
   md5: dc0516112c5f4441450c7eff4c81a161
@@ -22250,6 +22207,23 @@ packages:
   license_family: MIT
   size: 678926
   timestamp: 1749487071149
+- conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-netcdf-3.11.3-hcb0e93c_0.conda
+  sha256: 931bfc9b7d3b682f09dfd12fa8e8465c4dff582b7845153d6cfa97357bb88889
+  md5: 1055f668e8565fd8594df180b4d23469
+  depends:
+  - hdf4 >=4.2.15,<4.2.16.0a0
+  - hdf5 >=1.14.6,<1.14.7.0a0
+  - libgdal-core 3.11.3 hddc0a0b_0
+  - libgdal-hdf4 3.11.3.*
+  - libgdal-hdf5 3.11.3.*
+  - libnetcdf >=4.9.2,<4.9.3.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  license: MIT
+  license_family: MIT
+  size: 683304
+  timestamp: 1752354091485
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-pdf-3.10.2-h8221dc3_0.conda
   sha256: 12112808fd0c4dd6b46c906262d40c29c3f27083121634f61e0c00eec88b747d
   md5: 5903e9fefd5cf9d57a8841b0efd514d4
@@ -22356,21 +22330,6 @@ packages:
   license_family: MIT
   size: 606351
   timestamp: 1747849000264
-- conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-pdf-3.10.2-h33ae9eb_0.conda
-  sha256: 4b6622ed595c4ce0150032ad78dd5593bbd53811544041b46bb12d8846e64d4a
-  md5: 58a6defa4cc6bda4314bc6a096148bf5
-  depends:
-  - libgdal-core 3.10.2 h095903c_0
-  - libkml >=1.3.0,<1.4.0a0
-  - liblzma >=5.6.4,<6.0a0
-  - poppler >=24.12.0,<24.13.0a0
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  license: MIT
-  license_family: MIT
-  size: 634738
-  timestamp: 1739633849992
 - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-pdf-3.11.0-ha9b9ad8_5.conda
   sha256: e83bd07230760bf07f29e02bf43cd489fcef9c4540fd86771eaf9fc9e06864cd
   md5: 4020c3ec50452f5bf08390ffe637dbd7
@@ -22384,6 +22343,19 @@ packages:
   license_family: MIT
   size: 647195
   timestamp: 1749485907712
+- conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-pdf-3.11.3-h75c24f8_0.conda
+  sha256: c83c44724771a1f61eddaf7e13924c8aae4d6660b2b5ad9dd9f0b5b080253dcb
+  md5: b47b7d0bd696bb5adebd64fc319ab763
+  depends:
+  - libgdal-core 3.11.3 hddc0a0b_0
+  - poppler >=24.12.0,<24.13.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  license: MIT
+  license_family: MIT
+  size: 651903
+  timestamp: 1752353203867
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-pg-3.10.2-ha83508c_0.conda
   sha256: 7106188a8e90b48f320ab9bf27fe98bdd08c6f32e3932a9d75e31ef7331a0d1d
   md5: a6fc13714f9652693ed4840b312fd4d2
@@ -22498,22 +22470,6 @@ packages:
   license_family: MIT
   size: 507378
   timestamp: 1747849159684
-- conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-pg-3.10.2-h5e54256_0.conda
-  sha256: d80cc0c1309a11d9f98a17f6c504d79ea8e7df6df236dc9f7e5d0ecbb9d903fc
-  md5: c3d21775a92e3fdaeed08ef12f46b9ee
-  depends:
-  - libgdal-core 3.10.2 h095903c_0
-  - libkml >=1.3.0,<1.4.0a0
-  - liblzma >=5.6.4,<6.0a0
-  - libpq >=17.3,<18.0a0
-  - postgresql
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  license: MIT
-  license_family: MIT
-  size: 540028
-  timestamp: 1739634101013
 - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-pg-3.11.0-h38d3678_5.conda
   sha256: 996620fa078aee5361c6b22285af54163b5ca97b3e4922a8080785c455bab2e6
   md5: 42846549b2d1ef3c02ccf5ebb5959c00
@@ -22528,6 +22484,20 @@ packages:
   license_family: MIT
   size: 542547
   timestamp: 1749486106936
+- conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-pg-3.11.3-h103a44d_0.conda
+  sha256: f775be666e4332cc8cc760980d4997b7a6b089647bb8900f4103ae55b436b0d5
+  md5: 5e9facdc8fe591c71d1460ec907203e8
+  depends:
+  - libgdal-core 3.11.3 hddc0a0b_0
+  - libpq >=17.5,<18.0a0
+  - postgresql
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  license: MIT
+  license_family: MIT
+  size: 543519
+  timestamp: 1752353340210
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-postgisraster-3.10.2-ha83508c_0.conda
   sha256: 6b52cac9aa15f24116ce4a0f796c56c4796412987082ddc9333542da2f06737f
   md5: f5c3c642cb48f8a2abf18b6d06f2d7cc
@@ -22642,22 +22612,6 @@ packages:
   license_family: MIT
   size: 472108
   timestamp: 1747849308630
-- conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-postgisraster-3.10.2-h5e54256_0.conda
-  sha256: cc12e522bd266e548b6c769855f676d8fb1dab6c14828386b9ed8831d8c4c5d6
-  md5: 2b6062fd2d9c931f959586991a33f9d8
-  depends:
-  - libgdal-core 3.10.2 h095903c_0
-  - libkml >=1.3.0,<1.4.0a0
-  - liblzma >=5.6.4,<6.0a0
-  - libpq >=17.3,<18.0a0
-  - postgresql
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  license: MIT
-  license_family: MIT
-  size: 512687
-  timestamp: 1739634383808
 - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-postgisraster-3.11.0-h38d3678_5.conda
   sha256: 6e63ff970a61221820f39d2e0c30cad6e3dcf83d425cecabd1bef55fc400c5fb
   md5: 6d26937569d33b63411991cfb0a2d83b
@@ -22672,6 +22626,20 @@ packages:
   license_family: MIT
   size: 516159
   timestamp: 1749486294550
+- conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-postgisraster-3.11.3-h103a44d_0.conda
+  sha256: 9f2f07e4f437ab14805d5880e9759ae0f32f88f965c9476944702a2bc0503604
+  md5: d4731d3cc950744e8b39a8138fbc5022
+  depends:
+  - libgdal-core 3.11.3 hddc0a0b_0
+  - libpq >=17.5,<18.0a0
+  - postgresql
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  license: MIT
+  license_family: MIT
+  size: 516076
+  timestamp: 1752353488367
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-tiledb-3.10.2-h30425e6_0.conda
   sha256: f117e8ae2e386b79bfb0116f3ece4c0532232223953290f0e32c361c320d816e
   md5: 6af513ffd90e4c075bbeb8fc7a0d5284
@@ -22778,21 +22746,6 @@ packages:
   license_family: MIT
   size: 628643
   timestamp: 1747849450985
-- conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-tiledb-3.10.2-h8d6a7ae_0.conda
-  sha256: 6a65cdec434a8c8af7556581d9e27a133f78053e40eaf7f489ec4de36a1a4901
-  md5: da84eeb63ec44c51ad99052051e83a70
-  depends:
-  - libgdal-core 3.10.2 h095903c_0
-  - libkml >=1.3.0,<1.4.0a0
-  - liblzma >=5.6.4,<6.0a0
-  - tiledb >=2.27.0,<2.28.0a0
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  license: MIT
-  license_family: MIT
-  size: 645586
-  timestamp: 1739634694330
 - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-tiledb-3.11.0-h6c2f05d_5.conda
   sha256: af32bf49d66b3e30dfb6baa29961eb90b2d8430fefdfd6441e1a04466af295ef
   md5: 85777f0eb5dca0205f9087b87431917b
@@ -22806,6 +22759,19 @@ packages:
   license_family: MIT
   size: 649904
   timestamp: 1749486532697
+- conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-tiledb-3.11.3-h88e1fbc_0.conda
+  sha256: f91bb9264dcfad62f2e712820dd3a5ea808a17babe8e19541fc5395f0228fc01
+  md5: 673ca85c5ef67427602720155bb3fc20
+  depends:
+  - libgdal-core 3.11.3 hddc0a0b_0
+  - tiledb >=2.28.0,<2.29.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  license: MIT
+  license_family: MIT
+  size: 647347
+  timestamp: 1752353662832
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-xls-3.10.2-h5b36e33_0.conda
   sha256: b614d3b7b4ed7f5a0900f52408103c114b9057b472296b318f3dab10abcbcc5a
   md5: 010cc2702a2c8257ad3a13709c702ef0
@@ -22912,21 +22878,6 @@ packages:
   license_family: MIT
   size: 436320
   timestamp: 1747849564578
-- conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-xls-3.10.2-hd0c044b_0.conda
-  sha256: d666f024014763c2c843f7483baec41a1501027eb8f8cb06f60c0a58db46e59b
-  md5: 69f490130158732be52edb547dce1e1e
-  depends:
-  - freexl >=2.0.0,<3.0a0
-  - libgdal-core 3.10.2 h095903c_0
-  - libkml >=1.3.0,<1.4.0a0
-  - liblzma >=5.6.4,<6.0a0
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  license: MIT
-  license_family: MIT
-  size: 473606
-  timestamp: 1739634945588
 - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-xls-3.11.0-hc931c72_5.conda
   sha256: 351c6b5f7df58551236d5eecfb1621e9912d5fcd20043f25dc8487b1e0255460
   md5: d831c1b0834724b0b97f0886b6f2e57b
@@ -22940,6 +22891,19 @@ packages:
   license_family: MIT
   size: 477239
   timestamp: 1749486701906
+- conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-xls-3.11.3-h93cc17c_0.conda
+  sha256: 93cf1132d3155d547d17537aa56e16b5cb230e86d118487266aada36af50f449
+  md5: 18b169c2dd6fd6361df701e47c66590c
+  depends:
+  - freexl >=2.0.0,<3.0a0
+  - libgdal-core 3.11.3 hddc0a0b_0
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  license: MIT
+  license_family: MIT
+  size: 476651
+  timestamp: 1752353791940
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libgettextpo-0.24.1-h5888daf_0.conda
   sha256: 104f2341546e295d1136ab3010e81391bd3fd5be0f095db59266e8eba2082d37
   md5: 2ee6d71b72f75d50581f2f68e965efdb
@@ -23300,23 +23264,6 @@ packages:
   license: LGPL-2.1-or-later
   size: 3666180
   timestamp: 1747837044507
-- conda: https://conda.anaconda.org/conda-forge/win-64/libglib-2.84.1-h7025463_0.conda
-  sha256: 75a35a0134c7b2f3f41dbf24faa417be6a98a70db23dc1225b0c74ea45c0ce61
-  md5: 6cbaea9075a4f007eb7d0a90bb9a2a09
-  depends:
-  - libffi >=3.4.6,<3.5.0a0
-  - libiconv >=1.18,<2.0a0
-  - libintl >=0.22.5,<1.0a0
-  - libzlib >=1.3.1,<2.0a0
-  - pcre2 >=10.44,<10.45.0a0
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  constrains:
-  - glib 2.84.1 *_0
-  license: LGPL-2.1-or-later
-  size: 3806534
-  timestamp: 1743774256525
 - conda: https://conda.anaconda.org/conda-forge/win-64/libglib-2.84.2-hbc94333_0.conda
   sha256: 457e297389609ff6886fef88ae7f1f6ea4f4f3febea7dd690662a50983967d6d
   md5: fee05801cc5db97bec20a5e78fb3905b
@@ -23334,6 +23281,23 @@ packages:
   license: LGPL-2.1-or-later
   size: 3771466
   timestamp: 1747837394297
+- conda: https://conda.anaconda.org/conda-forge/win-64/libglib-2.84.3-h1c1036b_0.conda
+  sha256: bd322efaebc369e188a1dd93030325a40753a4c009e92c1f82ec481a20f0d232
+  md5: 2bcc00752c158d4a70e1eaccbf6fe8ae
+  depends:
+  - libffi >=3.4.6,<3.5.0a0
+  - libiconv >=1.18,<2.0a0
+  - libintl >=0.22.5,<1.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - pcre2 >=10.45,<10.46.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  constrains:
+  - glib 2.84.3 *_0
+  license: LGPL-2.1-or-later
+  size: 3826069
+  timestamp: 1754315362939
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libglu-9.0.3-h5888daf_1.conda
   sha256: a0105eb88f76073bbb30169312e797ed5449ebb4e964a756104d6e54633d17ef
   md5: 8422fcc9e5e172c91e99aef703b3ce65
@@ -23579,24 +23543,6 @@ packages:
   license_family: Apache
   size: 874398
   timestamp: 1741878533033
-- conda: https://conda.anaconda.org/conda-forge/win-64/libgoogle-cloud-2.32.0-h07d40e7_0.conda
-  sha256: 1df1000de42160fcccf45d78dd1884c6a79176778633659688c3b2027e68cb5f
-  md5: a2efe439d2c66634bd04a7a9f75a71fb
-  depends:
-  - libabseil * cxx17*
-  - libabseil >=20240722.0,<20240723.0a0
-  - libcurl >=8.10.1,<9.0a0
-  - libgrpc >=1.67.1,<1.68.0a0
-  - libprotobuf >=5.28.2,<5.28.3.0a0
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  constrains:
-  - libgoogle-cloud 2.32.0 *_0
-  license: Apache-2.0
-  license_family: Apache
-  size: 14449
-  timestamp: 1733513814100
 - conda: https://conda.anaconda.org/conda-forge/win-64/libgoogle-cloud-2.36.0-hf249c01_1.conda
   sha256: 04baf461a2ebb8e8ac0978a006774124d1a8928e921c3ae4d9c27f072db7b2e2
   md5: 2842dfad9b784ab71293915db73ff093
@@ -23745,22 +23691,6 @@ packages:
   license_family: Apache
   size: 529458
   timestamp: 1741879638484
-- conda: https://conda.anaconda.org/conda-forge/win-64/libgoogle-cloud-storage-2.32.0-he5eb982_0.conda
-  sha256: 901b3bb7c84ba21d484f1f0f131c706120f4b3fbf44563af257313f89e6dafa2
-  md5: bddd7316c6a5cf7902e0f7d341a53d71
-  depends:
-  - libabseil
-  - libcrc32c >=1.1.2,<1.2.0a0
-  - libcurl
-  - libgoogle-cloud 2.32.0 h07d40e7_0
-  - libzlib >=1.3.1,<2.0a0
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  license: Apache-2.0
-  license_family: Apache
-  size: 14369
-  timestamp: 1733514224688
 - conda: https://conda.anaconda.org/conda-forge/win-64/libgoogle-cloud-storage-2.36.0-he5eb982_1.conda
   sha256: 0dbdfc80b79bd491f4240c6f6dc6c275d341ea24765ce40f07063a253ad21063
   md5: 8b5af0aa84ff9c2117c1cefc07622800
@@ -23960,27 +23890,6 @@ packages:
   license_family: APACHE
   size: 4908484
   timestamp: 1745191611284
-- conda: https://conda.anaconda.org/conda-forge/win-64/libgrpc-1.67.1-h7aa3b8a_0.conda
-  sha256: 986dafe9c3219e88a82389e679a2804d4256aa9ddaead193f91b7d6b4ef89ea1
-  md5: daad5d4a1c24c1afe748afbb83377e43
-  depends:
-  - c-ares >=1.34.2,<2.0a0
-  - libabseil * cxx17*
-  - libabseil >=20240722.0,<20240723.0a0
-  - libprotobuf >=5.28.2,<5.28.3.0a0
-  - libre2-11 >=2024.7.2
-  - libzlib >=1.3.1,<2.0a0
-  - openssl >=3.3.2,<4.0a0
-  - re2
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  constrains:
-  - grpc-cpp =1.67.1
-  license: Apache-2.0
-  license_family: APACHE
-  size: 17167461
-  timestamp: 1730236510917
 - conda: https://conda.anaconda.org/conda-forge/win-64/libgrpc-1.71.0-h8c3449c_1.conda
   sha256: eb832f8eea6936400753a5344ebce3e09c36698d04becd6ef234fda9c480cccb
   md5: ef38e4d5e1814a912311abd4468e90bb
@@ -24053,6 +23962,20 @@ packages:
   license_family: APACHE
   size: 205005
   timestamp: 1715098992968
+- conda: https://conda.anaconda.org/conda-forge/win-64/libgz-cmake3-3.5.5-h5112557_0.conda
+  sha256: d70cb16347841d0338696c5c761cb69ba9f64908918ab708145e8eb6935d0a01
+  md5: fdbb687b7f043662978ead3035655066
+  depends:
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  - ucrt >=10.0.20348.0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 216333
+  timestamp: 1759138437283
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libgz-cmake4-4.2.0-h3f2d84a_0.conda
   sha256: fd2f551f754285a45955478d072f81724d72dc91a3d3d472b03567bbbb413c89
   md5: a5ef8dad9018481b084713687ae6087e
@@ -24275,28 +24198,6 @@ packages:
   license_family: APACHE
   size: 582492
   timestamp: 1748593530695
-- conda: https://conda.anaconda.org/conda-forge/win-64/libgz-common6-6.0.1-hf79d240_0.conda
-  sha256: 9af332f7f7826dad2510252cf3cdd8a9cf4ac493596dd2c6b4c876132c2afff3
-  md5: fde60fa6324a92b14e8b3556b9920b63
-  depends:
-  - assimp >=5.4.3,<5.4.4.0a0
-  - dlfcn-win32 >=1.4.1,<2.0a0
-  - ffmpeg >=7.1.0,<8.0a0
-  - freeimage >=3.18.0,<3.19.0a0
-  - libgdal >=3.10.0,<3.11.0a0
-  - libgdal-core >=3.10.0,<3.11.0a0
-  - libgz-cmake4 >=4.1.0,<5.0a0
-  - libgz-math8 >=8.1.0,<9.0a0
-  - libgz-utils3 >=3.1.0,<4.0a0
-  - spdlog >=1.14.1,<1.15.0a0
-  - tinyxml2 >=10.0.0,<10.1.0a0
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  license: Apache-2.0
-  license_family: APACHE
-  size: 643811
-  timestamp: 1734514198210
 - conda: https://conda.anaconda.org/conda-forge/win-64/libgz-common6-6.1.0-h7e7f190_0.conda
   sha256: 2650edbaefddd66c64f8d14b8a6f218459fedb483d8bbd3c2830ff1c1f6206be
   md5: 01a9a265a095663b84b8df4afd288c39
@@ -24489,28 +24390,6 @@ packages:
   license_family: APACHE
   size: 224526
   timestamp: 1749240847298
-- conda: https://conda.anaconda.org/conda-forge/win-64/libgz-fuel-tools10-10.0.0-h2cc4d93_2.conda
-  sha256: e0b0b92525a2b6e48defb480606c2dadcbb45fe27ff949dd94083f8c45dd0fae
-  md5: 4389822bddb7e4ec066cd8b4daacdcfc
-  depends:
-  - jsoncpp >=1.9.6,<1.9.7.0a0
-  - libcurl >=8.10.1,<9.0a0
-  - libgz-cmake4 >=4.0.0,<5.0a0
-  - libgz-common6 >=6.0.0,<7.0a0
-  - libgz-math8 >=8.0.0,<9.0a0
-  - libgz-msgs11 >=11.0.1,<12.0a0
-  - libgz-tools2 >=2.0.1,<3.0a0
-  - libprotobuf >=5.28.2,<5.28.3.0a0
-  - libzip >=1.11.2,<2.0a0
-  - tinyxml2 >=10.0.0,<10.1.0a0
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  - yaml >=0.2.5,<0.3.0a0
-  license: Apache-2.0
-  license_family: APACHE
-  size: 228397
-  timestamp: 1730747670799
 - conda: https://conda.anaconda.org/conda-forge/win-64/libgz-fuel-tools10-10.1.0-h55227be_0.conda
   sha256: 4438601083823cf8924ee51c8127fb491fdbc021cbd3fe9e64219eb53c47c12b
   md5: 020a402d96b4f55af0af010adc9829fe
@@ -24741,32 +24620,6 @@ packages:
   license_family: APACHE
   size: 616920
   timestamp: 1743850584906
-- conda: https://conda.anaconda.org/conda-forge/win-64/libgz-gui9-9.0.0-h254a4ba_6.conda
-  sha256: dfe8198022acf7b95c43156b97f677e21a3a6a17c02f67f5b0ae026c06db4f1d
-  md5: 0b73e4c988d5e65fad534b19d623ca3e
-  depends:
-  - libabseil * cxx17*
-  - libabseil >=20240722.0,<20240723.0a0
-  - libgz-cmake4 >=4.1.0,<5.0a0
-  - libgz-common6 >=6.0.0,<7.0a0
-  - libgz-math8 >=8.0.0,<9.0a0
-  - libgz-msgs11 >=11.0.1,<12.0a0
-  - libgz-plugin3 >=3.0.0,<4.0a0
-  - libgz-rendering9 >=9.0.0,<10.0a0
-  - libgz-tools2 >=2.0.1,<3.0a0
-  - libgz-transport14 >=14.0.0,<15.0a0
-  - libgz-utils3 >=3.0.0,<4.0a0
-  - libprotobuf >=5.28.2,<5.28.3.0a0
-  - ogre >=1.10.12.1,<1.11.0a0
-  - qt-main >=5.15.15,<5.16.0a0
-  - tinyxml2 >=10.0.0,<10.1.0a0
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  license: Apache-2.0
-  license_family: APACHE
-  size: 596887
-  timestamp: 1731392466243
 - conda: https://conda.anaconda.org/conda-forge/win-64/libgz-gui9-9.0.1-h9b04ecd_1.conda
   sha256: ee98655a6967c9c4a23762ead38ef971caf17b4c8e08be48ff9df354528fad70
   md5: 558ec141caa308c17885de10de619d89
@@ -24900,20 +24753,6 @@ packages:
   license_family: APACHE
   size: 243187
   timestamp: 1742423701706
-- conda: https://conda.anaconda.org/conda-forge/win-64/libgz-math8-8.1.0-he0c23c2_0.conda
-  sha256: 2639788b77f9fc92ed9c6bf73236db65fc71832a021637ab67720aa0528f3d4e
-  md5: b3d2d97c34c3beab84e106ee6a6b4fbc
-  depends:
-  - eigen
-  - libgz-cmake4 >=4.1.0,<5.0a0
-  - libgz-utils3 >=3.1.0,<4.0a0
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  license: Apache-2.0
-  license_family: APACHE
-  size: 233736
-  timestamp: 1731782967723
 - conda: https://conda.anaconda.org/conda-forge/win-64/libgz-math8-8.2.0-h7661bb3_2.conda
   sha256: 9ae82f0caab37eb8ecd21d6ab575f76bd91b5d063d44e06654356b5547b5e177
   md5: 351f50057a34f5be30c0322850adc22b
@@ -25081,26 +24920,30 @@ packages:
   license_family: APACHE
   size: 938070
   timestamp: 1746857361284
-- conda: https://conda.anaconda.org/conda-forge/win-64/libgz-msgs11-11.0.1-hdde3068_4.conda
-  sha256: f5a9c7fcbe8e3f9469f2154177b29b07f26f902e037f070c760c87466214433c
-  md5: 81971f9f3de3ae75fc628fe5eb966f53
+- conda: https://conda.anaconda.org/conda-forge/win-64/libgz-msgs11-11.1.0-h30b9592_4.conda
+  sha256: 956924c58c91cf865a4fd72b542a0df7af949dd8e93e21bdb86263e5c50bad96
+  md5: 7b8b667094d9bf76ae7456f19d595a5d
   depends:
-  - dlfcn-win32 >=1.4.1,<2.0a0
-  - libabseil * cxx17*
-  - libabseil >=20240722.0,<20240723.0a0
-  - libgz-cmake4 >=4.0.0,<5.0a0
-  - libgz-math8 >=8.0.0,<9.0a0
-  - libgz-tools2 >=2.0.1,<3.0a0
-  - libprotobuf >=5.28.2,<5.28.3.0a0
   - python
-  - tinyxml2 >=10.0.0,<10.1.0a0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  - ucrt >=10.0.20348.0
+  - libgz-tools2 >=2.0.1,<3.0a0
+  - libprotobuf >=5.29.3,<5.29.4.0a0
+  - libgz-math8 >=8.2.0,<9.0a0
+  - dlfcn-win32 >=1.4.1,<2.0a0
+  - libgz-cmake4 >=4.2.0,<5.0a0
+  - libgz-utils3 >=3.1.1,<4.0a0
+  - tinyxml2 >=11.0.0,<11.1.0a0
+  - libabseil >=20250127.1,<20250128.0a0
+  - libabseil * cxx17*
   license: Apache-2.0
   license_family: APACHE
-  size: 1877616
-  timestamp: 1730703150383
+  size: 2173244
+  timestamp: 1753344964477
 - conda: https://conda.anaconda.org/conda-forge/win-64/libgz-msgs11-11.1.0-h5b6028b_0.conda
   sha256: fbe813ab08a8d4e3bbcee435f525d7239d3d3f30262561ad2c80232879bae26e
   md5: 711a3bd406417fc63ae70ddb9438973b
@@ -25280,27 +25123,6 @@ packages:
   license: Apache-2.0
   size: 1086329
   timestamp: 1750983377027
-- conda: https://conda.anaconda.org/conda-forge/win-64/libgz-physics8-8.1.0-hde7d378_0.conda
-  sha256: 70efbf872977890f50f4d54657ebae99abf1217fd274fa96364fce8fd07e9569
-  md5: 957e115d0e72e7ce267ea6cca902a5f6
-  depends:
-  - assimp >=5.4.3,<5.4.4.0a0
-  - bullet-cpp >=3.25,<3.26.0a0
-  - dartsim-cpp >=6.15.0,<6.16.0a0
-  - libgz-cmake4 >=4.1.0,<5.0a0
-  - libgz-common6 >=6.0.1,<7.0a0
-  - libgz-math8 >=8.1.0,<9.0a0
-  - libgz-plugin3 >=3.0.0,<4.0a0
-  - libgz-utils2 >=2.2.0,<3.0a0
-  - libode >=0.16.5,<0.16.6.0a0
-  - libsdformat15 >=15.1.1,<16.0a0
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  license: Apache-2.0
-  license_family: APACHE
-  size: 2994035
-  timestamp: 1739570574152
 - conda: https://conda.anaconda.org/conda-forge/win-64/libgz-physics8-8.2.0-hacf65ee_0.conda
   sha256: 35fe83bd6b2da735b4b2b89a7d3859e5385c4e981c35ff783bebbccc611b31fd
   md5: 5a3eda84cfdc2953198ef45ac443e9e1
@@ -25321,6 +25143,30 @@ packages:
   license: Apache-2.0
   size: 2607751
   timestamp: 1750984178551
+- conda: https://conda.anaconda.org/conda-forge/win-64/libgz-physics8-8.3.0-ha69dbe0_1.conda
+  sha256: 3e64fbe812aaf88d9c2c32b2bd375effbf20ffda13c611558e73f16b7b590ab8
+  md5: 2d1fc973f7c8b14ea4f2ba2a3d4c0639
+  depends:
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  - ucrt >=10.0.20348.0
+  - dartsim-cpp >=6.15.0,<6.16.0a0
+  - assimp >=5.4.3,<5.4.4.0a0
+  - libgz-cmake4 >=4.2.0,<5.0a0
+  - libgz-common6 >=6.1.0,<7.0a0
+  - bullet-cpp >=3.25,<3.26.0a0
+  - libgz-plugin3 >=3.1.0,<4.0a0
+  - libsdformat15 >=15.3.0,<16.0a0
+  - libgz-utils2 >=2.2.1,<3.0a0
+  - libode >=0.16.5,<0.16.6.0a0
+  - libgz-math8 >=8.2.0,<9.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 5330083
+  timestamp: 1759276207492
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libgz-plugin3-3.0.0-h5888daf_0.conda
   sha256: 1a91928b5a537eee07998e4d694867aa3280985b0d7ea89d972d7d93e674df0f
   md5: 0375e66788b00aa5ef1ea272260cf992
@@ -25427,21 +25273,24 @@ packages:
   license_family: APACHE
   size: 211271
   timestamp: 1747332681180
-- conda: https://conda.anaconda.org/conda-forge/win-64/libgz-plugin3-3.0.0-he0c23c2_0.conda
-  sha256: e2eb985af040b376f5564c4457157f92345b2847cc6f29b22d4ff10ce938d234
-  md5: b8ce7700c84f2599d70fa176325d2787
+- conda: https://conda.anaconda.org/conda-forge/win-64/libgz-plugin3-3.1.0-h5112557_0.conda
+  sha256: 03ed36509b4f3c500c36aa4c13077e664edf8c0ddfba2698b06f52b82d5bd24f
+  md5: a3e9f4ceaa2d6308a32f2be7d404377f
   depends:
-  - dlfcn-win32 >=1.4.1,<2.0a0
-  - libgz-cmake4 >=4.0.0,<5.0a0
-  - libgz-tools2 >=2.0.1,<3.0a0
-  - libgz-utils3 >=3.0.0,<4.0a0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  - ucrt >=10.0.20348.0
+  - libgz-tools >=2.0.3,<3.0a0
+  - libgz-cmake4 >=4.2.0,<5.0a0
+  - libgz-utils3 >=3.1.1,<4.0a0
+  - dlfcn-win32 >=1.4.1,<2.0a0
   license: Apache-2.0
   license_family: APACHE
-  size: 235399
-  timestamp: 1727483017686
+  size: 267376
+  timestamp: 1759152162510
 - conda: https://conda.anaconda.org/conda-forge/win-64/libgz-plugin3-3.1.0-he0c23c2_0.conda
   sha256: f148bbe6d83c7eccd8743df66f5a825882927eafb19662a51254b27f60de27a2
   md5: 261f6a4cad10db569b2592ce34199576
@@ -25601,24 +25450,6 @@ packages:
   license_family: APACHE
   size: 4399397
   timestamp: 1749280262183
-- conda: https://conda.anaconda.org/conda-forge/win-64/libgz-rendering9-9.0.0-he0c23c2_1.conda
-  sha256: b8afc1bb6a0e70ac6c4ccbba5ab1055cb38f19109161644f1439f784a832cabe
-  md5: eb0883db76aa7bcdfc86f8da1990eb02
-  depends:
-  - dlfcn-win32 >=1.4.1,<2.0a0
-  - libgz-common6 >=6.0.0,<7.0a0
-  - libgz-math8 >=8.0.0,<9.0a0
-  - libgz-plugin3 >=3.0.0,<4.0a0
-  - libgz-utils3 >=3.0.0,<4.0a0
-  - ogre >=1.10.12.1,<1.11.0a0
-  - ogre-next >=2.3.3,<2.3.4.0a0
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  license: Apache-2.0
-  license_family: APACHE
-  size: 4485421
-  timestamp: 1727857978456
 - conda: https://conda.anaconda.org/conda-forge/win-64/libgz-rendering9-9.2.0-he0c23c2_0.conda
   sha256: cd7c6c0b55ff5133ec8f8bb068d0305680d257409cb94b4dac5bb3d1299731af
   md5: 4e97e2bbe65c7d2d0c3c057feaaf19fe
@@ -25637,6 +25468,27 @@ packages:
   license_family: APACHE
   size: 4546467
   timestamp: 1749281005500
+- conda: https://conda.anaconda.org/conda-forge/win-64/libgz-rendering9-9.4.0-h5112557_0.conda
+  sha256: f28592dd6a90f38d22169f4a77dc6b5eb10f77c8d5442ca7dfc2b1b0a4324019
+  md5: 3c1b117470c847a7dc1011c8613f9744
+  depends:
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  - ucrt >=10.0.20348.0
+  - libgz-common6 >=6.1.0,<7.0a0
+  - libgz-math8 >=8.2.0,<9.0a0
+  - libgz-plugin3 >=3.1.0,<4.0a0
+  - ogre-next >=2.3.3,<2.3.4.0a0
+  - ogre >=1.10.12.1,<1.11.0a0
+  - libgz-utils3 >=3.1.1,<4.0a0
+  - dlfcn-win32 >=1.4.1,<2.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 5597762
+  timestamp: 1759351079937
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libgz-sensors9-9.0.0-h54e1e6c_6.conda
   sha256: fcbac5538a458e97f2a3701609d782f11eb3bb76d521cbce8e39775d6fc12ee5
   md5: e1d489ab1384a53bf1481e4977702994
@@ -25819,29 +25671,29 @@ packages:
   license_family: APACHE
   size: 379356
   timestamp: 1743849927107
-- conda: https://conda.anaconda.org/conda-forge/win-64/libgz-sensors9-9.0.0-h395346c_6.conda
-  sha256: e5a779855efc9c04d1120e07961dbb1c78f479cad4770b489f6bf83d036cacce
-  md5: 7fdfad9f0c9c50fafb64255dd03f9722
+- conda: https://conda.anaconda.org/conda-forge/win-64/libgz-sensors9-9.1.0-h574b0c1_2.conda
+  sha256: 1c8db17203dfb9b88b789d672d1e859eb3983393aa8df79b58f1c3f793cb2a70
+  md5: f2ebe5f29112146fa32a88d055b26a56
   depends:
   - libabseil * cxx17*
-  - libabseil >=20240722.0,<20240723.0a0
-  - libgz-cmake4 >=4.1.0,<5.0a0
-  - libgz-common6 >=6.0.0,<7.0a0
-  - libgz-math8 >=8.0.0,<9.0a0
-  - libgz-msgs11 >=11.0.1,<12.0a0
-  - libgz-plugin3 >=3.0.0,<4.0a0
-  - libgz-rendering9 >=9.0.0,<10.0a0
-  - libgz-transport14 >=14.0.0,<15.0a0
-  - libprotobuf >=5.28.2,<5.28.3.0a0
-  - libsdformat15 >=15.0.0,<16.0a0
+  - libabseil >=20250127.1,<20250128.0a0
+  - libgz-cmake4 >=4.2.0,<5.0a0
+  - libgz-common6 >=6.1.0,<7.0a0
+  - libgz-math8 >=8.1.1,<9.0a0
+  - libgz-msgs11 >=11.1.0,<12.0a0
+  - libgz-plugin3 >=3.1.0,<4.0a0
+  - libgz-rendering9 >=9.2.0,<10.0a0
+  - libgz-transport14 >=14.1.0,<15.0a0
+  - libprotobuf >=5.29.3,<5.29.4.0a0
+  - libsdformat15 >=15.3.0,<16.0a0
   - ogre >=1.10.12.1,<1.11.0a0
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   license: Apache-2.0
   license_family: APACHE
-  size: 396099
-  timestamp: 1731392586347
+  size: 400569
+  timestamp: 1751571948934
 - conda: https://conda.anaconda.org/conda-forge/win-64/libgz-sensors9-9.1.0-hcd3be65_1.conda
   sha256: ce9a3dcfbec82fac8354e9ee3da05784c44e7980dae4a96fc6c3b7f527da86e5
   md5: b1d4ee604f1e47c0465c2ae0b7683e46
@@ -26127,39 +25979,39 @@ packages:
   license_family: APACHE
   size: 9925956
   timestamp: 1733419565631
-- conda: https://conda.anaconda.org/conda-forge/win-64/libgz-sim9-9.0.0-h8fb2a06_3.conda
-  sha256: 9c05bb58d015f147a51e2a05d2dfaac4c587a5806962de7109bb8b16c476312e
-  md5: 9d7c6458024e6b97145a04d03a355300
+- conda: https://conda.anaconda.org/conda-forge/win-64/libgz-sim9-9.0.0-ha248be3_7.conda
+  sha256: fa6396482d47a961630e2f5fcb90143254046b9e646263dfc7b0f4d59407a527
+  md5: c5c78b3ce7c54942480734f460a2a806
   depends:
   - dlfcn-win32 >=1.4.1,<2.0a0
   - libabseil * cxx17*
-  - libabseil >=20240722.0,<20240723.0a0
-  - libgz-cmake4 >=4.1.0,<5.0a0
-  - libgz-common6 >=6.0.0,<7.0a0
-  - libgz-fuel-tools10 >=10.0.0,<11.0a0
-  - libgz-gui9 >=9.0.0,<10.0a0
-  - libgz-math8 >=8.1.0,<9.0a0
-  - libgz-msgs11 >=11.0.1,<12.0a0
-  - libgz-physics8 >=8.0.0,<9.0a0
-  - libgz-plugin3 >=3.0.0,<4.0a0
-  - libgz-rendering9 >=9.0.0,<10.0a0
-  - libgz-sensors9 >=9.0.0,<10.0a0
+  - libabseil >=20250127.1,<20250128.0a0
+  - libgz-cmake4 >=4.2.0,<5.0a0
+  - libgz-common6 >=6.1.0,<7.0a0
+  - libgz-fuel-tools10 >=10.1.0,<11.0a0
+  - libgz-gui9 >=9.0.1,<10.0a0
+  - libgz-math8 >=8.2.0,<9.0a0
+  - libgz-msgs11 >=11.1.0,<12.0a0
+  - libgz-physics8 >=8.2.0,<9.0a0
+  - libgz-plugin3 >=3.1.0,<4.0a0
+  - libgz-rendering9 >=9.2.0,<10.0a0
+  - libgz-sensors9 >=9.1.0,<10.0a0
   - libgz-tools2 >=2.0.1,<3.0a0
-  - libgz-transport14 >=14.0.0,<15.0a0
-  - libgz-utils3 >=3.1.0,<4.0a0
-  - libprotobuf >=5.28.2,<5.28.3.0a0
-  - libsdformat15 >=15.0.0,<16.0a0
-  - pybind11-abi 4
+  - libgz-transport14 >=14.1.0,<15.0a0
+  - libgz-utils3 >=3.1.1,<4.0a0
+  - libprotobuf >=5.29.3,<5.29.4.0a0
+  - libsdformat15 >=15.3.0,<16.0a0
+  - pybind11-abi 11
   - python_abi 3.11.* *_cp311
   - qt-main >=5.15.15,<5.16.0a0
-  - tinyxml2 >=10.0.0,<10.1.0a0
+  - tinyxml2 >=11.0.0,<11.1.0a0
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   license: Apache-2.0
   license_family: APACHE
-  size: 10484092
-  timestamp: 1733419859287
+  size: 10426122
+  timestamp: 1753371749235
 - conda: https://conda.anaconda.org/conda-forge/win-64/libgz-sim9-9.0.0-hcb1d94f_7.conda
   sha256: 45b063d81d5b55d0cbac790e6d890db3d6ad3f904dc40923483b1e3520e7b92f
   md5: b56013e33ed56dccddd583d92b77b094
@@ -26193,6 +26045,21 @@ packages:
   license_family: APACHE
   size: 10269036
   timestamp: 1753372463169
+- conda: https://conda.anaconda.org/conda-forge/win-64/libgz-tools-2.0.3-hb268c4e_1.conda
+  sha256: c4947d4a4c434905db6365e789bd12dbe0c7e4492fc853c74504d643c583fb79
+  md5: c2c457a00b79056ea7ea159bb178a4d9
+  depends:
+  - ruby
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  - ucrt >=10.0.20348.0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 48371
+  timestamp: 1759148417520
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libgz-tools2-2.0.1-h17585e0_0.conda
   sha256: 5acb80f086503978e410ec6f2722e2408de9689cc8576f835e62c7bdc43c6e58
   md5: 395c1139239414c65e46e994ead5e997
@@ -26423,27 +26290,6 @@ packages:
   license_family: APACHE
   size: 517594
   timestamp: 1747219050336
-- conda: https://conda.anaconda.org/conda-forge/win-64/libgz-transport14-14.0.0-h0369456_3.conda
-  sha256: 3f087dec3da09f6378069f2eb0655b941a86047b367fa645086b62ba3ca26495
-  md5: 540d9c0a4f94bff7e93ef0a78c5f0d35
-  depends:
-  - cppzmq
-  - libabseil * cxx17*
-  - libabseil >=20240722.0,<20240723.0a0
-  - libgz-cmake4 >=4.1.0,<5.0a0
-  - libgz-msgs11 >=11.0.1,<12.0a0
-  - libgz-tools2 >=2.0.1,<3.0a0
-  - libgz-utils3 >=3.0.0,<4.0a0
-  - libprotobuf >=5.28.2,<5.28.3.0a0
-  - libsqlite >=3.47.0,<4.0a0
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  - zeromq >=4.3.5,<4.3.6.0a0
-  license: Apache-2.0
-  license_family: APACHE
-  size: 491814
-  timestamp: 1731345191873
 - conda: https://conda.anaconda.org/conda-forge/win-64/libgz-transport14-14.1.0-head58a4_0.conda
   sha256: 23038ca5284265257d4760f63e57923f592fa23c9d7815cb565b6b8b1aee5105
   md5: 1d9c526d30c86e7ef1b85cbf1f959d83
@@ -26465,6 +26311,30 @@ packages:
   license_family: APACHE
   size: 502896
   timestamp: 1747219915474
+- conda: https://conda.anaconda.org/conda-forge/win-64/libgz-transport14-14.1.0-py313h7b44034_2.conda
+  sha256: bc720c6ba4cec9f9cc64b3296c374cb4cf9d6056b7f2f656eefa1673aedbae73
+  md5: 5f0177ca7e841a527e180463f2982ed7
+  depends:
+  - cppzmq
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  - ucrt >=10.0.20348.0
+  - libgz-cmake4 >=4.2.0,<5.0a0
+  - libgz-msgs11 >=11.1.0,<12.0a0
+  - zeromq >=4.3.5,<4.3.6.0a0
+  - libgz-tools2 >=2.0.1,<3.0a0
+  - libgz-utils3 >=3.1.1,<4.0a0
+  - libprotobuf >=5.29.3,<5.29.4.0a0
+  - libsqlite >=3.50.3,<4.0a0
+  - libabseil >=20250127.1,<20250128.0a0
+  - libabseil * cxx17*
+  license: Apache-2.0
+  license_family: APACHE
+  size: 556320
+  timestamp: 1753365935732
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libgz-utils2-2.2.0-h5888daf_1.conda
   sha256: 2c0a504271025efaf30c090d510f33a6a133f406a00b5c3ddbab60f1132fefce
   md5: 17fc2ed903a613f4565c83b301ad0cbd
@@ -26527,6 +26397,19 @@ packages:
   license_family: APACHE
   size: 59517
   timestamp: 1735638385714
+- conda: https://conda.anaconda.org/conda-forge/win-64/libgz-utils2-2.2.1-h5112557_2.conda
+  sha256: b17ae9a2763cc9d96f2483ac9aec9e4f5128b40a9d8ba3db357972c20eeed89a
+  md5: 5cd9f60e59b7021361fb89588de8333d
+  depends:
+  - cli11
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  - ucrt >=10.0.20348.0
+  - libgz-cmake3 >=3.5.5,<4.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 63846
+  timestamp: 1767701526638
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libgz-utils3-3.1.0-h6ea83cf_0.conda
   sha256: 8c415049ee0907e948c42792068c56ee0f6e87aa113a3773d564a2c1892c167c
   md5: bb7f466f7448e82511028cabf8d4d00b
@@ -26633,20 +26516,23 @@ packages:
   license_family: APACHE
   size: 65501
   timestamp: 1743717322505
-- conda: https://conda.anaconda.org/conda-forge/win-64/libgz-utils3-3.1.0-hb990982_0.conda
-  sha256: 35f0b01fe9a2527402d307d5eaf38325f257d79906d00db3ef89e0163805488b
-  md5: 4d3d243dc53e1c62d11d04ca028968c0
+- conda: https://conda.anaconda.org/conda-forge/win-64/libgz-utils3-3.1.1-h3ca27b7_2.conda
+  sha256: 3e5d72246d291b037e7b455f0d2ebc14dc59ee0fd5bdc75598d8d67927863e45
+  md5: 212be0f53921378a126e4bb87800dbbb
   depends:
   - cli11
-  - libgz-cmake4 >=4.1.0,<5.0a0
-  - spdlog >=1.14.1,<1.15.0a0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  - ucrt >=10.0.20348.0
+  - spdlog >=1.15.3,<1.16.0a0
+  - libgz-cmake4 >=4.2.0,<5.0a0
   license: Apache-2.0
   license_family: APACHE
-  size: 68835
-  timestamp: 1731756428102
+  size: 74705
+  timestamp: 1759142889347
 - conda: https://conda.anaconda.org/conda-forge/win-64/libgz-utils3-3.1.1-hb55fcea_1.conda
   sha256: 9607b2e3eb97e6e718800c47f803718d3e8b5ed49da4a5e4084b3c817fbed4c9
   md5: 0cb8c84a8c2a30446a47daedefea6266
@@ -26722,22 +26608,6 @@ packages:
   license_family: LGPL
   size: 442225
   timestamp: 1741014159707
-- conda: https://conda.anaconda.org/conda-forge/win-64/libheif-1.19.7-gpl_h2684147_100.conda
-  sha256: 55965154b428c22cf0fcf1bd53844c1c4c59f0301ece36782b082a92a51e52af
-  md5: d7a6c3df36c3281b38164ce518d45528
-  depends:
-  - aom >=3.9.1,<3.10.0a0
-  - dav1d >=1.2.1,<1.2.2.0a0
-  - libavif16 >=1.2.0,<2.0a0
-  - libde265 >=1.0.15,<1.0.16.0a0
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  - x265 >=3.5,<3.6.0a0
-  license: LGPL-3.0-or-later
-  license_family: LGPL
-  size: 391084
-  timestamp: 1741307167944
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libhiredis-1.0.2-h2cc385e_0.tar.bz2
   sha256: ee39c69df4fb39cfe1139ac4f7405bb066eba773e11ba3ab7c33835be00c2e48
   md5: b34907d3a81a3cd8095ee83d174c074a
@@ -26904,6 +26774,16 @@ packages:
   license_family: Apache
   size: 456913
   timestamp: 1744841708967
+- conda: https://conda.anaconda.org/conda-forge/win-64/libhwy-1.3.0-ha71e874_1.conda
+  sha256: c722a04f065656b988a46dee87303ff0bf037179c50e2e76704b693def7f9a96
+  md5: f4649d4b6bf40d616eda57d6255d2333
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  license: Apache-2.0 OR BSD-3-Clause
+  size: 536186
+  timestamp: 1758894243956
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libi2c-4.4-h5888daf_0.conda
   sha256: c6edef9b97719961a68aa631e4b0ed4dcd34254646e10b37555562c119ddefc5
   md5: 36c48b1a98b62f477ddb1185eecddbc5
@@ -27184,25 +27064,6 @@ packages:
   license_family: APACHE
   size: 475002
   timestamp: 1743774070851
-- conda: https://conda.anaconda.org/conda-forge/win-64/libignition-common3-3.15.1-h3fb02f2_5.conda
-  sha256: 99e9edfb89ac73fa82e5a56edbd46a6a973711ca54a6cab8cc8e3c35153e9f36
-  md5: d745ac9cffe6ce24042216b0d1530018
-  depends:
-  - dlfcn-win32 >=1.4.1,<2.0a0
-  - ffmpeg >=7.0.2,<8.0a0
-  - freeimage >=3.18.0,<3.19.0a0
-  - gts >=0.7.6,<0.8.0a0
-  - libglib >=2.80.3,<3.0a0
-  - libignition-cmake2 >=2.17.2,<3.0a0
-  - libignition-math6 >=6.15.1,<7.0a0
-  - tinyxml2 >=10.0.0,<10.1.0a0
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  license: Apache-2.0
-  license_family: APACHE
-  size: 535726
-  timestamp: 1725252342389
 - conda: https://conda.anaconda.org/conda-forge/win-64/libignition-common3-3.17.1-hd7a2a08_0.conda
   sha256: 1f5f8c1049857e6bb875b714fdc840db5a3a2f96ac1cff6299562f32f7fb263b
   md5: b2160088210bfb481f7e9e2e5d01ee02
@@ -27384,28 +27245,6 @@ packages:
   license_family: APACHE
   size: 207305
   timestamp: 1743833236118
-- conda: https://conda.anaconda.org/conda-forge/win-64/libignition-fuel-tools4-4.6.0-h78cb115_12.conda
-  sha256: 37319d18ddc26c447b7b7c497b1a8c37e4ae896ee6a60956a6dd8421b43d11fe
-  md5: 14c5d5e0c946c7cc68f8eda892a757af
-  depends:
-  - jsoncpp >=1.9.6,<1.9.7.0a0
-  - libcurl >=8.10.1,<9.0a0
-  - libignition-common3 >=3.15.1,<4.0a0
-  - libignition-math6 >=6.15.1,<7.0a0
-  - libignition-msgs5 >=5.11.0,<6.0a0
-  - libignition-tools1 >=1.5.0,<2.0a0
-  - libprotobuf >=5.28.2,<5.28.3.0a0
-  - libzip >=1.11.1,<2.0a0
-  - libzlib >=1.3.1,<2.0a0
-  - tinyxml2 >=10.0.0,<10.1.0a0
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  - yaml >=0.2.5,<0.3.0a0
-  license: Apache-2.0
-  license_family: APACHE
-  size: 214962
-  timestamp: 1729584356374
 - conda: https://conda.anaconda.org/conda-forge/win-64/libignition-fuel-tools4-4.6.0-h7dbd45c_15.conda
   sha256: 5b1df37d8ef67d0231c82c211b508c5a8666f561309b7ef5641ac63b0676339e
   md5: b49279630bd2927ee68769a63222090e
@@ -27520,22 +27359,22 @@ packages:
   license_family: APACHE
   size: 1055826
   timestamp: 1725376199646
-- conda: https://conda.anaconda.org/conda-forge/win-64/libignition-math6-6.15.1-py311h1e2dbc3_2.conda
-  sha256: f57fa44428cb5e4899f3046762e5f49436c75c68a19e08581f3f3988c45e69fd
-  md5: 9cfe51f0318c0e495ab8f4b7efba2ee1
+- conda: https://conda.anaconda.org/conda-forge/win-64/libignition-math6-6.15.1-py311hffe65ed_4.conda
+  sha256: 8ed499091bee231f63bfd6ff5dc65bb6ce5810752d711d55c91ba45243c15c00
+  md5: d49d79fd27d482f54c676c7dec2a1ae2
   depends:
   - eigen
   - libignition-cmake2 >=2.17.2,<3.0a0
-  - pybind11-abi 4
+  - pybind11-abi 11
   - python >=3.11,<3.12.0a0
   - python_abi 3.11.* *_cp311
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   license: Apache-2.0
   license_family: APACHE
-  size: 718994
-  timestamp: 1725375903149
+  size: 751531
+  timestamp: 1756310591824
 - conda: https://conda.anaconda.org/conda-forge/win-64/libignition-math6-6.15.1-py39he991b8b_3.conda
   sha256: 90f2050cc72df66bd35ed075d930cbd05468e8f24294d2dcf8f9f03888e5d839
   md5: 33f4fa8c53130196dea1dbe748532b88
@@ -27699,23 +27538,6 @@ packages:
   license_family: APACHE
   size: 1506299
   timestamp: 1743700824850
-- conda: https://conda.anaconda.org/conda-forge/win-64/libignition-msgs5-5.11.0-hddf5caf_11.conda
-  sha256: 664692cca3a0ca9cfb195ac5196e5ec302687b92c357ee9c5f43d9db6932e079
-  md5: 77a385782a6dad245cabf3c5d2fbc88e
-  depends:
-  - libabseil * cxx17*
-  - libabseil >=20240722.0,<20240723.0a0
-  - libignition-math6 >=6.15.1,<7.0a0
-  - libignition-tools1 >=1.5.0,<2.0a0
-  - libprotobuf >=5.28.2,<5.28.3.0a0
-  - tinyxml2 >=10.0.0,<10.1.0a0
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  license: Apache-2.0
-  license_family: APACHE
-  size: 1530082
-  timestamp: 1729571573993
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libignition-tools1-1.5.0-h1caa08d_3.conda
   sha256: f54f070a5304af7ef075142e459410d91ea1a90f9fe3db1acf60b2178e25304e
   md5: 3ab1673a7669a9c9c54c4cc5534a8740
@@ -27920,25 +27742,6 @@ packages:
   license_family: APACHE
   size: 308281
   timestamp: 1729585153169
-- conda: https://conda.anaconda.org/conda-forge/win-64/libignition-transport8-8.4.0-h6173c75_13.conda
-  sha256: cb29d5cf66e7917be288a4761d4df67a7f6af198faaf7751cebd86af7a8155a1
-  md5: 8939d6eb2ab70e6095fd2cabe0ad13b5
-  depends:
-  - cppzmq
-  - libabseil * cxx17*
-  - libabseil >=20240722.0,<20240723.0a0
-  - libignition-cmake2 >=2.17.2,<3.0a0
-  - libignition-msgs5 >=5.11.0,<6.0a0
-  - libignition-tools1 >=1.5.0,<2.0a0
-  - libprotobuf >=5.28.2,<5.28.3.0a0
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  - zeromq >=4.3.5,<4.3.6.0a0
-  license: Apache-2.0
-  license_family: APACHE
-  size: 303531
-  timestamp: 1729585827748
 - conda: https://conda.anaconda.org/conda-forge/win-64/libignition-transport8-8.4.0-h7824680_15.conda
   sha256: eb634599b3dbdcfad64b02e04264948e4867164cf1d032a5ee3c3ea2a3dc3b53
   md5: 6c5cc9c360aea7a218987a0abe6a9ba9
@@ -28133,6 +27936,20 @@ packages:
   license_family: BSD
   size: 1022654
   timestamp: 1749126610763
+- conda: https://conda.anaconda.org/conda-forge/win-64/libjxl-0.11.1-hb7713f0_4.conda
+  sha256: 019de576f4eb0ca78ba2466514f4f84b83e222d9be83ea920f6c0f3ae260b71a
+  md5: f0584648fbaf89d1cef77d94bc838d3a
+  depends:
+  - libbrotlidec >=1.1.0,<1.2.0a0
+  - libbrotlienc >=1.1.0,<1.2.0a0
+  - libhwy >=1.3.0,<1.4.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1091608
+  timestamp: 1757584385770
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libkml-1.3.0-hf539b9f_1021.conda
   sha256: 721c3916d41e052ffd8b60e77f2da6ee47ff0d18babfca48ccf93606f1e0656a
   md5: e8c7620cc49de0c6a2349b6dd6e39beb
@@ -28659,20 +28476,20 @@ packages:
   license_family: BSD
   size: 150305
   timestamp: 1746546888129
-- conda: https://conda.anaconda.org/conda-forge/win-64/libmatio-1.5.28-he9c0ad6_2.conda
-  sha256: c1c9a3138e0f8e49da0829a5142e6797abe5b1f552a344d0a56581d360e0e6a9
-  md5: dcf7f5465f53e5ebb0f23bba913bbf77
+- conda: https://conda.anaconda.org/conda-forge/win-64/libmatio-1.5.30-hbeb426f_0.conda
+  sha256: 733183c1dc37501af50a6e32afaac287e5aa3383d0829faaaa45c3b4993bf325
+  md5: 379cd16225411177a51f9bab3619f145
   depends:
-  - hdf5 >=1.14.3,<1.14.4.0a0
+  - hdf5 >=1.14.6,<1.14.7.0a0
   - libzlib >=1.3.1,<2.0a0
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - zlib
   license: BSD-2-Clause
   license_family: BSD
-  size: 149868
-  timestamp: 1733292950711
+  size: 186697
+  timestamp: 1767753708811
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libmicrohttpd-1.0.1-hbc5bc17_1.conda
   sha256: 0aa6287ec8698090d09def3416c38e5975fd2b76cd24ff5dac97edcdd6e1fbd4
   md5: c384e4dcd3c345b54bfb79d9ff712349
@@ -28872,28 +28689,28 @@ packages:
   license_family: MIT
   size: 685490
   timestamp: 1733232513009
-- conda: https://conda.anaconda.org/conda-forge/win-64/libnetcdf-4.9.2-nompi_h008f77d_116.conda
-  sha256: f2976ffb686974f6df6195f34b36d1366e66ac9c57edc501f65474133eb4d357
-  md5: cb226a2cc8909d2fa636fba3f623ae6b
+- conda: https://conda.anaconda.org/conda-forge/win-64/libnetcdf-4.9.2-nompi_ha45073a_118.conda
+  sha256: f179694134c0d0ebc600f1ef0d6797c17a894fea8f089a91db6e7bc04e467b76
+  md5: 54557b761dc20f53f504271208cd88c7
   depends:
   - blosc >=1.21.6,<2.0a0
   - bzip2 >=1.0.8,<2.0a0
   - hdf4 >=4.2.15,<4.2.16.0a0
-  - hdf5 >=1.14.3,<1.14.4.0a0
-  - libaec >=1.1.3,<2.0a0
-  - libcurl >=8.10.1,<9.0a0
-  - libxml2 >=2.13.5,<2.14.0a0
+  - hdf5 >=1.14.6,<1.14.7.0a0
+  - libaec >=1.1.4,<2.0a0
+  - libcurl >=8.14.1,<9.0a0
+  - libxml2 >=2.13.8,<2.14.0a0
   - libzip >=1.11.2,<2.0a0
   - libzlib >=1.3.1,<2.0a0
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - zlib
-  - zstd >=1.5.6,<1.6.0a0
+  - zstd >=1.5.7,<1.6.0a0
   license: MIT
   license_family: MIT
-  size: 624813
-  timestamp: 1733232696254
+  size: 626420
+  timestamp: 1754055160171
 - conda: https://conda.anaconda.org/conda-forge/win-64/libnetcdf-4.9.2-nompi_he045f6b_117.conda
   sha256: d6ab060abc23909b69ef99e871599ae8d62cbfd901b823a142a3cb7cf90a7681
   md5: 92dc648b5a8d990c70297ed472588499
@@ -29635,51 +29452,55 @@ packages:
   license_family: Apache
   size: 17405398
   timestamp: 1750898268807
-- conda: https://conda.anaconda.org/conda-forge/win-64/libopencv-4.10.0-qt6_py311h375890f_613.conda
-  sha256: 4ee95bfd018675460d9bd4518961c6bf59e5728f09fa76f4e8437826adab11ac
-  md5: f3319ea36a15e2148e0ef9834a1061f0
+- conda: https://conda.anaconda.org/conda-forge/win-64/libopencv-4.12.0-qt6_py311hf39e5f2_600.conda
+  sha256: 8e75630cc85990e38f73b4d57a1e2f446bea8ea39bdee36901bcbe165423086c
+  md5: 2152433b6b9cc782d7222c06dc066b7f
   depends:
-  - ffmpeg >=7.1.0,<8.0a0
-  - freetype >=2.12.1,<3.0a0
-  - harfbuzz >=9.0.0
-  - hdf5 >=1.14.3,<1.14.4.0a0
-  - jasper >=4.2.4,<5.0a0
+  - ffmpeg >=7.1.1,<8.0a0
+  - harfbuzz >=11.0.1
+  - hdf5 >=1.14.6,<1.14.7.0a0
+  - jasper >=4.2.5,<5.0a0
   - libasprintf >=0.22.5,<1.0a0
+  - libavif16 >=1.3.0,<2.0a0
   - libcblas >=3.9.0,<4.0a0
-  - libexpat >=2.6.4,<3.0a0
+  - libexpat >=2.7.0,<3.0a0
+  - libfreetype >=2.13.3
+  - libfreetype6 >=2.13.3
   - libgettextpo >=0.22.5,<1.0a0
-  - libglib >=2.82.2,<3.0a0
+  - libglib >=2.84.2,<3.0a0
   - libintl >=0.22.5,<1.0a0
-  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libjpeg-turbo >=3.1.0,<4.0a0
   - liblapack >=3.9.0,<4.0a0
   - liblapacke >=3.9.0,<4.0a0
-  - libopenvino >=2024.5.0,<2024.5.1.0a0
-  - libopenvino-auto-batch-plugin >=2024.5.0,<2024.5.1.0a0
-  - libopenvino-auto-plugin >=2024.5.0,<2024.5.1.0a0
-  - libopenvino-hetero-plugin >=2024.5.0,<2024.5.1.0a0
-  - libopenvino-intel-cpu-plugin >=2024.5.0,<2024.5.1.0a0
-  - libopenvino-intel-gpu-plugin >=2024.5.0,<2024.5.1.0a0
-  - libopenvino-ir-frontend >=2024.5.0,<2024.5.1.0a0
-  - libopenvino-onnx-frontend >=2024.5.0,<2024.5.1.0a0
-  - libopenvino-paddle-frontend >=2024.5.0,<2024.5.1.0a0
-  - libopenvino-pytorch-frontend >=2024.5.0,<2024.5.1.0a0
-  - libopenvino-tensorflow-frontend >=2024.5.0,<2024.5.1.0a0
-  - libopenvino-tensorflow-lite-frontend >=2024.5.0,<2024.5.1.0a0
-  - libpng >=1.6.44,<1.7.0a0
-  - libprotobuf >=5.28.2,<5.28.3.0a0
+  - libopenvino >=2025.0.0,<2025.0.1.0a0
+  - libopenvino-auto-batch-plugin >=2025.0.0,<2025.0.1.0a0
+  - libopenvino-auto-plugin >=2025.0.0,<2025.0.1.0a0
+  - libopenvino-hetero-plugin >=2025.0.0,<2025.0.1.0a0
+  - libopenvino-intel-cpu-plugin >=2025.0.0,<2025.0.1.0a0
+  - libopenvino-intel-gpu-plugin >=2025.0.0,<2025.0.1.0a0
+  - libopenvino-ir-frontend >=2025.0.0,<2025.0.1.0a0
+  - libopenvino-onnx-frontend >=2025.0.0,<2025.0.1.0a0
+  - libopenvino-paddle-frontend >=2025.0.0,<2025.0.1.0a0
+  - libopenvino-pytorch-frontend >=2025.0.0,<2025.0.1.0a0
+  - libopenvino-tensorflow-frontend >=2025.0.0,<2025.0.1.0a0
+  - libopenvino-tensorflow-lite-frontend >=2025.0.0,<2025.0.1.0a0
+  - libpng >=1.6.50,<1.7.0a0
+  - libprotobuf >=5.29.3,<5.29.4.0a0
   - libtiff >=4.7.0,<4.8.0a0
-  - libwebp-base >=1.4.0,<2.0a0
+  - libwebp-base >=1.5.0,<2.0a0
   - libzlib >=1.3.1,<2.0a0
-  - numpy >=1.19,<3
-  - openexr >=3.3.2,<3.4.0a0
-  - qt6-main >=6.7.3,<6.9.0a0
+  - numpy >=1.23,<3
+  - openexr >=3.3.4,<3.4.0a0
+  - qt6-main >=6.9.1,<6.10.0a0
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  constrains:
+  - imath<3.2.0a0
   license: Apache-2.0
   license_family: Apache
-  size: 33192084
-  timestamp: 1734361231501
+  size: 34147022
+  timestamp: 1751759661653
 - conda: https://conda.anaconda.org/conda-forge/win-64/libopencv-4.12.0-qt6_py39h45bf879_600.conda
   sha256: cb920c92c9c7305b7832dbc6fd6afd40634bd5a43020bcbb9103165fbffe5a95
   md5: 3e04b3e60fc19477865d5c6b7f06d659
@@ -29845,17 +29666,6 @@ packages:
   - tbb >=2021.13.0
   size: 4139593
   timestamp: 1742042352150
-- conda: https://conda.anaconda.org/conda-forge/win-64/libopenvino-2024.5.0-hfe1841e_0.conda
-  sha256: 50af575bfbd2a61189eafcec5b16c2f6e9d4fc73989fffb46ec58f8e0761d8e4
-  md5: 9bb55a464510a566a482aeb120ab105f
-  depends:
-  - pugixml >=1.14,<1.15.0a0
-  - tbb >=2021.13.0
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  size: 3382857
-  timestamp: 1732894850238
 - conda: https://conda.anaconda.org/conda-forge/win-64/libopenvino-2025.0.0-hb1d9b14_3.conda
   sha256: 739f3570dd9ff9261d3e8a1f965a81cb379d8cdaac1b3727284f01c3af3bae7b
   md5: 265783a27455cbfd3634778d9b931ed7
@@ -29993,17 +29803,6 @@ packages:
   - tbb >=2021.13.0
   size: 104368
   timestamp: 1742042427434
-- conda: https://conda.anaconda.org/conda-forge/win-64/libopenvino-auto-batch-plugin-2024.5.0-h04f32e0_0.conda
-  sha256: beccc362f3452276d4a0d70e918a92a3431b6940d4cec81b418f2e70f6991caa
-  md5: 4729f7dfaf5fb87f620e5184f59c4bfb
-  depends:
-  - libopenvino 2024.5.0 hfe1841e_0
-  - tbb >=2021.13.0
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  size: 98925
-  timestamp: 1732894888009
 - conda: https://conda.anaconda.org/conda-forge/win-64/libopenvino-auto-batch-plugin-2025.0.0-h04f32e0_3.conda
   sha256: 0f0527efc2028f30022031e8815ccd281d693e1a3cf7634935dbe14804cccb62
   md5: 22588deedffa127c26d96f85412c1b73
@@ -30097,17 +29896,6 @@ packages:
   - tbb >=2021.13.0
   size: 208634
   timestamp: 1742042444660
-- conda: https://conda.anaconda.org/conda-forge/win-64/libopenvino-auto-plugin-2024.5.0-h04f32e0_0.conda
-  sha256: 80727cb7ca7ff73478f2421f6f27ff719ff1e0ecb6c114a706bdb0b770ae8e1b
-  md5: abc259655430b2bd8307b1b0b4ddc099
-  depends:
-  - libopenvino 2024.5.0 hfe1841e_0
-  - tbb >=2021.13.0
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  size: 192912
-  timestamp: 1732894926342
 - conda: https://conda.anaconda.org/conda-forge/win-64/libopenvino-auto-plugin-2025.0.0-h04f32e0_3.conda
   sha256: 5cf3594d461aa98c0fe3d4840e1e8694ad51fff0e6868ace9d1813b6ed1d210b
   md5: 05f7ca19e5ed62a1394ea8de850b3e39
@@ -30201,17 +29989,6 @@ packages:
   - pugixml >=1.15,<1.16.0a0
   size: 174158
   timestamp: 1742042462067
-- conda: https://conda.anaconda.org/conda-forge/win-64/libopenvino-hetero-plugin-2024.5.0-h372dad0_0.conda
-  sha256: 72bed5ce1978b482f9d46c531542498474f062df34cf5e2dcbb8cf752c5ca0fe
-  md5: d545e518fdf2af59b56b8589d8eb60aa
-  depends:
-  - libopenvino 2024.5.0 hfe1841e_0
-  - pugixml >=1.14,<1.15.0a0
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  size: 159349
-  timestamp: 1732894957727
 - conda: https://conda.anaconda.org/conda-forge/win-64/libopenvino-hetero-plugin-2025.0.0-hb61b842_3.conda
   sha256: f7f5ae68081da308644103775d38ea194347ea8b55363e8ff49da9fd2fd5dd47
   md5: 8bf1a9d0e65f2a58e0be816cb801c4db
@@ -30269,18 +30046,6 @@ packages:
   - tbb >=2021.13.0
   size: 11667694
   timestamp: 1742043215871
-- conda: https://conda.anaconda.org/conda-forge/win-64/libopenvino-intel-cpu-plugin-2024.5.0-hfe1841e_0.conda
-  sha256: c6dc3bee29603cd0008a6fb233667aa0a7707613cfb7f0e215ceee21ab080f25
-  md5: 1b94c13ab1697f9ebc9698e98bbee8c2
-  depends:
-  - libopenvino 2024.5.0 hfe1841e_0
-  - pugixml >=1.14,<1.15.0a0
-  - tbb >=2021.13.0
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  size: 8172189
-  timestamp: 1732894989822
 - conda: https://conda.anaconda.org/conda-forge/win-64/libopenvino-intel-cpu-plugin-2025.0.0-hb1d9b14_3.conda
   sha256: bca7df94a926c80494385f257a9d81f3e8e783386e5c8a75a28eb49cb2ddba90
   md5: f96e1b760d32fa17c4dc12978eace146
@@ -30319,19 +30084,6 @@ packages:
   - tbb >=2021.13.0
   size: 10119530
   timestamp: 1742047030958
-- conda: https://conda.anaconda.org/conda-forge/win-64/libopenvino-intel-gpu-plugin-2024.5.0-hfe1841e_0.conda
-  sha256: 1cb59ef7f7e5a604205de938f4c6c8ff4961c3354606f72c4cb2d03e24572d43
-  md5: 92f84e9812f07e821b8cae5ec996dc8f
-  depends:
-  - khronos-opencl-icd-loader >=2024.5.8
-  - libopenvino 2024.5.0 hfe1841e_0
-  - pugixml >=1.14,<1.15.0a0
-  - tbb >=2021.13.0
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  size: 7693941
-  timestamp: 1732895044904
 - conda: https://conda.anaconda.org/conda-forge/win-64/libopenvino-intel-gpu-plugin-2025.0.0-hb1d9b14_3.conda
   sha256: f8ebf9385485357dcfef937e574852568a3240b0e190f19417802692fccb7062
   md5: 37278c95cc7faa59a80b3886606e25c5
@@ -30452,17 +30204,6 @@ packages:
   - pugixml >=1.15,<1.16.0a0
   size: 174794
   timestamp: 1742042478544
-- conda: https://conda.anaconda.org/conda-forge/win-64/libopenvino-ir-frontend-2024.5.0-h372dad0_0.conda
-  sha256: 4d551cf4af56de7e4f4c1d757597170523189a68873adb8da23eee6f8c8f95ef
-  md5: 691684383ad5f1d56ba9b6a78e33441d
-  depends:
-  - libopenvino 2024.5.0 hfe1841e_0
-  - pugixml >=1.14,<1.15.0a0
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  size: 159033
-  timestamp: 1732895094293
 - conda: https://conda.anaconda.org/conda-forge/win-64/libopenvino-ir-frontend-2025.0.0-hb61b842_3.conda
   sha256: 93f38e934e3359f50052c3507bc35207de1f9b266283e38012662d962be1a3e8
   md5: c15601d32d79f5fc25341b97b1d66593
@@ -30572,19 +30313,6 @@ packages:
   - libprotobuf >=5.29.3,<5.29.4.0a0
   size: 1284556
   timestamp: 1742042510559
-- conda: https://conda.anaconda.org/conda-forge/win-64/libopenvino-onnx-frontend-2024.5.0-h7d5e7ba_0.conda
-  sha256: 6afc4383fcfc57e85ab11deafcb01b245c8b0e6482882e1a4e7f0c7c7996f890
-  md5: efecaff4a4659eb56d6fe2a1993e68a6
-  depends:
-  - libabseil * cxx17*
-  - libabseil >=20240722.0,<20240723.0a0
-  - libopenvino 2024.5.0 hfe1841e_0
-  - libprotobuf >=5.28.2,<5.28.3.0a0
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  size: 1023758
-  timestamp: 1732895128230
 - conda: https://conda.anaconda.org/conda-forge/win-64/libopenvino-onnx-frontend-2025.0.0-hf9c6bd6_3.conda
   sha256: 2afb3f8df012068b370efca994bd224bfa75e1228e8e7cea646e59f585d8c59a
   md5: 75e66013b7b10ee5abbcfd988c97c81e
@@ -30696,19 +30424,6 @@ packages:
   - libprotobuf >=5.29.3,<5.29.4.0a0
   size: 431639
   timestamp: 1742042534121
-- conda: https://conda.anaconda.org/conda-forge/win-64/libopenvino-paddle-frontend-2024.5.0-h7d5e7ba_0.conda
-  sha256: 91ac6425c5fa53423e8d0359e09a9277db0ff5daac40b6ec3d9cb7b88deeb18c
-  md5: 3ec6540bf5842e58593592fe2cb6d0e9
-  depends:
-  - libabseil * cxx17*
-  - libabseil >=20240722.0,<20240723.0a0
-  - libopenvino 2024.5.0 hfe1841e_0
-  - libprotobuf >=5.28.2,<5.28.3.0a0
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  size: 421490
-  timestamp: 1732895164264
 - conda: https://conda.anaconda.org/conda-forge/win-64/libopenvino-paddle-frontend-2025.0.0-hf9c6bd6_3.conda
   sha256: aef47b7f002ca930eb97165c3bc14146a57daf642107a1030aaf0055dab88c3a
   md5: a43f8073e100f8630df3b151c2fd9362
@@ -30796,16 +30511,6 @@ packages:
   - libopenvino 2025.0.0 h3f17238_3
   size: 789148
   timestamp: 1742042551199
-- conda: https://conda.anaconda.org/conda-forge/win-64/libopenvino-pytorch-frontend-2024.5.0-he0c23c2_0.conda
-  sha256: 52d8279a9be1a920efda8c7509275799445a3fa076d63edefdd99d6c59e38228
-  md5: bbfc03bb777f345ebe4d3e2b96304e19
-  depends:
-  - libopenvino 2024.5.0 hfe1841e_0
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  size: 691428
-  timestamp: 1732895195469
 - conda: https://conda.anaconda.org/conda-forge/win-64/libopenvino-pytorch-frontend-2025.0.0-he0c23c2_3.conda
   sha256: ec4f3a2f057302dc2d15b60a3fdec9e65d4a0415fcd1ca9bd9409631a9c9a47c
   md5: eefe7c5981902b97678d900458e4248b
@@ -30922,20 +30627,6 @@ packages:
   - snappy >=1.2.1,<1.3.0a0
   size: 945306
   timestamp: 1742042598581
-- conda: https://conda.anaconda.org/conda-forge/win-64/libopenvino-tensorflow-frontend-2024.5.0-h7d689a8_0.conda
-  sha256: cd736af3d04bb64819a2c291b5816b46041a1a59c559fd15e24a7d309553eca2
-  md5: fa43b56427e78c219e3bbf4c2ed83370
-  depends:
-  - libabseil * cxx17*
-  - libabseil >=20240722.0,<20240723.0a0
-  - libopenvino 2024.5.0 hfe1841e_0
-  - libprotobuf >=5.28.2,<5.28.3.0a0
-  - snappy >=1.2.1,<1.3.0a0
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  size: 892733
-  timestamp: 1732895230040
 - conda: https://conda.anaconda.org/conda-forge/win-64/libopenvino-tensorflow-frontend-2025.0.0-hd51e7bd_3.conda
   sha256: 9fbefd6ff948c27528d52bf4d84e0d7e4e366b3f0de540e538d3204e4f6a88f3
   md5: dee8acb258065e4144ffee81a9e746ad
@@ -31024,16 +30715,6 @@ packages:
   - libopenvino 2025.0.0 h3f17238_3
   size: 384569
   timestamp: 1742042618165
-- conda: https://conda.anaconda.org/conda-forge/win-64/libopenvino-tensorflow-lite-frontend-2024.5.0-he0c23c2_0.conda
-  sha256: c4fabee6d3060287eec883306377b1037fcabc2ba6e3865fb61ecd2ae7154a02
-  md5: 5006625e477e9a70bdcf96d724b35de6
-  depends:
-  - libopenvino 2024.5.0 hfe1841e_0
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  size: 336917
-  timestamp: 1732895261855
 - conda: https://conda.anaconda.org/conda-forge/win-64/libopenvino-tensorflow-lite-frontend-2025.0.0-he0c23c2_3.conda
   sha256: 55f7764ae0f7fce4b1b28f5fc9db963804f6c5612d162a689d375db8e37e54bd
   md5: 392d4d2e9dc870aa63d2642448d8f3d9
@@ -31151,17 +30832,6 @@ packages:
   license: zlib-acknowledgement
   size: 259291
   timestamp: 1750095759683
-- conda: https://conda.anaconda.org/conda-forge/win-64/libpng-1.6.49-h7a4582a_0.conda
-  sha256: 8876a2d32d3538675e035b6560691471a1571835c0bcbf23816c24c460d31439
-  md5: 27269977c8f25d499727ceabc47cee3d
-  depends:
-  - libzlib >=1.3.1,<2.0a0
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  license: zlib-acknowledgement
-  size: 347727
-  timestamp: 1750096091724
 - conda: https://conda.anaconda.org/conda-forge/win-64/libpng-1.6.50-h7351971_1.conda
   sha256: e84b041f91c94841cb9b97952ab7f058d001d4a15ed4ce226ec5fdb267cc0fa5
   md5: 3ae6e9f5c47c495ebeed95651518be61
@@ -31176,6 +30846,17 @@ packages:
   license: zlib-acknowledgement
   size: 382709
   timestamp: 1753879944850
+- conda: https://conda.anaconda.org/conda-forge/win-64/libpng-1.6.53-h7351971_0.conda
+  sha256: e5d061e7bdb2b97227b6955d1aa700a58a5703b5150ab0467cc37de609f277b6
+  md5: fb6f43f6f08ca100cb24cff125ab0d9e
+  depends:
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  - ucrt >=10.0.20348.0
+  - libzlib >=1.3.1,<2.0a0
+  license: zlib-acknowledgement
+  size: 383702
+  timestamp: 1764981078732
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libpq-17.5-h27ae623_0.conda
   sha256: 2dbcef0db82e0e7b6895b6c0dadd3d36c607044c40290c7ca10656f3fca3166f
   md5: 6458be24f09e1b034902ab44fe9de908
@@ -31344,20 +31025,20 @@ packages:
   license_family: BSD
   size: 2613087
   timestamp: 1745158781377
-- conda: https://conda.anaconda.org/conda-forge/win-64/libprotobuf-5.28.2-hcaed137_0.conda
-  sha256: 798c6675fb709ceaa6a9bd83e9cffe06bc98e83f519c7d7d881243d2e6d0c34d
-  md5: 97c6d2f83edd7b400a22660e2a4d1488
+- conda: https://conda.anaconda.org/conda-forge/win-64/libprotobuf-5.29.3-hd33f5f0_3.conda
+  sha256: 4279fd791b3dc7701af5ef931621f6b381c72f4b49ef3f3e17f7e1526d9688ba
+  md5: 5ad3febd356c46036718d04dd6f47a07
   depends:
   - libabseil * cxx17*
-  - libabseil >=20240722.0,<20240723.0a0
+  - libabseil >=20250127.1,<20250128.0a0
   - libzlib >=1.3.1,<2.0a0
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   license: BSD-3-Clause
   license_family: BSD
-  size: 6033581
-  timestamp: 1728565880841
+  size: 7029271
+  timestamp: 1764145684746
 - conda: https://conda.anaconda.org/conda-forge/win-64/libprotobuf-5.29.3-he9d8c4a_1.conda
   sha256: 101b6cd0bde3ea29a161c9d36beda20851c0426e115d845555222e75d620d33e
   md5: d1d3b80a1a04251bd75439b630e874be
@@ -31612,21 +31293,6 @@ packages:
   license: BSD-3-Clause
   size: 167704
   timestamp: 1751053331260
-- conda: https://conda.anaconda.org/conda-forge/win-64/libre2-11-2024.07.02-h4eb7d71_2.conda
-  sha256: f5bcc036ea1946444dc3adc772dfb045ff9e6d3486e924133ad7d018de651738
-  md5: 67612b1af5350b6dcf289db63ec3e685
-  depends:
-  - libabseil * cxx17*
-  - libabseil >=20240722.0,<20240723.0a0
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  constrains:
-  - re2 2024.07.02.*
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 260655
-  timestamp: 1735541391655
 - conda: https://conda.anaconda.org/conda-forge/win-64/libre2-11-2025.06.26-habfad5f_0.conda
   sha256: ab65399d05be6d0e0733068b47d7d57e91e360ec46c7ced9e21d7f80ac8e05c3
   md5: 38df4686fd7b22710a066faa749d9fa3
@@ -31825,18 +31491,6 @@ packages:
   license_family: GPL
   size: 404655
   timestamp: 1741167186009
-- conda: https://conda.anaconda.org/conda-forge/win-64/librttopo-1.1.0-hd4c2148_17.conda
-  sha256: 0f4a1c8ed579f96ccb73245b4002d7152a2a8ecd05a01d49901c5d280561f766
-  md5: 06ea16b8c60b4ce1970c06191f8639d4
-  depends:
-  - geos >=3.13.0,<3.13.1.0a0
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  license: GPL-2.0-or-later
-  license_family: GPL
-  size: 404515
-  timestamp: 1727265928370
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libsanitizer-13.3.0-he8ea267_2.conda
   sha256: 27c4c8bf8e2dd60182d47274389be7c70446df6ed5344206266321ee749158b4
   md5: 2b6cdf7bb95d3d10ef4e38ce0bc95dba
@@ -32114,24 +31768,6 @@ packages:
   license_family: APACHE
   size: 970700
   timestamp: 1747518889913
-- conda: https://conda.anaconda.org/conda-forge/win-64/libsdformat15-15.1.1-hf143461_0.conda
-  sha256: 5af2d131876fd17835b67338460cd13eef89c43c36840aa79813fe16a8167ba4
-  md5: 0019380d81da80e607221a55ca1b9588
-  depends:
-  - dlfcn-win32 >=1.4.1,<2.0a0
-  - libgz-cmake4 >=4.1.0,<5.0a0
-  - libgz-math8 >=8.1.0,<9.0a0
-  - libgz-tools2 >=2.0.1,<3.0a0
-  - libgz-utils3 >=3.1.0,<4.0a0
-  - tinyxml2 >=10.0.0,<10.1.0a0
-  - ucrt >=10.0.20348.0
-  - urdfdom >=4.0.1,<4.1.0a0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  license: Apache-2.0
-  license_family: APACHE
-  size: 825911
-  timestamp: 1739404587180
 - conda: https://conda.anaconda.org/conda-forge/win-64/libsdformat15-15.3.0-he55aed0_0.conda
   sha256: 7f580f571c5d1457668fe8c3c767b74e5a14221877a2521cc17fce342ca38646
   md5: 06d02e663fbdbe3031da87adee4a6315
@@ -32150,6 +31786,27 @@ packages:
   license_family: APACHE
   size: 982352
   timestamp: 1747520930184
+- conda: https://conda.anaconda.org/conda-forge/win-64/libsdformat15-15.3.0-py314h3ff8ef8_3.conda
+  sha256: 89522bc8fb06b96d6b2f3ce0db06977c329dfb30bb740b5c2d9d17ae6aab2d9f
+  md5: 6b59ac2250a7cc36424e9879c4ba4df0
+  depends:
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  - ucrt >=10.0.20348.0
+  - libgz-cmake4 >=4.2.0,<5.0a0
+  - libgz-math8 >=8.2.0,<9.0a0
+  - libgz-tools >=2.0.3,<3.0a0
+  - libgz-utils3 >=3.1.1,<4.0a0
+  - dlfcn-win32 >=1.4.1,<2.0a0
+  - tinyxml2 >=11.0.0,<11.1.0a0
+  - urdfdom >=4.0.1,<4.1.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 1066474
+  timestamp: 1759340813403
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libsndfile-1.2.2-hc60ed4a_1.conda
   sha256: f709cbede3d4f3aee4e2f8d60bd9e256057f410bd60b8964cb8cf82ec1457573
   md5: ef1910918dd895516a769ed36b5b3a4e
@@ -32553,27 +32210,6 @@ packages:
   license_family: MOZILLA
   size: 8277831
   timestamp: 1742308854436
-- conda: https://conda.anaconda.org/conda-forge/win-64/libspatialite-5.1.0-h939089a_12.conda
-  sha256: fafedc5940e49b3dcce2cd6dfe3cabf64e7cc6b2a0ef7c8fefbf9d6d2c1afb77
-  md5: 8b5bfc6caa7c652ec4ec755efb5b7b73
-  depends:
-  - freexl >=2
-  - freexl >=2.0.0,<3.0a0
-  - geos >=3.13.0,<3.13.1.0a0
-  - librttopo >=1.1.0,<1.2.0a0
-  - libsqlite >=3.47.2,<4.0a0
-  - libxml2 >=2.13.5,<2.14.0a0
-  - libzlib >=1.3.1,<2.0a0
-  - proj >=9.5.1,<9.6.0a0
-  - sqlite
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  - zlib
-  license: MPL-1.1
-  license_family: MOZILLA
-  size: 8715367
-  timestamp: 1734001064515
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libspral-2025.03.06-h39c1cf3_0.conda
   sha256: a4a6b0473ce4d7f74ee4ab128fc5acb2745914981a6c61982d19aaf574d0f3d8
   md5: 23e84e1dc106ce0e073c0404f2f42a38
@@ -32660,6 +32296,16 @@ packages:
   license: Unlicense
   size: 1285981
   timestamp: 1751135695346
+- conda: https://conda.anaconda.org/conda-forge/win-64/libsqlite-3.51.2-hf5d6505_0.conda
+  sha256: 756478128e3e104bd7e7c3ce6c1b0efad7e08c7320c69fdc726e039323c63fbb
+  md5: 903979414b47d777d548e5f0165e6cd8
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  license: blessing
+  size: 1291616
+  timestamp: 1768148278261
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libssh2-1.11.1-hcf80075_0.conda
   sha256: fa39bfd69228a13e553bd24601332b7cfeb30ca11a3ca50bb028108fe90a7661
   md5: eecce068c7e4eddeb169591baac20ac4
@@ -33084,22 +32730,22 @@ packages:
   license: HPND
   size: 979074
   timestamp: 1747067408877
-- conda: https://conda.anaconda.org/conda-forge/win-64/libtiff-4.7.0-h797046b_4.conda
-  sha256: 3456e2a6dfe6c00fd0cda316f0cbb47caddf77f83d3ed4040b6ad17ec1610d2a
-  md5: 7d938ca70c64c5516767b4eae0a56172
+- conda: https://conda.anaconda.org/conda-forge/win-64/libtiff-4.7.1-h550210a_0.conda
+  sha256: d6cac6596ded0d5bbbc4198d7eb4db88da8c00236ebf5e2c8ad333ccde8965e2
+  md5: e23f29747d9d2aa2a39b594c114fac67
   depends:
   - lerc >=4.0.0,<5.0a0
-  - libdeflate >=1.23,<1.24.0a0
+  - libdeflate >=1.24,<1.25.0a0
   - libjpeg-turbo >=3.1.0,<4.0a0
   - liblzma >=5.8.1,<6.0a0
   - libzlib >=1.3.1,<2.0a0
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - zstd >=1.5.7,<1.6.0a0
   license: HPND
-  size: 980597
-  timestamp: 1745373037447
+  size: 992060
+  timestamp: 1758278535260
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libudev1-257.4-h9a4d06a_0.conda
   sha256: 65ebc2185cdc008f8da92864e8063e60293c59134b11b13e4bc44fd6f6e04eec
   md5: 8b87f46f586167c54b2d4c0fd4a72001
@@ -33517,6 +33163,19 @@ packages:
   license_family: BSD
   size: 71348
   timestamp: 1734956464680
+- conda: https://conda.anaconda.org/conda-forge/win-64/libwebp-1.6.0-h4d5522a_0.conda
+  sha256: 9442e93a6e51bdfdeb1e3f90889f7ddea4e1127ceda5b19e97c0ad7c0aede5ca
+  md5: 151aee0a97a0234a289c781e2e48ce9a
+  depends:
+  - libwebp-base 1.6.0.*
+  - libwebp-base >=1.6.0,<2.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 72249
+  timestamp: 1752167597373
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libwebp-base-1.5.0-h851e524_0.conda
   sha256: c45283fd3e90df5f0bd3dbcd31f59cdd2b001d424cf30a07223655413b158eaf
   md5: 63f790534398730f59e1b899c3644d4a
@@ -33575,6 +33234,19 @@ packages:
   license_family: BSD
   size: 273661
   timestamp: 1734777665516
+- conda: https://conda.anaconda.org/conda-forge/win-64/libwebp-base-1.6.0-h4d5522a_0.conda
+  sha256: 7b6316abfea1007e100922760e9b8c820d6fc19df3f42fb5aca684cfacb31843
+  md5: f9bbae5e2537e3b06e0f7310ba76c893
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  constrains:
+  - libwebp 1.6.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 279176
+  timestamp: 1752159543911
 - conda: https://conda.anaconda.org/conda-forge/win-64/libwinpthread-12.0.0.r4.gg4f2fc60ca-h57928b3_9.conda
   sha256: 373f2973b8a358528b22be5e8d84322c165b4c5577d24d94fd67ad1bb0a0f261
   md5: 08bfa5da6e242025304b206d152479ef
@@ -33810,6 +33482,18 @@ packages:
   license_family: MIT
   size: 418542
   timestamp: 1701629338549
+- conda: https://conda.anaconda.org/conda-forge/win-64/libxslt-1.1.43-h25c3957_0.conda
+  sha256: 20857f1adb91cc59826e146ee6cb1157c6abf2901a93d359b1106ba87c8e770b
+  md5: e84f36aa02735c140099d992d491968d
+  depends:
+  - libxml2 >=2.13.8,<2.14.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 416974
+  timestamp: 1753273998632
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libzip-1.11.2-h6991a6a_0.conda
   sha256: 991e7348b0f650d495fb6d8aa9f8c727bdf52dabf5853c0cc671439b160dce48
   md5: a7b27c075c9b7f459f1c022090697cba
@@ -36291,25 +35975,6 @@ packages:
   license_family: MIT
   size: 114991803
   timestamp: 1748563835620
-- conda: https://conda.anaconda.org/conda-forge/win-64/ogre-1.10.12.1-h58a323e_5.conda
-  sha256: afd6c029d5c38be27a9d9d7e2cd5e535d54c7432f106230ad80fa8bccaefd462
-  md5: a0ca5a1f3986903f89c9559de2b878e4
-  depends:
-  - freeimage >=3.18.0,<3.19.0a0
-  - freetype >=2.12.1,<3.0a0
-  - libzlib >=1.3.1,<2.0a0
-  - openexr >=3.3.2,<3.4.0a0
-  - pugixml >=1.14,<1.15.0a0
-  - sdl2
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  - zlib
-  - zziplib >=0.13.69,<0.14.0a0
-  license: MIT
-  license_family: MIT
-  size: 116007837
-  timestamp: 1735188367239
 - conda: https://conda.anaconda.org/conda-forge/linux-64/ogre-next-2.3.3-ha916a4f_1.conda
   sha256: 795663f6f85c955e4736cb4852a61e4b43a9cc19e3079bec2892aa89de38dbca
   md5: 1ac0ff2de586986bdfd19347321df8c9
@@ -36463,23 +36128,23 @@ packages:
   license_family: BSD
   size: 1730873
   timestamp: 1732805976465
-- conda: https://conda.anaconda.org/conda-forge/win-64/ompl-1.6.0-py311h8ee540d_4.conda
-  sha256: 11a759bae93b17681bbac751147aace7cb90da5b539f5d94b9b6655be4eeeafb
-  md5: 79ded1445dd07b8ab4ab88797b92d18a
+- conda: https://conda.anaconda.org/conda-forge/win-64/ompl-1.7.0-py311h24c37c6_0.conda
+  sha256: d028963f1eb8ebaf2170fbf90dd98d6e2f78fb74814fa335743ff7175d4ada8e
+  md5: 8925bd23f31036218b645f7d3d257972
   depends:
   - flann >=1.9.2,<1.9.3.0a0
   - libboost >=1.86.0,<1.87.0a0
   - libode >=0.16.5,<0.16.6.0a0
-  - numpy >=1.19,<3
+  - numpy >=1.23,<3
   - python >=3.11,<3.12.0a0
   - python_abi 3.11.* *_cp311
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   license: BSD-3-Clause
   license_family: BSD
-  size: 12706592
-  timestamp: 1732805121289
+  size: 13775037
+  timestamp: 1751019694096
 - conda: https://conda.anaconda.org/conda-forge/linux-64/onnxruntime-cpp-1.22.0-h641f3bf_0_cpu.conda
   sha256: 13ab55b8c76518a919c2e638c3097ceda6390c37ca835f6d63e823f445494b78
   md5: 3a016523ee6fc084f891546facf157f5
@@ -36596,17 +36261,6 @@ packages:
   license_family: LGPL
   size: 699309
   timestamp: 1746482677735
-- conda: https://conda.anaconda.org/conda-forge/win-64/openal-soft-1.23.1-h91493d7_0.conda
-  sha256: f75f230ec3ad992e52c129aac8163903d69df937adcad799328079a6c6241b33
-  md5: dc82f4c44f951cc5da59b3d340a4ac3b
-  depends:
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  license: LGPL-2.0-or-later
-  license_family: LGPL
-  size: 572369
-  timestamp: 1703367466828
 - conda: https://conda.anaconda.org/conda-forge/win-64/openal-soft-1.24.3-h79cd779_0.conda
   sha256: 50d33a0253cfc6cb308f26f19f73af222c50d5c5a532e50bcaf89e315606d137
   md5: 0956db0f83a038b02cbf9d33d1831660
@@ -36754,19 +36408,18 @@ packages:
   license_family: Apache
   size: 29331
   timestamp: 1750898376922
-- conda: https://conda.anaconda.org/conda-forge/win-64/opencv-4.10.0-qt6_py311h4ed4151_613.conda
-  sha256: afc4d5f4fd4a82425ad95c1c710683078eea7319f3277bb456d13c411f736e8a
-  md5: 3f077cf34630decaf426c68308780d0e
+- conda: https://conda.anaconda.org/conda-forge/win-64/opencv-4.12.0-qt6_py311h50c7551_600.conda
+  sha256: 3bcc3b3f5159bfa49e655bbf62afdcd735504a69fe6bdb726f076bafaddb23ac
+  md5: 30665f2e1fb6657c8a52c4a48ff5846a
   depends:
-  - hdf5 >=1.14.3,<1.14.4.0a0
-  - libopencv 4.10.0 qt6_py311h375890f_613
-  - libprotobuf >=5.28.2,<5.28.3.0a0
-  - py-opencv 4.10.0 qt6_py311h955f2ee_613
+  - libopencv 4.12.0 qt6_py311hf39e5f2_600
+  - libprotobuf >=5.29.3,<5.29.4.0a0
+  - py-opencv 4.12.0 qt6_py311h336b8d4_600
   - python_abi 3.11.* *_cp311
   license: Apache-2.0
   license_family: Apache
-  size: 26867
-  timestamp: 1734361405446
+  size: 27525
+  timestamp: 1751759817851
 - conda: https://conda.anaconda.org/conda-forge/win-64/opencv-4.12.0-qt6_py39hb5cec6c_600.conda
   sha256: 2d03917bfa8eccf871ce5f6bdf0a662821623a6265dfb1c1057e59c123303b22
   md5: 906fea7b266f2ef28958596c911a4d2d
@@ -36885,23 +36538,6 @@ packages:
   license_family: BSD
   size: 1099991
   timestamp: 1749538993886
-- conda: https://conda.anaconda.org/conda-forge/win-64/openexr-3.3.3-h1acc403_0.conda
-  sha256: 89e04298afacdc43b3a6de03067486f529eeebbfc249c99417ec2de6d20ba4a0
-  md5: 1fd0778c8850a74fedfb401ba013cce9
-  depends:
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  - ucrt >=10.0.20348.0
-  - imath >=3.1.12,<3.1.13.0a0
-  - libzlib >=1.3.1,<2.0a0
-  - libdeflate >=1.23,<1.24.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 1045157
-  timestamp: 1742803785709
 - conda: https://conda.anaconda.org/conda-forge/win-64/openexr-3.3.4-h9fcfcc6_0.conda
   sha256: f5f7cf824bebd2b3e61613e57a60e700851ed659a0a12ff08fd80f8f7178d959
   md5: 9eac393cac0f3356abedd0e3a94dadde
@@ -36919,6 +36555,23 @@ packages:
   license_family: BSD
   size: 1045280
   timestamp: 1749538933185
+- conda: https://conda.anaconda.org/conda-forge/win-64/openexr-3.3.5-h4750f91_0.conda
+  sha256: d1ba290a484da1dcb6900a94a6b0a9e37799a056b6416c81fdae46fd73224094
+  md5: 1adc969e971c0265e57f2fe0fce7035c
+  depends:
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  - ucrt >=10.0.20348.0
+  - libdeflate >=1.24,<1.25.0a0
+  - imath >=3.1.12,<3.1.13.0a0
+  - libzlib >=1.3.1,<2.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1060265
+  timestamp: 1753614985511
 - conda: https://conda.anaconda.org/conda-forge/linux-64/openh264-2.5.0-hf92e6e3_0.conda
   sha256: dedda20c58aec3d8f9c12e3660225608b93a257a21e0da703fdd814789291519
   md5: d1b18a73fc3cfd0de9c7e786d2febb8f
@@ -37321,6 +36974,18 @@ packages:
   license_family: Apache
   size: 9025176
   timestamp: 1746227349882
+- conda: https://conda.anaconda.org/conda-forge/win-64/openssl-3.6.0-h725018a_0.conda
+  sha256: 6d72d6f766293d4f2aa60c28c244c8efed6946c430814175f959ffe8cab899b3
+  md5: 84f8fb4afd1157f59098f618cd2437e4
+  depends:
+  - ca-certificates
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  license: Apache-2.0
+  license_family: Apache
+  size: 9440812
+  timestamp: 1762841722179
 - conda: https://conda.anaconda.org/conda-forge/linux-64/orocos-kdl-1.5.1-h5888daf_8.conda
   sha256: 2c32fc459cabed3b272b3d41c63a869de3bee69636dee39519005fbc3e9c7b64
   md5: 81554d1604c59c8eabf592eacd1f561a
@@ -37741,26 +37406,6 @@ packages:
   license_family: BSD
   size: 13240094
   timestamp: 1748339721490
-- conda: https://conda.anaconda.org/conda-forge/win-64/pcl-1.14.1-hcec6b29_7.conda
-  sha256: 249ce30377a6e75a00332aba8392f1961f389ee13a79f6b69c30d7a296d73df9
-  md5: 4f7bb8c77e145edb149ef3a496e980cb
-  depends:
-  - flann >=1.9.2,<1.9.3.0a0
-  - glew >=2.1.0,<2.2.0a0
-  - libboost >=1.86.0,<1.87.0a0
-  - libpng >=1.6.44,<1.7.0a0
-  - qhull >=2020.2,<2020.3.0a0
-  - qt6-main >=6.8.1,<6.9.0a0
-  - tbb >=2021.13.0
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  - vtk * qt*
-  - vtk-base >=9.3.1,<9.3.2.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 9459195
-  timestamp: 1736290037832
 - conda: https://conda.anaconda.org/conda-forge/win-64/pcl-1.15.0-hd388526_2.conda
   sha256: 6d6a80ced532beaaa7de540b87b11f3d66d79160958c00772875785c70c2e954
   md5: 30de620107e3beaf00ddd2b98d0d6c4f
@@ -37921,19 +37566,6 @@ packages:
   license_family: BSD
   size: 837826
   timestamp: 1745955207242
-- conda: https://conda.anaconda.org/conda-forge/win-64/pcre2-10.44-h99c9b8b_2.conda
-  sha256: 15dffc9a2d6bb6b8ccaa7cbd26b229d24f1a0a1c4f5685b308a63929c56b381f
-  md5: a912b2c4ff0f03101c751aa79a331831
-  depends:
-  - bzip2 >=1.0.8,<2.0a0
-  - libzlib >=1.3.1,<2.0a0
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 816653
-  timestamp: 1745931851696
 - conda: https://conda.anaconda.org/conda-forge/win-64/pcre2-10.45-h99c9b8b_0.conda
   sha256: 165d6f76e7849615cfa5fe5f0209b90103102db17a7b4632f933fa9c0e8d8bfe
   md5: f4c483274001678e129f5cbaf3a8d765
@@ -38702,23 +38334,6 @@ packages:
   license_family: MIT
   size: 2764393
   timestamp: 1749233378439
-- conda: https://conda.anaconda.org/conda-forge/win-64/proj-9.5.1-h4f671f6_0.conda
-  sha256: ddd0be6172e3903bc6602a93394e8051826235377c1ce8c6ba2435869794e726
-  md5: 7303dac2aa92318f319508aedab6a127
-  depends:
-  - libcurl >=8.10.1,<9.0a0
-  - libsqlite >=3.47.0,<4.0a0
-  - libtiff >=4.7.0,<4.8.0a0
-  - sqlite
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  constrains:
-  - proj4 ==999999999999
-  license: MIT
-  license_family: MIT
-  size: 2740461
-  timestamp: 1733138695290
 - conda: https://conda.anaconda.org/conda-forge/win-64/proj-9.6.2-h4f671f6_0.conda
   sha256: be95bff8ec43463df725f265399f9e1fdb4405f0cc75ea83afaa11229a20598d
   md5: 1a3419a04d6680dd7be6e15bd61644d6
@@ -38736,6 +38351,23 @@ packages:
   license_family: MIT
   size: 2770261
   timestamp: 1749233851327
+- conda: https://conda.anaconda.org/conda-forge/win-64/proj-9.6.2-h7990399_2.conda
+  sha256: e798e9bd658f6c00cfac0d8573c7fe97d9ebad5966c96c23e0702f44e51905bb
+  md5: 6e0e8fcc3eb2c1418d663005bf040d8d
+  depends:
+  - libcurl >=8.14.1,<9.0a0
+  - libsqlite >=3.50.4,<4.0a0
+  - libtiff >=4.7.0,<4.8.0a0
+  - sqlite
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  constrains:
+  - proj4 ==999999999999
+  license: MIT
+  license_family: MIT
+  size: 2788230
+  timestamp: 1754928361098
 - conda: https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.51-pyha770c72_0.conda
   sha256: ebc1bb62ac612af6d40667da266ff723662394c0ca78935340a5b5c14831227b
   md5: d17ae9db4dc594267181bd199bf9a551
@@ -39039,17 +38671,6 @@ packages:
   license_family: MIT
   size: 91283
   timestamp: 1736601509593
-- conda: https://conda.anaconda.org/conda-forge/win-64/pugixml-1.14-h63175ca_0.conda
-  sha256: 68a5cb9a7560b2ce0d72ccebc7f6623e13ca66a67f80feb1094a75199bd1a50c
-  md5: 6794ab7a1f26ebfe0452297eba029d4f
-  depends:
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  license: MIT
-  license_family: MIT
-  size: 111324
-  timestamp: 1696182979614
 - conda: https://conda.anaconda.org/conda-forge/win-64/pugixml-1.15-h372dad0_0.conda
   sha256: 97b34ed73b6f559fcf5e706d4c8435923ba95cfed478d3fd50b475f94f60dc6e
   md5: cadea4c6edb512e979edbf793bf979ac
@@ -39213,20 +38834,19 @@ packages:
   license_family: Apache
   size: 1156197
   timestamp: 1750898351572
-- conda: https://conda.anaconda.org/conda-forge/win-64/py-opencv-4.10.0-qt6_py311h955f2ee_613.conda
-  sha256: 848bf425700d4c98e07132ac9b69f1d9ddb2b9dd7a240c0550bd4095cbd9a30e
-  md5: 6a0f15f4bb24bcb6cde0eff1c1951e4a
+- conda: https://conda.anaconda.org/conda-forge/win-64/py-opencv-4.12.0-qt6_py311h336b8d4_600.conda
+  sha256: 602c0b6dce021947f805af6a2733d0a7a6317ae92484a1b6f2935de525d02b12
+  md5: aae5382b81509f5e8dcd5d7202162545
   depends:
-  - hdf5 >=1.14.3,<1.14.4.0a0
-  - libopencv 4.10.0 qt6_py311h375890f_613
-  - libprotobuf >=5.28.2,<5.28.3.0a0
-  - numpy >=1.19,<3
+  - libopencv 4.12.0 qt6_py311hf39e5f2_600
+  - libprotobuf >=5.29.3,<5.29.4.0a0
+  - numpy >=1.23,<3
   - python >=3.11,<3.12.0a0
   - python_abi 3.11.* *_cp311
   license: Apache-2.0
   license_family: Apache
-  size: 1153760
-  timestamp: 1734361378217
+  size: 1153957
+  timestamp: 1751759792903
 - conda: https://conda.anaconda.org/conda-forge/win-64/py-opencv-4.12.0-qt6_py39h54bbc76_600.conda
   sha256: fefb6d66d2618beec38580a8a4ff9610f8c783fb39beb2cf3d8b9a4ab860fae5
   md5: 3e5bfa02815483d3db6b2cb4992a396b
@@ -39291,18 +38911,6 @@ packages:
   license_family: BSD
   size: 180116
   timestamp: 1747934418811
-- conda: https://conda.anaconda.org/conda-forge/noarch/pybind11-global-2.13.6-pyh6a1d191_3.conda
-  sha256: 91ef6a928e7e0e691246037566bbec6db2cf17fa5d76f626102323a95dbb4f08
-  md5: 2e9cbcb18272d66bc0d3b0dc4ff24935
-  depends:
-  - __win
-  - python >=3.9
-  constrains:
-  - pybind11-abi ==4
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 182238
-  timestamp: 1747934667819
 - conda: https://conda.anaconda.org/conda-forge/noarch/pybind11-global-3.0.1-pyh5e4992e_0.conda
   sha256: fff9c4f726644a1889a4b631aca547d8f302c72109d75518ae32997a3d54f23a
   md5: 58564979e28f8b18955ec56c4dc6b252
@@ -40194,24 +39802,6 @@ packages:
   license_family: LGPL
   size: 7409124
   timestamp: 1749047769387
-- conda: https://conda.anaconda.org/conda-forge/win-64/pyside6-6.8.3-py311h4238720_0.conda
-  sha256: 2aa15d19ef77892ba8a29405ce9668e6f87e0b4768f79967d47ff529c97dde81
-  md5: a69d789b78dbeb65365b66c3ae6d8379
-  depends:
-  - libclang13 >=20.1.1
-  - libxml2 >=2.13.7,<2.14.0a0
-  - libxslt >=1.1.39,<2.0a0
-  - python >=3.11,<3.12.0a0
-  - python_abi 3.11.* *_cp311
-  - qt6-main 6.8.3.*
-  - qt6-main >=6.8.3,<6.9.0a0
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  license: LGPL-3.0-only
-  license_family: LGPL
-  size: 9452092
-  timestamp: 1743274143289
 - conda: https://conda.anaconda.org/conda-forge/win-64/pyside6-6.9.1-py39h5f4aa1c_0.conda
   sha256: ffd82f56464c75301ec5e5f2f1c743795ab95f52c4ac75960bf92b8588767e9a
   md5: 85d380da5c107a27506c80b740981c48
@@ -40230,6 +39820,24 @@ packages:
   license_family: LGPL
   size: 8848496
   timestamp: 1749047971188
+- conda: https://conda.anaconda.org/conda-forge/win-64/pyside6-6.9.2-py311h5d1a980_1.conda
+  sha256: 8d6f5411eea073cf77daf335d904f64701abc3e8086b1f540c2b24ea8f342276
+  md5: 372dcf53b700d63d76f46dab66bf41ed
+  depends:
+  - libclang13 >=21.1.0
+  - libxml2 >=2.13.8,<2.14.0a0
+  - libxslt >=1.1.43,<2.0a0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - qt6-main 6.9.2.*
+  - qt6-main >=6.9.2,<6.10.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  license: LGPL-3.0-only
+  license_family: LGPL
+  size: 8918376
+  timestamp: 1756674096337
 - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-8.4.1-pyhd8ed1ab_0.conda
   sha256: 93e267e4ec35353e81df707938a6527d5eb55c97bf54c3b87229b69523afb59d
   md5: a49c2283f24696a7b30367b7346a0144
@@ -40439,6 +40047,22 @@ packages:
   license: Apache-2.0
   size: 233310
   timestamp: 1751104122689
+- conda: https://conda.anaconda.org/conda-forge/win-64/python-orocos-kdl-1.5.3-py311h3e6a449_0.conda
+  sha256: 52a415e1c84c518eec06ef79b63ecffd63da2f071580fd017a3aaf0d8ed79ff5
+  md5: 3992bbe9256acabc48bc2986c776124f
+  depends:
+  - eigen
+  - orocos-kdl
+  - pybind11
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  license: LGPL-2.1-or-later
+  license_family: LGPL
+  size: 373801
+  timestamp: 1760696299316
 - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.10-7_cp310.conda
   build_number: 7
   sha256: 1316c66889313d9caebcfa5d5e9e6af25f8ba09396fc1bc196a08a3febbbabb8
@@ -41510,34 +41134,6 @@ packages:
   license: LGPL-3.0-only
   size: 44579847
   timestamp: 1750918830891
-- conda: https://conda.anaconda.org/conda-forge/win-64/qt6-main-6.8.3-h72a539a_2.conda
-  sha256: 67c53099288f4fdd6d8ef25c79958757f285f9a1d4427b98c12f598fc89b7252
-  md5: 6705dbdf916d1f65d7edf9a3af9e37e1
-  depends:
-  - double-conversion >=3.3.1,<3.4.0a0
-  - harfbuzz >=11.0.1
-  - icu >=75.1,<76.0a0
-  - krb5 >=1.21.3,<1.22.0a0
-  - libclang13 >=20.1.2
-  - libglib >=2.84.1,<3.0a0
-  - libjpeg-turbo >=3.0.0,<4.0a0
-  - libpng >=1.6.47,<1.7.0a0
-  - libsqlite >=3.49.1,<4.0a0
-  - libtiff >=4.7.0,<4.8.0a0
-  - libwebp-base >=1.5.0,<2.0a0
-  - libzlib >=1.3.1,<2.0a0
-  - openssl >=3.5.0,<4.0a0
-  - pcre2 >=10.44,<10.45.0a0
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  - zstd >=1.5.7,<1.6.0a0
-  constrains:
-  - qt 6.8.3
-  license: LGPL-3.0-only
-  license_family: LGPL
-  size: 94436059
-  timestamp: 1744220252684
 - conda: https://conda.anaconda.org/conda-forge/win-64/qt6-main-6.9.1-h02ddd7d_1.conda
   sha256: cd7a9a3972c0f1114294c9f84463838d645c6f596cbcfefef03b4ee229d88d43
   md5: fc796cf6c16db38d44c2efefbe6afcea
@@ -41565,6 +41161,34 @@ packages:
   license: LGPL-3.0-only
   size: 91608911
   timestamp: 1750922811982
+- conda: https://conda.anaconda.org/conda-forge/win-64/qt6-main-6.9.2-h236c7cd_0.conda
+  sha256: 5088ed0c6c769925a6df7d5a1a55fb7fc52278f327b986f45664453622fc98e2
+  md5: 774ff6166c5f29c0c16e6c2bc43b485f
+  depends:
+  - double-conversion >=3.3.1,<3.4.0a0
+  - harfbuzz >=11.4.3
+  - icu >=75.1,<76.0a0
+  - krb5 >=1.21.3,<1.22.0a0
+  - libclang13 >=20.1.8
+  - libglib >=2.84.3,<3.0a0
+  - libjpeg-turbo >=3.1.0,<4.0a0
+  - libpng >=1.6.50,<1.7.0a0
+  - libsqlite >=3.50.4,<4.0a0
+  - libtiff >=4.7.0,<4.8.0a0
+  - libwebp-base >=1.6.0,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.5.2,<4.0a0
+  - pcre2 >=10.45,<10.46.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  - zstd >=1.5.7,<1.6.0a0
+  constrains:
+  - qt 6.9.2
+  license: LGPL-3.0-only
+  license_family: LGPL
+  size: 94567291
+  timestamp: 1756296858553
 - conda: https://conda.anaconda.org/conda-forge/noarch/qtpy-2.4.3-pyhd8ed1ab_1.conda
   sha256: b17dd9d2ee7a4f60fb13712883cd2664aa1339df4b29eb7ae0f4423b31778b00
   md5: b49c000df5aca26d36b3f078ba85e03a
@@ -41783,15 +41407,6 @@ packages:
   license: BSD-3-Clause
   size: 27423
   timestamp: 1751053372858
-- conda: https://conda.anaconda.org/conda-forge/win-64/re2-2024.07.02-haf4117d_2.conda
-  sha256: fde3bbe0ade147bf735bf1bb5a15aa26d2cc197bfa026d2964012737f89ed351
-  md5: 10980cbe103147435a40288db9f49847
-  depends:
-  - libre2-11 2024.07.02 h4eb7d71_2
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 214916
-  timestamp: 1735541425594
 - conda: https://conda.anaconda.org/conda-forge/win-64/re2-2025.06.26-h3dd2b4f_0.conda
   sha256: e7b9a7c39987589f7b597882d60193b9599cc4cb2fe950ae406c010fed53aaaa
   md5: 83fe4d44b2c2089ad3778a49c5ca5340
@@ -41950,28 +41565,28 @@ packages:
   license: BSD-3-Clause
   size: 105461
   timestamp: 1736208490753
-- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-action-msgs-1.2.1-np126py311h7d8ee0e_8.conda
-  sha256: d134e7d1c7bd97dc86e849e7f665aad9b6bd13abda0feef515bf54a9f38f35da
-  md5: 7a985b3f260be56969e56649c2a6d438
+- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-action-msgs-1.2.1-np126py311hd5de103_13.conda
+  sha256: 36cffeac2bbc42ed9112db3527242364273a4185bf5f74e66e32b5fe07d7a7ab
+  md5: 6544237642cdd6be6af4596c331a176a
   depends:
   - python
   - ros-humble-builtin-interfaces
   - ros-humble-ros-workspace
   - ros-humble-rosidl-default-runtime
   - ros-humble-unique-identifier-msgs
-  - ros2-distro-mutex 0.6.* humble_*
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - ros2-distro-mutex 0.7.* humble_*
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - ros2-distro-mutex >=0.6.0,<0.7.0a0
-  - numpy >=1.26.4,<2.0a0
   - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
+  - numpy >=1.26.4,<2.0a0
   license: BSD-3-Clause
-  size: 117054
-  timestamp: 1736230223275
+  size: 119164
+  timestamp: 1753323718948
 - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-actionlib-msgs-4.2.4-np126py311h2c3b307_7.conda
   sha256: ba7c4da796226718cfb9368529f590fa1b2c9d53710901a7fc748d648d599dad
   md5: b329fa326a4faaec014668e24e7c0326
@@ -42047,28 +41662,28 @@ packages:
   license: BSD-3-Clause
   size: 92028
   timestamp: 1736208748580
-- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-actionlib-msgs-4.2.4-np126py311h7d8ee0e_8.conda
-  sha256: 6fef8933f51f23b90922f81788fe4fc8acce38d3ae5f0f9935299f982b69a50a
-  md5: 1b37fdc8d7be23af1a468968be820a86
+- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-actionlib-msgs-4.9.0-np126py311hd5de103_13.conda
+  sha256: b49c61ddf1da268ad3a5ba00a4d66d4ad0e1f457482721393aad02749383b8ec
+  md5: 9a91e7295d91d695686ea2776c8b6181
   depends:
   - python
   - ros-humble-builtin-interfaces
   - ros-humble-ros-workspace
   - ros-humble-rosidl-default-runtime
   - ros-humble-std-msgs
-  - ros2-distro-mutex 0.6.* humble_*
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - ros2-distro-mutex 0.7.* humble_*
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - python_abi 3.11.* *_cp311
-  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
   - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
   license: BSD-3-Clause
-  size: 103485
-  timestamp: 1736231107105
+  size: 105499
+  timestamp: 1753325459132
 - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-ament-cmake-1.3.11-np126py311h2c3b307_7.conda
   sha256: 23e4a88ccbdc761ffbf89bd51135769c84006b1849b4e58f041ecc6878f5ae48
   md5: ee0a75fcf398d8bc287aa01b87076538
@@ -42192,11 +41807,10 @@ packages:
   license: BSD-3-Clause
   size: 21964
   timestamp: 1736206371410
-- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-ament-cmake-1.3.11-np126py311h7d8ee0e_8.conda
-  sha256: d7490b527c9a7a9469c2811d8d331c69022f678bf9a877daa114cbdc33e672d6
-  md5: 4cd93e818cf6191a864fb5450c1a6080
+- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-ament-cmake-1.3.12-np126py311hd5de103_13.conda
+  sha256: 199f7e125290e5580d54e4c65adf1e2cd9fe0b0e085e355597665f2254dd4de9
+  md5: dd60cd540c7c5c193f70337335d2b1f7
   depends:
-  - cmake
   - python
   - ros-humble-ament-cmake-core
   - ros-humble-ament-cmake-export-definitions
@@ -42213,19 +41827,20 @@ packages:
   - ros-humble-ament-cmake-test
   - ros-humble-ament-cmake-version
   - ros-humble-ros-workspace
-  - ros2-distro-mutex 0.6.* humble_*
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - ros2-distro-mutex 0.7.* humble_*
+  - cmake
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - ros2-distro-mutex >=0.6.0,<0.7.0a0
-  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
   - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
   license: BSD-3-Clause
-  size: 18787
-  timestamp: 1736207584491
+  size: 19988
+  timestamp: 1753311884817
 - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-ament-cmake-auto-1.3.11-np126py311h2c3b307_7.conda
   sha256: 3cf30c5f54b43e8396dbc4fc110d7b356c2349b990e2e88090e3523960441571
   md5: 7936416b355dffde1ee1da4e2e093ebd
@@ -42300,28 +41915,28 @@ packages:
   license: BSD-3-Clause
   size: 25629
   timestamp: 1736206650326
-- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-ament-cmake-auto-1.3.11-np126py311h7d8ee0e_8.conda
-  sha256: 09091317e2b9bddeaf73e985398addc99dd136ffaf6d840170758d99283108c8
-  md5: a10701ea06f468bf55efda379b8eab0e
+- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-ament-cmake-auto-1.3.12-np126py311hd5de103_13.conda
+  sha256: 538bb9556771cc5da1645d6ddf35cdc7b178a904671953f05c45977f7d5debae
+  md5: 3dcf1ed1805286fdaa1589e0aa61b586
   depends:
   - python
   - ros-humble-ament-cmake
   - ros-humble-ament-cmake-gmock
   - ros-humble-ament-cmake-gtest
   - ros-humble-ros-workspace
-  - ros2-distro-mutex 0.6.* humble_*
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - ros2-distro-mutex 0.7.* humble_*
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - ros2-distro-mutex >=0.6.0,<0.7.0a0
   - python_abi 3.11.* *_cp311
   - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
   license: BSD-3-Clause
-  size: 22426
-  timestamp: 1736207945340
+  size: 23842
+  timestamp: 1753312788917
 - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-ament-cmake-copyright-0.12.11-np126py311h2c3b307_7.conda
   sha256: 773e5e132aa070efc953723dd28ebb94d3177625d494a5e1803bcea30cd7cd2d
   md5: c9fa5f251605ed495fc3639d198b4c50
@@ -42393,27 +42008,27 @@ packages:
   license: BSD-3-Clause
   size: 21439
   timestamp: 1736206752805
-- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-ament-cmake-copyright-0.12.11-np126py311h7d8ee0e_8.conda
-  sha256: efdf838bec23f2b95eb7ab4cd29980bfd0741243d44f4ac1c0369f998234ed5a
-  md5: 46a5df531fad8f0b42645c57dfe06351
+- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-ament-cmake-copyright-0.12.12-np126py311hd5de103_13.conda
+  sha256: fb95e28e7fc9d2f77296b2573339569f70d1c21d320db1c252e7edb534f2c4f9
+  md5: da155601f522b223396869b15e90bb62
   depends:
   - python
   - ros-humble-ament-cmake-test
   - ros-humble-ament-copyright
   - ros-humble-ros-workspace
-  - ros2-distro-mutex 0.6.* humble_*
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - ros2-distro-mutex 0.7.* humble_*
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - ros2-distro-mutex >=0.6.0,<0.7.0a0
   - numpy >=1.26.4,<2.0a0
   - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
   license: BSD-3-Clause
-  size: 18167
-  timestamp: 1736208375909
+  size: 19312
+  timestamp: 1753313865976
 - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-ament-cmake-core-1.3.11-np126py311h2c3b307_7.conda
   sha256: c03405e62fd6d62191b0d246dca97712a3f104bd3efaac18d92ef8cd13e02823
   md5: b481c03fa5af51cb5982fdec4618befe
@@ -42485,27 +42100,27 @@ packages:
   license: BSD-3-Clause
   size: 43634
   timestamp: 1736205156129
-- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-ament-cmake-core-1.3.11-np126py311h7d8ee0e_8.conda
-  sha256: d4ddddec5335594ebd7664640bc02fff234cd8e35037655070539071b8bf8cc6
-  md5: cca7904d7a49344fa4b100c4aee9e8f1
+- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-ament-cmake-core-1.3.12-np126py311hd5de103_13.conda
+  sha256: 8d6d8e00f6d457db11ff48635dd72536862b39ced0026075acd75d61a946e89e
+  md5: 5e97d822162cb3ae2abf8f719c900e4f
   depends:
   - catkin_pkg
-  - cmake
   - python
   - ros-humble-ament-package
-  - ros2-distro-mutex 0.6.* humble_*
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - ros2-distro-mutex 0.7.* humble_*
+  - cmake
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
   - numpy >=1.26.4,<2.0a0
-  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
   - python_abi 3.11.* *_cp311
   license: BSD-3-Clause
-  size: 40560
-  timestamp: 1736205450418
+  size: 41073
+  timestamp: 1753308029869
 - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-ament-cmake-cppcheck-0.12.11-np126py311h2c3b307_7.conda
   sha256: b5244bb6e8d33983fb968327e258ec2718c151972734768039000d8a9ecfb852
   md5: 2edd28e20d62c13ace301f89c0abac21
@@ -42582,28 +42197,28 @@ packages:
   license: BSD-3-Clause
   size: 23030
   timestamp: 1736206837904
-- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-ament-cmake-cppcheck-0.12.11-np126py311h7d8ee0e_8.conda
-  sha256: 0bdf0469bb2280d28910b4a23bbfd9449f6ac727e8e8682d0c52b36c3da130e3
-  md5: 2ef8ab2b72d9888c1aa004eda0e337f5
+- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-ament-cmake-cppcheck-0.12.12-np126py311hd5de103_13.conda
+  sha256: 14762b5ef3a6f2e1c5957a36825ce1d1f1b3156ed90fa2cfee66991d8f2b83e3
+  md5: 65fccc6622ff3094d5be0be8e3f572d5
   depends:
   - python
   - ros-humble-ament-cmake-core
   - ros-humble-ament-cmake-test
   - ros-humble-ament-cppcheck
   - ros-humble-ros-workspace
-  - ros2-distro-mutex 0.6.* humble_*
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - ros2-distro-mutex 0.7.* humble_*
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - ros2-distro-mutex >=0.6.0,<0.7.0a0
   - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
   - python_abi 3.11.* *_cp311
   license: BSD-3-Clause
-  size: 19777
-  timestamp: 1736208735120
+  size: 21044
+  timestamp: 1753315151488
 - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-ament-cmake-cpplint-0.12.11-np126py311h2c3b307_7.conda
   sha256: 796bc98dc66ffac37b84da64d1943a1b50306e88e24e939947ed4c1df6d4991e
   md5: f204d58f0c5d0447af2ace2d653c7016
@@ -42674,27 +42289,27 @@ packages:
   license: BSD-3-Clause
   size: 21921
   timestamp: 1736206881415
-- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-ament-cmake-cpplint-0.12.11-np126py311h7d8ee0e_8.conda
-  sha256: 26aca932d67f1630fe03840f9468706728c4d47c06e8b5a1fe9dddbe7717fc20
-  md5: 7115f19541182b41f3cc13eddfe94137
+- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-ament-cmake-cpplint-0.12.12-np126py311hd5de103_13.conda
+  sha256: d7330bf92caf521f63bddcce49e72ec2a3fecd1f7d640e5157d7b9d4a63c9e35
+  md5: f7aa555563c1c75f4e809684f0198eed
   depends:
   - python
   - ros-humble-ament-cmake-test
   - ros-humble-ament-cpplint
   - ros-humble-ros-workspace
-  - ros2-distro-mutex 0.6.* humble_*
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - ros2-distro-mutex 0.7.* humble_*
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - ros2-distro-mutex >=0.6.0,<0.7.0a0
-  - numpy >=1.26.4,<2.0a0
   - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
+  - numpy >=1.26.4,<2.0a0
   license: BSD-3-Clause
-  size: 18653
-  timestamp: 1736208883408
+  size: 19766
+  timestamp: 1753315094439
 - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-ament-cmake-export-definitions-1.3.11-np126py311h2c3b307_7.conda
   sha256: 3312be0a0090c5dea6a4a6539b2445b0f6af8c859b081742c27852ebb3db504c
   md5: 1616226e84d7d96b67b562a42998ccab
@@ -42760,26 +42375,26 @@ packages:
   license: BSD-3-Clause
   size: 20834
   timestamp: 1736205242632
-- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-ament-cmake-export-definitions-1.3.11-np126py311h7d8ee0e_8.conda
-  sha256: 2112599e97aa3f83b8e6047af8214ce3063a4daf8e3a7faf47ece22cf7453db2
-  md5: f3c234a73dc45527238ffcfa737f858f
+- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-ament-cmake-export-definitions-1.3.12-np126py311hd5de103_13.conda
+  sha256: ba43badfc6e44bee0744d520a95eda6caa57ad8176adbead6a53841b6307d902
+  md5: dbb3c7cd17a6f83773ad4b4104420ad9
   depends:
   - python
   - ros-humble-ament-cmake-core
   - ros-humble-ros-workspace
-  - ros2-distro-mutex 0.6.* humble_*
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - ros2-distro-mutex 0.7.* humble_*
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
   - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
   - numpy >=1.26.4,<2.0a0
-  - ros2-distro-mutex >=0.6.0,<0.7.0a0
   license: BSD-3-Clause
-  size: 17599
-  timestamp: 1736205838173
+  size: 18721
+  timestamp: 1753308727006
 - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-ament-cmake-export-dependencies-1.3.11-np126py311h2c3b307_7.conda
   sha256: ca8e343bb56568ac6103a2343e75c88ee026730fb67d1126cf7b0ffae1518ae1
   md5: a47fce87cc31132d8fd1c07aadd58485
@@ -42852,27 +42467,27 @@ packages:
   license: BSD-3-Clause
   size: 21758
   timestamp: 1736205466561
-- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-ament-cmake-export-dependencies-1.3.11-np126py311h7d8ee0e_8.conda
-  sha256: 4a63f3ffccbbad19859a59ca0f13c673b32dd03ecee1ad812bb2337b07873743
-  md5: 4a28189443019867973c9e5e03dbea69
+- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-ament-cmake-export-dependencies-1.3.12-np126py311hd5de103_13.conda
+  sha256: 68d9b4d2273df0f290afca16970ee578faca1de631181f8ea0ed23ed2dc5320b
+  md5: d7b89b404f686c1cc06c37c1933f9ec1
   depends:
   - python
   - ros-humble-ament-cmake-core
   - ros-humble-ament-cmake-libraries
   - ros-humble-ros-workspace
-  - ros2-distro-mutex 0.6.* humble_*
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - ros2-distro-mutex 0.7.* humble_*
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
   - numpy >=1.26.4,<2.0a0
   - python_abi 3.11.* *_cp311
-  - ros2-distro-mutex >=0.6.0,<0.7.0a0
   license: BSD-3-Clause
-  size: 18532
-  timestamp: 1736206287
+  size: 19938
+  timestamp: 1753309426878
 - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-ament-cmake-export-include-directories-1.3.11-np126py311h2c3b307_7.conda
   sha256: fa21a9f2db81a30bdd1adc00607bf2d247a2fc4dca8e6798dd92f55bbeaa14b7
   md5: 6b5ce82a7fe33f2e91ae4ac1a94ccb3f
@@ -42939,26 +42554,26 @@ packages:
   license: BSD-3-Clause
   size: 21252
   timestamp: 1736205237467
-- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-ament-cmake-export-include-directories-1.3.11-np126py311h7d8ee0e_8.conda
-  sha256: 23ddd8127abe5a82b8aeb5b1a2c3f0ec44b5e3805426bbf0f0abada803e0743b
-  md5: 277dd1836603d815ca521cefd4b17030
+- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-ament-cmake-export-include-directories-1.3.12-np126py311hd5de103_13.conda
+  sha256: 02ae68371d6028522229445bd21ddf1005ff2f4deb4e161c40ce0942aea58bc6
+  md5: c1f27de4924b6469ef3b26ba6633970c
   depends:
   - python
   - ros-humble-ament-cmake-core
   - ros-humble-ros-workspace
-  - ros2-distro-mutex 0.6.* humble_*
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - ros2-distro-mutex 0.7.* humble_*
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - python_abi 3.11.* *_cp311
-  - ros2-distro-mutex >=0.6.0,<0.7.0a0
   - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
+  - python_abi 3.11.* *_cp311
   license: BSD-3-Clause
-  size: 17993
-  timestamp: 1736205817443
+  size: 19107
+  timestamp: 1753308694089
 - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-ament-cmake-export-interfaces-1.3.11-np126py311h2c3b307_7.conda
   sha256: 044d715c407b25e9b84add16fa6d4db8137c4fee7fa10b3e355dc790235c8567
   md5: 0c628430cf7c32fcc1b4805e72735b7e
@@ -43030,27 +42645,27 @@ packages:
   license: BSD-3-Clause
   size: 21428
   timestamp: 1736205460507
-- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-ament-cmake-export-interfaces-1.3.11-np126py311h7d8ee0e_8.conda
-  sha256: 70359af534690deef083e4fe48857971e428d91f14a4cd61ff12de81bc8a298b
-  md5: 04815819304350cfe23cd647ffa4d8a2
+- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-ament-cmake-export-interfaces-1.3.12-np126py311hd5de103_13.conda
+  sha256: 30cd102b353337c2d79bd9757edeec2900c77a396f2c89d5b5305beb773ef688
+  md5: 9fc8e557525825eb327390b4d239d110
   depends:
   - python
   - ros-humble-ament-cmake-core
   - ros-humble-ament-cmake-export-libraries
   - ros-humble-ros-workspace
-  - ros2-distro-mutex 0.6.* humble_*
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - ros2-distro-mutex 0.7.* humble_*
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
   - numpy >=1.26.4,<2.0a0
   - python_abi 3.11.* *_cp311
-  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
   license: BSD-3-Clause
-  size: 18170
-  timestamp: 1736206567801
+  size: 19298
+  timestamp: 1753309384173
 - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-ament-cmake-export-libraries-1.3.11-np126py311h2c3b307_7.conda
   sha256: 42ef8accfa2f2a8dff64a255d200733d32799bd2939691c7ad388c31424f004a
   md5: d6e39dc492c7dfe395fc13f147c7aa3f
@@ -43116,26 +42731,26 @@ packages:
   license: BSD-3-Clause
   size: 22780
   timestamp: 1736205204792
-- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-ament-cmake-export-libraries-1.3.11-np126py311h7d8ee0e_8.conda
-  sha256: 4d2aaf3caea129c6b70f94d939581fe8c836431fc9638bb86ff02dc01049c435
-  md5: b5b7ba81ef2493495c64d62110eab3f7
+- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-ament-cmake-export-libraries-1.3.12-np126py311hd5de103_13.conda
+  sha256: 01ba01d5cf31c521d3b7c93b82ebfe434f12958082133a90bb4e83a44182e593
+  md5: 5d2b3a4c6d7ebb67e80b965f0d483c2d
   depends:
   - python
   - ros-humble-ament-cmake-core
   - ros-humble-ros-workspace
-  - ros2-distro-mutex 0.6.* humble_*
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - ros2-distro-mutex 0.7.* humble_*
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
   - numpy >=1.26.4,<2.0a0
-  - ros2-distro-mutex >=0.6.0,<0.7.0a0
   - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
   license: BSD-3-Clause
-  size: 19525
-  timestamp: 1736205700843
+  size: 20646
+  timestamp: 1753308567083
 - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-ament-cmake-export-link-flags-1.3.11-np126py311h2c3b307_7.conda
   sha256: b847d395b22456e462fab27b140555f0582b35d7f53427d95590ad2a742163b2
   md5: c0b178f47eb707335321239a6ab2f7c3
@@ -43202,26 +42817,26 @@ packages:
   license: BSD-3-Clause
   size: 20784
   timestamp: 1736205443319
-- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-ament-cmake-export-link-flags-1.3.11-np126py311h7d8ee0e_8.conda
-  sha256: bd4d194b365e88e662ec4a70f479abe5e9f36927524cead4588b1879427da942
-  md5: b512263657ec2561181bd5968b5a30b9
+- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-ament-cmake-export-link-flags-1.3.12-np126py311hd5de103_13.conda
+  sha256: a0cd258a87606899e2bfc70e8f1dc22e748f9f66675209063b2de50588469693
+  md5: 71d263803353d893c3c1b9c1bd09c653
   depends:
   - python
   - ros-humble-ament-cmake-core
   - ros-humble-ros-workspace
-  - ros2-distro-mutex 0.6.* humble_*
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - ros2-distro-mutex 0.7.* humble_*
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - ros2-distro-mutex >=0.6.0,<0.7.0a0
-  - numpy >=1.26.4,<2.0a0
   - python_abi 3.11.* *_cp311
+  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
   license: BSD-3-Clause
-  size: 17510
-  timestamp: 1736205796464
+  size: 18620
+  timestamp: 1753308655671
 - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-ament-cmake-export-targets-1.3.11-np126py311h2c3b307_7.conda
   sha256: d103b760ab84bc7516320ac07eae351922c8315ce87b7dc79411b2e5ecf13db0
   md5: 0ea169ff34b677b672bfbda5626d4041
@@ -43294,27 +42909,27 @@ packages:
   license: BSD-3-Clause
   size: 21570
   timestamp: 1736205480689
-- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-ament-cmake-export-targets-1.3.11-np126py311h7d8ee0e_8.conda
-  sha256: 046b80e7be130124d47ae3879d9e52508a1a6f57b39913e8cfe53486f351a34f
-  md5: 2439016e933dd34472f75c3f218c8032
+- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-ament-cmake-export-targets-1.3.12-np126py311hd5de103_13.conda
+  sha256: 60712bd70edb94ce69348c4a1bbdb116af4350d7d340df21af78665961153cfd
+  md5: 3b165d8869d6a40c60ec71c859afad23
   depends:
   - python
   - ros-humble-ament-cmake-core
   - ros-humble-ament-cmake-export-libraries
   - ros-humble-ros-workspace
-  - ros2-distro-mutex 0.6.* humble_*
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - ros2-distro-mutex 0.7.* humble_*
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - ros2-distro-mutex >=0.6.0,<0.7.0a0
-  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
   - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
   license: BSD-3-Clause
-  size: 18322
-  timestamp: 1736206545850
+  size: 19428
+  timestamp: 1753309340088
 - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-ament-cmake-flake8-0.12.11-np126py311h2c3b307_7.conda
   sha256: 1d988b0373d481884d1ea419c83c96369669fe490e5bf2ca3aab3ea109c81a1d
   md5: 73e58a5a02356d71e00bbe25c2ae8ee5
@@ -43385,27 +43000,27 @@ packages:
   license: BSD-3-Clause
   size: 22153
   timestamp: 1736206874683
-- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-ament-cmake-flake8-0.12.11-np126py311h7d8ee0e_8.conda
-  sha256: 2417dfc7bc68fe3c9e9025f483a6f20c33d87545c69fc00127ab8fed2aefa430
-  md5: b35a84401f001d99dc0da4a53ee8a0ea
+- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-ament-cmake-flake8-0.12.12-np126py311hd5de103_13.conda
+  sha256: 6dce2289ecba7bd39d9df3cacc03c7acb2d6c40882131daecc188477fcff8374
+  md5: c126e1cc38e4a379c6b4e256fdf95594
   depends:
   - python
   - ros-humble-ament-cmake-test
   - ros-humble-ament-flake8
   - ros-humble-ros-workspace
-  - ros2-distro-mutex 0.6.* humble_*
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - ros2-distro-mutex 0.7.* humble_*
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
   - numpy >=1.26.4,<2.0a0
-  - ros2-distro-mutex >=0.6.0,<0.7.0a0
   - python_abi 3.11.* *_cp311
   license: BSD-3-Clause
-  size: 18943
-  timestamp: 1736208861802
+  size: 20047
+  timestamp: 1753315028359
 - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-ament-cmake-gen-version-h-1.3.11-np126py311h2c3b307_7.conda
   sha256: 50649cb811b244995a57d5d938a7eeff990f220be67b5c06d31787856bac1304
   md5: 75cedd56c7e6b0c86dbcf8a076d4504a
@@ -43473,26 +43088,26 @@ packages:
   license: BSD-3-Clause
   size: 23544
   timestamp: 1736206293911
-- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-ament-cmake-gen-version-h-1.3.11-np126py311h7d8ee0e_8.conda
-  sha256: fa18db1c5f6b91796afb9aa91c31501c56f61f9f42c2172b50a6314bdc408ae0
-  md5: 11f67013805982d3b933b130d19e6262
+- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-ament-cmake-gen-version-h-1.3.12-np126py311hd5de103_13.conda
+  sha256: b1a40ab847d751f38c444a9df0f7e380038dbe42982c686019d753cc442b906f
+  md5: 288d2758185d096704dfd75f6166fe9c
   depends:
   - python
   - ros-humble-ament-cmake-core
   - ros-humble-ros-workspace
-  - ros2-distro-mutex 0.6.* humble_*
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - ros2-distro-mutex 0.7.* humble_*
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
   - numpy >=1.26.4,<2.0a0
   - python_abi 3.11.* *_cp311
   license: BSD-3-Clause
-  size: 20329
-  timestamp: 1736207179115
+  size: 21453
+  timestamp: 1753310674710
 - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-ament-cmake-gmock-1.3.11-np126py311h2c3b307_7.conda
   sha256: e34e880a128d657392cb1fc4699704902745d7f22821e8a2c1249f8d730b09bf
   md5: 363bb5cf965f797f9a1e9784e898daf1
@@ -43571,9 +43186,9 @@ packages:
   license: BSD-3-Clause
   size: 23138
   timestamp: 1736206306335
-- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-ament-cmake-gmock-1.3.11-np126py311h7d8ee0e_8.conda
-  sha256: 489a4dd8e4d159a455e7060b0a64e20d090a589cfd9e2db5c1b21de6e05f4861
-  md5: b1a56a4a193d939abf9dd56151be1bb8
+- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-ament-cmake-gmock-1.3.12-np126py311hd5de103_13.conda
+  sha256: b018dc3aa2aecb1010dabf972097efeb8a2ece61ef1272ce167415c6622535cb
+  md5: f8f66e3a546d0bab3327e2431bd68e31
   depends:
   - gmock
   - python
@@ -43581,19 +43196,19 @@ packages:
   - ros-humble-ament-cmake-test
   - ros-humble-gmock-vendor
   - ros-humble-ros-workspace
-  - ros2-distro-mutex 0.6.* humble_*
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - ros2-distro-mutex 0.7.* humble_*
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
   - numpy >=1.26.4,<2.0a0
-  - ros2-distro-mutex >=0.6.0,<0.7.0a0
   - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
   license: BSD-3-Clause
-  size: 19874
-  timestamp: 1736207229663
+  size: 20986
+  timestamp: 1753310787227
 - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-ament-cmake-gtest-1.3.11-np126py311h2c3b307_7.conda
   sha256: b11d04f83877f48fb5966b96d59a1c80ce94c3134c786621d01ffa525df7e7f8
   md5: 8d3230320ed54ac6153902c2203436cb
@@ -43673,29 +43288,29 @@ packages:
   license: BSD-3-Clause
   size: 23367
   timestamp: 1736206185548
-- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-ament-cmake-gtest-1.3.11-np126py311h7d8ee0e_8.conda
-  sha256: 6da998d8f85d98631095913bb1ba64e705a4a025c7cc92dc64997426dc1c5973
-  md5: 5f914b640d8ffe1ede7c85a84dc79223
+- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-ament-cmake-gtest-1.3.12-np126py311hd5de103_13.conda
+  sha256: d8e7408f3627348ec03d8e2fd6da4ce574d0312d0cac9babab7873e756f8cc3d
+  md5: 894f45a461ef772274ca24bda9009824
   depends:
   - gtest
   - python
   - ros-humble-ament-cmake-test
   - ros-humble-gtest-vendor
   - ros-humble-ros-workspace
-  - ros2-distro-mutex 0.6.* humble_*
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - ros2-distro-mutex 0.7.* humble_*
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - gtest >=1.15.2,<1.15.3.0a0
-  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
+  - gtest >=1.17.0,<1.17.1.0a0
   - numpy >=1.26.4,<2.0a0
-  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - python_abi 3.11.* *_cp311
   license: BSD-3-Clause
-  size: 20098
-  timestamp: 1736206861733
+  size: 21204
+  timestamp: 1753309928588
 - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-ament-cmake-include-directories-1.3.11-np126py311h2c3b307_7.conda
   sha256: 08d4ba482a6f697ce0299fb030f9b27a7ea00d0f5326e8ecb99d6e0b8732798e
   md5: 0e7a11d653aef8b622a648b7480196ba
@@ -43764,26 +43379,26 @@ packages:
   license: BSD-3-Clause
   size: 20720
   timestamp: 1736205239387
-- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-ament-cmake-include-directories-1.3.11-np126py311h7d8ee0e_8.conda
-  sha256: 5c5f4ca42fdc6915139c6faf6067cbf61ee37f99618d9c044d688e6e24150e64
-  md5: a2f901cc2ad9295ad746dc6a3b653ba7
+- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-ament-cmake-include-directories-1.3.12-np126py311hd5de103_13.conda
+  sha256: 3b7faea541c543b5bbec07a662980286cb2c76b5e5b2889866104f6f9ed366cf
+  md5: 6cf19b3f74c08a3376debeee30af2d28
   depends:
   - python
   - ros-humble-ament-cmake-core
   - ros-humble-ros-workspace
-  - ros2-distro-mutex 0.6.* humble_*
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - ros2-distro-mutex 0.7.* humble_*
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - ros2-distro-mutex >=0.6.0,<0.7.0a0
   - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
   - numpy >=1.26.4,<2.0a0
   license: BSD-3-Clause
-  size: 17462
-  timestamp: 1736205756656
+  size: 18605
+  timestamp: 1753308519660
 - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-ament-cmake-libraries-1.3.11-np126py311h2c3b307_7.conda
   sha256: 20d33b463dcaa986f7057ede995c96b84eda6c37c83ad8aa0b6a6bec6fec4b92
   md5: 70d50c3633cc3fba38b228779d86bef6
@@ -43850,26 +43465,26 @@ packages:
   license: BSD-3-Clause
   size: 20394
   timestamp: 1736205232902
-- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-ament-cmake-libraries-1.3.11-np126py311h7d8ee0e_8.conda
-  sha256: fa10c605205b98866c3c1f47bf3bdd8f6497490c5518c50f4530ca3383ea39d0
-  md5: d3e9cecace6aa81faa07edebb5d54fa2
+- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-ament-cmake-libraries-1.3.12-np126py311hd5de103_13.conda
+  sha256: 98e4c8123a8170fbdacb8b3c2df441e31b4d1f37cc515bfcd2ab3587c6f186a7
+  md5: 1678ec1553b9139d4f755930656221fe
   depends:
   - python
   - ros-humble-ament-cmake-core
   - ros-humble-ros-workspace
-  - ros2-distro-mutex 0.6.* humble_*
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - ros2-distro-mutex 0.7.* humble_*
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
   - numpy >=1.26.4,<2.0a0
   - python_abi 3.11.* *_cp311
-  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
   license: BSD-3-Clause
-  size: 17095
-  timestamp: 1736205735129
+  size: 18214
+  timestamp: 1753308478455
 - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-ament-cmake-lint-cmake-0.12.11-np126py311h2c3b307_7.conda
   sha256: 90c83b3de00c6d88591a0f286df3b4ee181c7c47afe4be3bedea8f6fd9816bf5
   md5: 34e3f94ddf7afa9463ba07955eb5c34f
@@ -43940,27 +43555,27 @@ packages:
   license: BSD-3-Clause
   size: 21093
   timestamp: 1736206443162
-- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-ament-cmake-lint-cmake-0.12.11-np126py311h7d8ee0e_8.conda
-  sha256: e1bf8eae7ce0e0d797b3e1a4e49a57cd517875ca4604d36dd97cdb223d3b63b1
-  md5: 94a4e6152519aabe67d75cfeb1ba289f
+- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-ament-cmake-lint-cmake-0.12.12-np126py311hd5de103_13.conda
+  sha256: f4a472618d357558b905f5779fb4d3130a3a42adcf5db03d7cbe49930ed84b81
+  md5: 26a81736dbe7552fcc4e5bc66711efcf
   depends:
   - python
   - ros-humble-ament-cmake-test
   - ros-humble-ament-lint-cmake
   - ros-humble-ros-workspace
-  - ros2-distro-mutex 0.6.* humble_*
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - ros2-distro-mutex 0.7.* humble_*
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
   - python_abi 3.11.* *_cp311
   - numpy >=1.26.4,<2.0a0
   license: BSD-3-Clause
-  size: 17824
-  timestamp: 1736207894211
+  size: 18956
+  timestamp: 1753312682696
 - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-ament-cmake-pep257-0.12.11-np126py311h2c3b307_7.conda
   sha256: 02c0695afd3798edd9f873246b3c3898be82085ae59ed24bfc38bfdd315f7eb2
   md5: 71311da5e5ed80a4e15fc46285e43afc
@@ -44032,27 +43647,27 @@ packages:
   license: BSD-3-Clause
   size: 21856
   timestamp: 1736206866329
-- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-ament-cmake-pep257-0.12.11-np126py311h7d8ee0e_8.conda
-  sha256: f937b4dde617a0c9e35b1b23c48bb78c05788a07b1cc5b61371d456941441fe8
-  md5: 151688657387f34c84a569afd619b539
+- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-ament-cmake-pep257-0.12.12-np126py311hd5de103_13.conda
+  sha256: 9fef772f08314e426b8f227ec47d3e8317712b0acb72736278c48ec4e64125e8
+  md5: 53c59c33cd67312fe8e9334555c18b0d
   depends:
   - python
   - ros-humble-ament-cmake-test
   - ros-humble-ament-pep257
   - ros-humble-ros-workspace
-  - ros2-distro-mutex 0.6.* humble_*
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - ros2-distro-mutex 0.7.* humble_*
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - ros2-distro-mutex >=0.6.0,<0.7.0a0
   - python_abi 3.11.* *_cp311
   - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
   license: BSD-3-Clause
-  size: 18583
-  timestamp: 1736208838971
+  size: 19702
+  timestamp: 1753314968588
 - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-ament-cmake-pytest-1.3.11-np126py311h2c3b307_7.conda
   sha256: 2d7263c5e6576089a7f9ea700976956134a38b6ecc3b87bb9a2694dbdd844273
   md5: 36b452cc0f53b2c93f86880e5bd7bcc2
@@ -44129,28 +43744,28 @@ packages:
   license: BSD-3-Clause
   size: 23421
   timestamp: 1736206203598
-- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-ament-cmake-pytest-1.3.11-np126py311h7d8ee0e_8.conda
-  sha256: ae79c6563f1bc3a395686b3f120d37b1e3d7cd77bc8c1d7fee004f0aa5dc9808
-  md5: 682b13811199b6f08b4487ebb0163d9a
+- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-ament-cmake-pytest-1.3.12-np126py311hd5de103_13.conda
+  sha256: dfc7f70eec93d8067a54e30fd821ca68328a5bf5b3e9688de3e38e78472edcc8
+  md5: 11629758eb914b64087e2d3b99650026
   depends:
   - pytest
   - python
   - ros-humble-ament-cmake-core
   - ros-humble-ament-cmake-test
   - ros-humble-ros-workspace
-  - ros2-distro-mutex 0.6.* humble_*
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - ros2-distro-mutex 0.7.* humble_*
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
   - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
   - numpy >=1.26.4,<2.0a0
-  - ros2-distro-mutex >=0.6.0,<0.7.0a0
   license: BSD-3-Clause
-  size: 20170
-  timestamp: 1736206938208
+  size: 21519
+  timestamp: 1753310059601
 - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-ament-cmake-python-1.3.11-np126py311h2c3b307_7.conda
   sha256: 47ce511bdee4659c51169b28c3d2fd0146b3700a3f22d59841463e3a1d75cc80
   md5: 2012aca135f7d3b82ea8453e357fac8d
@@ -44218,26 +43833,26 @@ packages:
   license: BSD-3-Clause
   size: 23065
   timestamp: 1736205218103
-- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-ament-cmake-python-1.3.11-np126py311h7d8ee0e_8.conda
-  sha256: 8554d631235e5dc6580b262535aad42c87f07a42a84490266af74982fc907e45
-  md5: 7d09b50aa305bb30fd58d6d67f8df87b
+- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-ament-cmake-python-1.3.12-np126py311hd5de103_13.conda
+  sha256: f2f214e84c12a848b4a1a37d536c1eae7d39fd4715876cd484cd3a4f6b03e3e6
+  md5: f2ab7d030f41f1ec6a898ddac1a60bb8
   depends:
   - python
   - ros-humble-ament-cmake-core
   - ros-humble-ros-workspace
-  - ros2-distro-mutex 0.6.* humble_*
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - ros2-distro-mutex 0.7.* humble_*
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - ros2-distro-mutex >=0.6.0,<0.7.0a0
-  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
   - python_abi 3.11.* *_cp311
+  - numpy >=1.26.4,<2.0a0
   license: BSD-3-Clause
-  size: 20144
-  timestamp: 1736205682711
+  size: 20891
+  timestamp: 1753308386191
 - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-ament-cmake-ros-0.10.0-np126py311h2c3b307_7.conda
   sha256: 005b202f7fc9210489ebdf03a163cbad34a4c987aa68e453d220ea398af8c0ad
   md5: 3def493e443c1e454bfb6a6c4d474c3e
@@ -44320,9 +43935,9 @@ packages:
   license: BSD-3-Clause
   size: 29242
   timestamp: 1736207442383
-- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-ament-cmake-ros-0.10.0-np126py311h7d8ee0e_8.conda
-  sha256: 92d7aba52996279e5c7df3f7f2b7ee8f22964673edc5eda9d2d89f6cf306db1a
-  md5: 60ef4e472553ce3f08e598f43ec00139
+- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-ament-cmake-ros-0.10.0-np126py311hd5de103_13.conda
+  sha256: ceebda7322d57a9e073878fbfcd10ee393b7a2e635af755588cf2532b1704e68
+  md5: 972022aa3c51ec45a85e946b3b3c9438
   depends:
   - python
   - ros-humble-ament-cmake
@@ -44331,19 +43946,19 @@ packages:
   - ros-humble-ament-cmake-pytest
   - ros-humble-domain-coordinator
   - ros-humble-ros-workspace
-  - ros2-distro-mutex 0.6.* humble_*
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - ros2-distro-mutex 0.7.* humble_*
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
   - python_abi 3.11.* *_cp311
-  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - numpy >=1.26.4,<2.0a0
   license: BSD-3-Clause
-  size: 25920
-  timestamp: 1736210598132
+  size: 27380
+  timestamp: 1753317648004
 - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-ament-cmake-target-dependencies-1.3.11-np126py311h2c3b307_7.conda
   sha256: d62c1f14d169a8565ed9f201b9f73598041e2f8382e6e2c890eec3e866604eaf
   md5: caa0adf1df6773fc4bc23bd23c9451f7
@@ -44419,28 +44034,28 @@ packages:
   license: BSD-3-Clause
   size: 22426
   timestamp: 1736205475854
-- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-ament-cmake-target-dependencies-1.3.11-np126py311h7d8ee0e_8.conda
-  sha256: edfa388c51942c4e433a632a62e4a5eda27b02935fe7e67efad947e412e22e6b
-  md5: 75e2541df15c955be3c2ed09df0b2ca1
+- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-ament-cmake-target-dependencies-1.3.12-np126py311hd5de103_13.conda
+  sha256: 08b3e7974491a3cb232e20fc159179ab0fd4a3492e47cdf427a5b855e15ed265
+  md5: c1912a88fb3db58edfa6e5f234151712
   depends:
   - python
   - ros-humble-ament-cmake-core
   - ros-humble-ament-cmake-include-directories
   - ros-humble-ament-cmake-libraries
   - ros-humble-ros-workspace
-  - ros2-distro-mutex 0.6.* humble_*
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - ros2-distro-mutex 0.7.* humble_*
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
   - numpy >=1.26.4,<2.0a0
   - python_abi 3.11.* *_cp311
-  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
   license: BSD-3-Clause
-  size: 19176
-  timestamp: 1736206524295
+  size: 20300
+  timestamp: 1753309296042
 - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-ament-cmake-test-1.3.11-np126py311h2c3b307_7.conda
   sha256: 2f978c4098b0c4731ae61bda6b298ddebcad6ca64b19a743aec7867a2e6d9f2e
   md5: 80a632762483d5a26fa4494f2c152d6f
@@ -44509,26 +44124,26 @@ packages:
   license: BSD-3-Clause
   size: 35047
   timestamp: 1736205461152
-- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-ament-cmake-test-1.3.11-np126py311h7d8ee0e_8.conda
-  sha256: d8ccc857d540532b4f4cdbcb41c76aca3a004ef6d94b1f696ae3856f966488a1
-  md5: 73d1160dbf31d31cc562b61b62b4b252
+- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-ament-cmake-test-1.3.12-np126py311hd5de103_13.conda
+  sha256: da3dfa9234ab2791369e6a5c68d69c561c9724acdfa9c0c60725844b983bbabc
+  md5: cffaf502b573b1ee3b4737c134b6cdd5
   depends:
   - python
   - ros-humble-ament-cmake-core
   - ros-humble-ros-workspace
-  - ros2-distro-mutex 0.6.* humble_*
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - ros2-distro-mutex 0.7.* humble_*
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - python_abi 3.11.* *_cp311
-  - ros2-distro-mutex >=0.6.0,<0.7.0a0
   - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
+  - python_abi 3.11.* *_cp311
   license: BSD-3-Clause
-  size: 31575
-  timestamp: 1736206482498
+  size: 32907
+  timestamp: 1753309221361
 - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-ament-cmake-uncrustify-0.12.11-np126py311h2c3b307_7.conda
   sha256: adfd92d2873ef269a4d426684ede008d2222969fb5da2410a9e8b4b68e671fa8
   md5: 43b73f7f089d76b2e89d7cae274d3b43
@@ -44600,27 +44215,27 @@ packages:
   license: BSD-3-Clause
   size: 22200
   timestamp: 1736206856677
-- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-ament-cmake-uncrustify-0.12.11-np126py311h7d8ee0e_8.conda
-  sha256: fcf38a6ad4f9aebd8f8a090b48d95002730feafeb0601bff7aeacf5ef14b3807
-  md5: 3245a398f2923b831a1318f819654c56
+- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-ament-cmake-uncrustify-0.12.12-np126py311hd5de103_13.conda
+  sha256: dad078af7905f5ab365cbb0bceb694d0705d68a31b96768870a2318d957102d0
+  md5: 42b577f3f5ed88cd5cb7689273fc49ab
   depends:
   - python
   - ros-humble-ament-cmake-test
   - ros-humble-ament-uncrustify
   - ros-humble-ros-workspace
-  - ros2-distro-mutex 0.6.* humble_*
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - ros2-distro-mutex 0.7.* humble_*
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - ros2-distro-mutex >=0.6.0,<0.7.0a0
-  - numpy >=1.26.4,<2.0a0
   - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
+  - numpy >=1.26.4,<2.0a0
   license: BSD-3-Clause
-  size: 18981
-  timestamp: 1736208813477
+  size: 20103
+  timestamp: 1753314901194
 - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-ament-cmake-version-1.3.11-np126py311h2c3b307_7.conda
   sha256: 5b700c9fd1474e5a8b21f8bc807b02258ce3b750d56278be0b2e03148bd3c9a7
   md5: fbd1026fc17d5d6cb9d1cbdf3d4794dd
@@ -44686,26 +44301,26 @@ packages:
   license: BSD-3-Clause
   size: 20549
   timestamp: 1736205469431
-- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-ament-cmake-version-1.3.11-np126py311h7d8ee0e_8.conda
-  sha256: 43062125b95a1a63fbb1e4619c57e5f803771d2001c4e4669fc027358e6527fd
-  md5: 190ef0dd65f89c19a2635182362acac0
+- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-ament-cmake-version-1.3.12-np126py311hd5de103_13.conda
+  sha256: ab2fab22225d82d6c39f905c1ebc1632e5010e9835e7b25ecdc3cc9dfbc474ee
+  md5: 2f28c0751b928671fbbdaafc0f72b33c
   depends:
   - python
   - ros-humble-ament-cmake-core
   - ros-humble-ros-workspace
-  - ros2-distro-mutex 0.6.* humble_*
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - ros2-distro-mutex 0.7.* humble_*
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - ros2-distro-mutex >=0.6.0,<0.7.0a0
-  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
   - python_abi 3.11.* *_cp311
+  - numpy >=1.26.4,<2.0a0
   license: BSD-3-Clause
-  size: 17342
-  timestamp: 1736205776610
+  size: 18484
+  timestamp: 1753308612176
 - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-ament-cmake-xmllint-0.12.11-np126py311h2c3b307_7.conda
   sha256: e19b2df307f9e39a2f60860522c36d0c26725515949e282e35129efe602f99d1
   md5: 0c1a923bbaf3322ebd4fd9469d0d71f6
@@ -44776,27 +44391,27 @@ packages:
   license: BSD-3-Clause
   size: 21585
   timestamp: 1736206838415
-- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-ament-cmake-xmllint-0.12.11-np126py311h7d8ee0e_8.conda
-  sha256: cb408a60ac7597b8852deeb7da7fb4f56b1a780af96ff7d569edea94f10571a7
-  md5: 4b78ea6168319cd9bcc7261913f157e3
+- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-ament-cmake-xmllint-0.12.12-np126py311hd5de103_13.conda
+  sha256: 285756eb01be53bbc82659f3f055cbfaec9f148154f86c1d92acc0043b5cd727
+  md5: e1d2813919cf7ed48c2a60588d87980b
   depends:
   - python
   - ros-humble-ament-cmake-test
   - ros-humble-ament-xmllint
   - ros-humble-ros-workspace
-  - ros2-distro-mutex 0.6.* humble_*
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - ros2-distro-mutex 0.7.* humble_*
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - python_abi 3.11.* *_cp311
-  - ros2-distro-mutex >=0.6.0,<0.7.0a0
   - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
   license: BSD-3-Clause
-  size: 18332
-  timestamp: 1736208725510
+  size: 19430
+  timestamp: 1753314773735
 - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-ament-copyright-0.12.11-np126py311h2c3b307_7.conda
   sha256: 388dd42e53c4548a1777c24ec1441d83a628f61860cfb267e85e693ecac3a63b
   md5: c672f0ddc5c600c2dd35026fedfa5efb
@@ -44868,27 +44483,27 @@ packages:
   license: BSD-3-Clause
   size: 64719
   timestamp: 1736206277143
-- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-ament-copyright-0.12.11-np126py311h7d8ee0e_8.conda
-  sha256: 9623a042232d24a7f060b0087220b1df4a8d224ee4cbd0a21038b2b51ce4fde3
-  md5: 8ef88feca353d233f844a7f25760df1d
+- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-ament-copyright-0.12.12-np126py311hd5de103_13.conda
+  sha256: a7381d1a77cba10fd6bdc93a258e8f3873397eb2f2f70cd29f8437fd9f455e60
+  md5: 385f8592aff3635768b3326c23264f86
   depends:
   - importlib-metadata
   - python
   - ros-humble-ament-lint
   - ros-humble-ros-workspace
-  - ros2-distro-mutex 0.6.* humble_*
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - ros2-distro-mutex 0.7.* humble_*
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
   - python_abi 3.11.* *_cp311
-  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
   - numpy >=1.26.4,<2.0a0
   license: BSD-3-Clause
-  size: 68745
-  timestamp: 1736207123431
+  size: 69168
+  timestamp: 1753310561474
 - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-ament-cppcheck-0.12.11-np126py311h2c3b307_7.conda
   sha256: 9de3d5aa2a1095b1c78c3113b672a13d68143baf22f0f36b90255ff120058383
   md5: c4140ce5debf18f8bfd39ff869511b0e
@@ -44956,26 +44571,26 @@ packages:
   license: BSD-3-Clause
   size: 27256
   timestamp: 1736205218869
-- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-ament-cppcheck-0.12.11-np126py311h7d8ee0e_8.conda
-  sha256: 2f34ea887feb0b76fb17e214abd1cd7bf712b13de8018196e60a8939b283f03a
-  md5: b61bb8ec4852d6724f5df0199ade7d38
+- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-ament-cppcheck-0.12.12-np126py311hd5de103_13.conda
+  sha256: eadb0f47e0c07cc361f095886d76125dd50a4a9b56e4aded58a7319bdfc1ed84
+  md5: c25a54a2646ed6068c66a3ee25992d16
   depends:
   - cppcheck
   - python
   - ros-humble-ros-workspace
-  - ros2-distro-mutex 0.6.* humble_*
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - ros2-distro-mutex 0.7.* humble_*
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
   - python_abi 3.11.* *_cp311
-  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
   - numpy >=1.26.4,<2.0a0
   license: BSD-3-Clause
-  size: 32226
-  timestamp: 1736205679731
+  size: 32424
+  timestamp: 1753308315044
 - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-ament-cpplint-0.12.11-np126py311h2c3b307_7.conda
   sha256: 9e79cafd49aabad82ee69b463d30500d78e2fb1228075258a1816d79212663ce
   md5: f902ee8a89f72f4f7954c9e24af3e2fe
@@ -45037,25 +44652,25 @@ packages:
   license: BSD-3-Clause
   size: 175460
   timestamp: 1736206389785
-- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-ament-cpplint-0.12.11-np126py311h7d8ee0e_8.conda
-  sha256: b51bca86e4fff2bcc4a75be8c129cf91e562be39d9df25dd187c9795092450a2
-  md5: a94fb60d68847c57dc9aa513baf43828
+- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-ament-cpplint-0.12.12-np126py311hd5de103_13.conda
+  sha256: 1acdab7e1b1a147fe8db38027d11804b76cd2609c62d179aa973f8ad8f1cfb12
+  md5: 2ed8481949dba4534f1cc6f5213d72af
   depends:
   - python
   - ros-humble-ros-workspace
-  - ros2-distro-mutex 0.6.* humble_*
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - ros2-distro-mutex 0.7.* humble_*
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - ros2-distro-mutex >=0.6.0,<0.7.0a0
-  - python_abi 3.11.* *_cp311
   - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
   license: BSD-3-Clause
-  size: 184504
-  timestamp: 1736207673405
+  size: 184416
+  timestamp: 1753312011901
 - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-ament-flake8-0.12.11-np126py311h2c3b307_7.conda
   sha256: e3e7e01b652867ef71b6e4b9eb0a7377d591408826ac309d8aae248280bd7357
   md5: 0ec5ee13cb37dc5c46a45d243c76f48b
@@ -45127,27 +44742,27 @@ packages:
   license: BSD-3-Clause
   size: 28411
   timestamp: 1736205446728
-- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-ament-flake8-0.12.11-np126py311h7d8ee0e_8.conda
-  sha256: 0259e0750624fe7b459c2859c4f5186368458cf2f2e92b22d3e83c771625b6e8
-  md5: 2fa9301f1ce187176c8eeae3b3a592d8
+- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-ament-flake8-0.12.12-np126py311hd5de103_13.conda
+  sha256: 05711ff124e0ed4ec9c5b6283d321be832169b5e3246ee5c3ae5443c4080dddc
+  md5: 5d04db211089476bb38d81f92cb5c0df
   depends:
   - flake8
   - python
   - ros-humble-ament-lint
   - ros-humble-ros-workspace
-  - ros2-distro-mutex 0.6.* humble_*
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - ros2-distro-mutex 0.7.* humble_*
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
   - numpy >=1.26.4,<2.0a0
-  - ros2-distro-mutex >=0.6.0,<0.7.0a0
   - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
   license: BSD-3-Clause
-  size: 33297
-  timestamp: 1736206424344
+  size: 33521
+  timestamp: 1753309143958
 - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-ament-index-cpp-1.4.0-np126py311h2c3b307_7.conda
   sha256: 4dd3a439868403c3ff9ebe22bf786765d802a1a9f2ace349259d11eb26187512
   md5: 217fa69e0b2dcc2f6fbd1f91a45bc516
@@ -45211,25 +44826,25 @@ packages:
   license: BSD-3-Clause
   size: 44622
   timestamp: 1736207226922
-- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-ament-index-cpp-1.4.0-np126py311h7d8ee0e_8.conda
-  sha256: 9b92df47ffc790033ebb54ec0ede35dc61b205060a20a89d840d66159bd7a2e3
-  md5: 065afb7c2f9ea412a2e39e8ca720f2c7
+- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-ament-index-cpp-1.4.0-np126py311hd5de103_13.conda
+  sha256: 804012704f13c2ddd922f21def8215cd5f9880b4c277fdbeddf24ee387b0d869
+  md5: 2dcb2bafe9826789b1fc99c17e0b06ba
   depends:
   - python
   - ros-humble-ros-workspace
-  - ros2-distro-mutex 0.6.* humble_*
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - ros2-distro-mutex 0.7.* humble_*
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
   - python_abi 3.11.* *_cp311
   - numpy >=1.26.4,<2.0a0
-  - ros2-distro-mutex >=0.6.0,<0.7.0a0
   license: BSD-3-Clause
-  size: 47756
-  timestamp: 1736210409369
+  size: 49423
+  timestamp: 1753318509344
 - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-ament-index-python-1.4.0-np126py311h2c3b307_7.conda
   sha256: ab29d83fb3bbd8207557a246e27209e27d84392c3119ed2a5ef2d9a0137bb858
   md5: 86402019c344731609103b4808091600
@@ -45293,25 +44908,25 @@ packages:
   license: BSD-3-Clause
   size: 28085
   timestamp: 1736206399661
-- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-ament-index-python-1.4.0-np126py311h7d8ee0e_8.conda
-  sha256: 2cf7852ad56b712ab6b904d9c8eaffd771dc74421dbec470002ed390f4f18cb5
-  md5: 3b52432c88949b4597721df19f029d25
+- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-ament-index-python-1.4.0-np126py311hd5de103_13.conda
+  sha256: f7cea2e7a7c6a06ad5b3bf9fefd169491536543a22a1de1319633255ff7f8140
+  md5: 854584aab7814f7fd0747a8f0ffd84ec
   depends:
   - python
   - ros-humble-ros-workspace
-  - ros2-distro-mutex 0.6.* humble_*
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - ros2-distro-mutex 0.7.* humble_*
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - ros2-distro-mutex >=0.6.0,<0.7.0a0
-  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
   - python_abi 3.11.* *_cp311
+  - numpy >=1.26.4,<2.0a0
   license: BSD-3-Clause
-  size: 32823
-  timestamp: 1736207698009
+  size: 33261
+  timestamp: 1753312076219
 - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-ament-lint-0.12.11-np126py311h2c3b307_7.conda
   sha256: 5c4d125b5d67659b44166d0bef409b0f2e1e5ef2c6e666ba06348f369e296790
   md5: 4f2d9d6a9c610932d966f034400ba36f
@@ -45375,25 +44990,25 @@ packages:
   license: BSD-3-Clause
   size: 16421
   timestamp: 1736205201310
-- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-ament-lint-0.12.11-np126py311h7d8ee0e_8.conda
-  sha256: d834f7af1bddda81e6153216fe5b7123324dd8de30721404b188ed972fa70ef8
-  md5: f162ca6b0b6662153bf24e43d5681fb6
+- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-ament-lint-0.12.12-np126py311hd5de103_13.conda
+  sha256: c221ec435bf59ff269e7bc5255f72abc6ffe6ba80165ccd466261764e3c0d366
+  md5: e9603ab23cddbdef24ec20534faca674
   depends:
   - python
   - ros-humble-ros-workspace
-  - ros2-distro-mutex 0.6.* humble_*
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - ros2-distro-mutex 0.7.* humble_*
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - numpy >=1.26.4,<2.0a0
-  - ros2-distro-mutex >=0.6.0,<0.7.0a0
   - python_abi 3.11.* *_cp311
+  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
   license: BSD-3-Clause
-  size: 13280
-  timestamp: 1736205629992
+  size: 13517
+  timestamp: 1753308314751
 - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-ament-lint-auto-0.12.11-np126py311h2c3b307_7.conda
   sha256: ea4fc847e79f5de3beccf45f74460e2d7150c3992258886c8cdaf2859f0482aa
   md5: fc1c5838b478028ea842b138d89ffa19
@@ -45464,27 +45079,27 @@ packages:
   license: BSD-3-Clause
   size: 20840
   timestamp: 1736206193858
-- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-ament-lint-auto-0.12.11-np126py311h7d8ee0e_8.conda
-  sha256: a61762482aac1f95e1d98b50e57253b1f960f39c4d47b5ecc53cd39bca472c69
-  md5: 4febc8c196adca9ff5bc7bf035127535
+- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-ament-lint-auto-0.12.12-np126py311hd5de103_13.conda
+  sha256: a26d57551ae04feeefabfd9fa3cfe841b7cf205ce21d49e1812297e0f6c4af9a
+  md5: 10f66c325998e8a98e98e1f0aaf79bfd
   depends:
   - python
   - ros-humble-ament-cmake-core
   - ros-humble-ament-cmake-test
   - ros-humble-ros-workspace
-  - ros2-distro-mutex 0.6.* humble_*
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - ros2-distro-mutex 0.7.* humble_*
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
   - python_abi 3.11.* *_cp311
   - numpy >=1.26.4,<2.0a0
-  - ros2-distro-mutex >=0.6.0,<0.7.0a0
   license: BSD-3-Clause
-  size: 17507
-  timestamp: 1736206893472
+  size: 18609
+  timestamp: 1753309977038
 - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-ament-lint-cmake-0.12.11-np126py311h2c3b307_7.conda
   sha256: b89fad016ba75944dbd128dbb2b244d5528eccfaba12bd7db67b531ff6876fc8
   md5: a6ab244960992fa7c8cf91a4d7ae1237
@@ -45548,25 +45163,25 @@ packages:
   license: BSD-3-Clause
   size: 39634
   timestamp: 1736206350717
-- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-ament-lint-cmake-0.12.11-np126py311h7d8ee0e_8.conda
-  sha256: 13b96608576137a8330b5ccdb8eacceecc544715f81c3b8a91c58b565434cb0e
-  md5: bf06edebcbc7ac3c3c755cd4e30589df
+- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-ament-lint-cmake-0.12.12-np126py311hd5de103_13.conda
+  sha256: 50be8ff4a05fe6aedb494c4f5adf5926294740bc665fd4a1a21987f563ada50e
+  md5: 024e0f1fe2c300a4949ab56d29ce0bd7
   depends:
   - python
   - ros-humble-ros-workspace
-  - ros2-distro-mutex 0.6.* humble_*
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - ros2-distro-mutex 0.7.* humble_*
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - numpy >=1.26.4,<2.0a0
-  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
   - python_abi 3.11.* *_cp311
+  - numpy >=1.26.4,<2.0a0
   license: BSD-3-Clause
-  size: 44769
-  timestamp: 1736207512476
+  size: 45189
+  timestamp: 1753311779184
 - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-ament-lint-common-0.12.11-np126py311h2c3b307_7.conda
   sha256: 5549272b5213df130c58b0d966afa163733ff29db343eb1924e866bb1e03d235
   md5: 76782fb32c11de3eed6063c50e4071e1
@@ -45665,9 +45280,9 @@ packages:
   license: BSD-3-Clause
   size: 21026
   timestamp: 1736206912799
-- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-ament-lint-common-0.12.11-np126py311h7d8ee0e_8.conda
-  sha256: 5efd92d2fa4fd4b743f8a9c5f800c1b9364d71dfbd8662365852bc8dc626920b
-  md5: d50675ddf739bcb44a8f7ce65b967dc9
+- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-ament-lint-common-0.12.12-np126py311hd5de103_13.conda
+  sha256: 4353b410dc55292d800b0c08e6c3325e5c4e2f328374bcbd93d4e338d731e702
+  md5: 95729a84d99f1093e9b4eae3fa645087
   depends:
   - python
   - ros-humble-ament-cmake-copyright
@@ -45680,19 +45295,19 @@ packages:
   - ros-humble-ament-cmake-uncrustify
   - ros-humble-ament-cmake-xmllint
   - ros-humble-ros-workspace
-  - ros2-distro-mutex 0.6.* humble_*
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - ros2-distro-mutex 0.7.* humble_*
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - python_abi 3.11.* *_cp311
-  - ros2-distro-mutex >=0.6.0,<0.7.0a0
   - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
+  - python_abi 3.11.* *_cp311
   license: BSD-3-Clause
-  size: 17776
-  timestamp: 1736209012654
+  size: 18950
+  timestamp: 1753315588230
 - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-ament-package-0.14.0-np126py311h2c3b307_7.conda
   sha256: c75cc1ae8ef017f0752b65f6d5325b706e640983d9ac96fdea35bac7ca009a48
   md5: 158a13122d7eb30aa58975d7ba565663
@@ -45765,27 +45380,27 @@ packages:
   license: BSD-3-Clause
   size: 47179
   timestamp: 1736205118557
-- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-ament-package-0.14.0-np126py311h7d8ee0e_8.conda
-  sha256: dd77a9d7630432b61b05462ce81cc4b6e3b120ed5f3ff3a6a892816ed915cfe9
-  md5: 6a4da28073405717508e4d8d65c895d4
+- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-ament-package-0.14.1-np126py311hd5de103_13.conda
+  sha256: 460329eaff66a308a34834591ce276291f9c13ab33bfb992fb06080bfee2f0bf
+  md5: f809718cbc0f2420465609c12317257e
   depends:
   - importlib-metadata
   - importlib_resources
   - python
-  - ros2-distro-mutex 0.6.* humble_*
+  - ros2-distro-mutex 0.7.* humble_*
   - setuptools
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - ros2-distro-mutex >=0.6.0,<0.7.0a0
-  - numpy >=1.26.4,<2.0a0
   - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
+  - numpy >=1.26.4,<2.0a0
   license: BSD-3-Clause
-  size: 39436
-  timestamp: 1736205397859
+  size: 39545
+  timestamp: 1753307972060
 - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-ament-pep257-0.12.11-np126py311h2c3b307_7.conda
   sha256: 7601c4cf2fcb3a115e2ff157ab2eac9dacd42cea40d875208ba5f8aba51baa0d
   md5: d11ce05f0c2491e4828bc2ae043b19ac
@@ -45857,27 +45472,27 @@ packages:
   license: BSD-3-Clause
   size: 26059
   timestamp: 1736206169626
-- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-ament-pep257-0.12.11-np126py311h7d8ee0e_8.conda
-  sha256: 6c02b5256dfee5b936158985d08902734f118bf5fd5c6f0582c089a2e5c0b25d
-  md5: d3abb924c565c1d2ce7b3868169db08a
+- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-ament-pep257-0.12.12-np126py311hd5de103_13.conda
+  sha256: a9a54e4922b8ed092d286507387c728d2111b836ae09765eda11f9f64cb6f9e4
+  md5: 7d2cc216618c11decf4ef0f6ee4be6a3
   depends:
   - pydocstyle
   - python
   - ros-humble-ament-lint
   - ros-humble-ros-workspace
-  - ros2-distro-mutex 0.6.* humble_*
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - ros2-distro-mutex 0.7.* humble_*
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - ros2-distro-mutex >=0.6.0,<0.7.0a0
-  - python_abi 3.11.* *_cp311
   - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
+  - python_abi 3.11.* *_cp311
   license: BSD-3-Clause
-  size: 31023
-  timestamp: 1736206815492
+  size: 31435
+  timestamp: 1753309864575
 - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-ament-uncrustify-0.12.11-np126py311h2c3b307_7.conda
   sha256: 9bf2656e1967057a529e5b298cf3159a025e06ba24548059943259dcc8d7b30c
   md5: ee37deb5784e7c194c371c82e30d6fb2
@@ -45944,26 +45559,26 @@ packages:
   license: BSD-3-Clause
   size: 48984
   timestamp: 1736206770052
-- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-ament-uncrustify-0.12.11-np126py311h7d8ee0e_8.conda
-  sha256: cbd31e19b34e3f050c670c4eb3501b2058dadcefb0a0008f31b4563eb5109613
-  md5: 81319b458dd3419ee95697b55d331351
+- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-ament-uncrustify-0.12.12-np126py311hd5de103_13.conda
+  sha256: 0e32cb6235d0ccf766765324bc8979d8fe92662f007a9ba2ab00d5352c6b1efc
+  md5: 981fca20e38c1002a2a0181a3d9bb8a8
   depends:
   - python
   - ros-humble-ros-workspace
   - ros-humble-uncrustify-vendor
-  - ros2-distro-mutex 0.6.* humble_*
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - ros2-distro-mutex 0.7.* humble_*
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
   - numpy >=1.26.4,<2.0a0
   - python_abi 3.11.* *_cp311
   license: BSD-3-Clause
-  size: 54157
-  timestamp: 1736208457408
+  size: 54597
+  timestamp: 1753313980127
 - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-ament-xmllint-0.12.11-np126py311h2c3b307_7.conda
   sha256: f0e165150a0b35cc8a63318763d84810030885615da30ae2bb89d3bf7497c313
   md5: 4b16b51995b0658352b14ffeb2c90add
@@ -46034,27 +45649,27 @@ packages:
   license: BSD-3-Clause
   size: 27388
   timestamp: 1736206381246
-- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-ament-xmllint-0.12.11-np126py311h7d8ee0e_8.conda
-  sha256: 223977b8e40431e43ff50556585c3ad7cc7a15d572277dc9450b25c66349facd
-  md5: b2df795c866afccbabf06f61600f8aa5
+- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-ament-xmllint-0.12.12-np126py311hd5de103_13.conda
+  sha256: 4670fa4189d10e41144f0701f662c7e0dd770dd43619b31c1a56868286801de5
+  md5: 1503dc790255dad9949d7858c8eefd8d
   depends:
   - libxml2
   - python
   - ros-humble-ament-lint
   - ros-humble-ros-workspace
-  - ros2-distro-mutex 0.6.* humble_*
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - ros2-distro-mutex 0.7.* humble_*
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
   - numpy >=1.26.4,<2.0a0
-  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
   - python_abi 3.11.* *_cp311
   license: BSD-3-Clause
-  size: 32337
-  timestamp: 1736207651586
+  size: 32753
+  timestamp: 1753311959201
 - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-angles-1.15.0-np126py311h2c3b307_7.conda
   sha256: 54424e7f004f8e12afcda941f32f716cf0597c56bb4eb0ab197aa28c860c7ed0
   md5: cfb2dabad689326e0fcaa28939c8224f
@@ -46122,26 +45737,26 @@ packages:
   license: BSD-3-Clause
   size: 31472
   timestamp: 1736206639297
-- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-angles-1.15.0-np126py311h7d8ee0e_8.conda
-  sha256: 2f0bfd57983a13637ff550559e98e91d9e7c667bc4015879e9870f2765482b4b
-  md5: 71a761e54eeb0c3328487ad43ca4a33f
+- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-angles-1.15.0-np126py311hd5de103_13.conda
+  sha256: 1d4bbb2a37401e6c7a059d3df4dfda834d18df41975049295eec3d83aaf29f97
+  md5: 63dde0062f95ead2770f3ecbaa8bab2f
   depends:
   - python
   - ros-humble-ament-cmake
   - ros-humble-ros-workspace
-  - ros2-distro-mutex 0.6.* humble_*
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - ros2-distro-mutex 0.7.* humble_*
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
   - numpy >=1.26.4,<2.0a0
   - python_abi 3.11.* *_cp311
-  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
   license: BSD-3-Clause
-  size: 28294
-  timestamp: 1736207942953
+  size: 29622
+  timestamp: 1753313136491
 - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-backward-ros-1.0.6-np126py311h2c3b307_7.conda
   sha256: 6ab1282e838d6c804e95ecf9df33af82d6db4d64929170dbf6a422e373d8cd3c
   md5: 4b70167b399689ec2f916bb4f2e21890
@@ -46205,25 +45820,25 @@ packages:
   license: BSD-3-Clause
   size: 71955
   timestamp: 1736205458040
-- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-backward-ros-1.0.6-np126py311h7d8ee0e_8.conda
-  sha256: d5aa0dc5bc5851c92546b1e4e07483d9de13a22a862038857e728ef66ccf6dfd
-  md5: 465d8bb33859cb68fe2a6849b0ac250e
+- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-backward-ros-1.0.8-np126py311hd5de103_13.conda
+  sha256: 28b206beacc11a11e54fc20cbb2b0873c9cfa5c2c07c5aa6fa7330b84d3da699
+  md5: c47f420ce808e0339634b10e72c0be73
   depends:
   - python
   - ros-humble-ros-workspace
-  - ros2-distro-mutex 0.6.* humble_*
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - ros2-distro-mutex 0.7.* humble_*
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
   - numpy >=1.26.4,<2.0a0
-  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - python_abi 3.11.* *_cp311
   license: BSD-3-Clause
-  size: 142850
-  timestamp: 1736206463801
+  size: 145223
+  timestamp: 1753309610640
 - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-builtin-interfaces-1.2.1-np126py311h2c3b307_7.conda
   sha256: 2d5d8bdf8c6117bb5fb58a4e6e051e4afe8b1c2245dd6eb6af94f4fce74b2a96
   md5: 86eee592f38f478d7bccc1c44136414d
@@ -46290,26 +45905,49 @@ packages:
   license: BSD-3-Clause
   size: 68734
   timestamp: 1736208411511
-- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-builtin-interfaces-1.2.1-np126py311h7d8ee0e_8.conda
-  sha256: 2641e40cc011023e7bc464a0c2c3989979322954f31a2a2777e9ea2cb10c601f
-  md5: 3c0af1cae3a16ddea49bee7ef3c01f2f
+- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-builtin-interfaces-1.2.1-np126py311hd5de103_13.conda
+  sha256: 31e37c5add1fb81bde4ab1103dd6d59c217b9180429d21805022b452ae641a9a
+  md5: 82528b0ddefce8a2cbe6b85027d910d1
   depends:
   - python
   - ros-humble-ros-workspace
   - ros-humble-rosidl-default-runtime
-  - ros2-distro-mutex 0.6.* humble_*
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - ros2-distro-mutex 0.7.* humble_*
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - ros2-distro-mutex >=0.6.0,<0.7.0a0
   - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
   - numpy >=1.26.4,<2.0a0
   license: BSD-3-Clause
-  size: 78176
-  timestamp: 1736229868464
+  size: 80157
+  timestamp: 1753323072448
+- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-chomp-motion-planner-2.5.9-np126py311hd5de103_13.conda
+  sha256: d1adda7a67227c4289191625b036de1793666ab42319285d59c6cb603298bd9d
+  md5: 0e20e511ef21bf88fe2aaef8a8f65cde
+  depends:
+  - python
+  - ros-humble-moveit-common
+  - ros-humble-moveit-core
+  - ros-humble-rclcpp
+  - ros-humble-ros-workspace
+  - ros-humble-trajectory-msgs
+  - ros2-distro-mutex 0.7.* humble_*
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  - ucrt >=10.0.20348.0
+  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  size: 202764
+  timestamp: 1753346557201
 - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-class-loader-2.2.0-np126py311h2c3b307_7.conda
   sha256: 42dbc7bea7e9708399d15fb78020a230895b4889f8a8d2d3c193b9a630ba18b2
   md5: 73c40abac862f37bb7829a52c0f2f258
@@ -46389,29 +46027,29 @@ packages:
   license: BSD-3-Clause
   size: 63282
   timestamp: 1736207949933
-- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-class-loader-2.2.0-np126py311h7d8ee0e_8.conda
-  sha256: 910175d39462f47e8610a9a32d9ee608fb79c1d2ed23546a69dc2111e559eae2
-  md5: f29dd8a1e5a6c0a32984cd3f86d52cb3
+- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-class-loader-2.2.0-np126py311hd5de103_13.conda
+  sha256: 422bb1daf58180f4ee08f2977e62e0a8587280b5ef4748d2845972d1b8b1d8d8
+  md5: 7db94f191aeb212f25dff59c2c28fddd
   depends:
   - console_bridge
   - python
   - ros-humble-console-bridge-vendor
   - ros-humble-rcpputils
   - ros-humble-ros-workspace
-  - ros2-distro-mutex 0.6.* humble_*
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - ros2-distro-mutex 0.7.* humble_*
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - console_bridge >=1.0.2,<1.1.0a0
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
   - python_abi 3.11.* *_cp311
   - numpy >=1.26.4,<2.0a0
-  - console_bridge >=1.0.2,<1.1.0a0
   license: BSD-3-Clause
-  size: 66069
-  timestamp: 1736228075644
+  size: 69086
+  timestamp: 1753320986389
 - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-common-interfaces-4.2.4-np126py311h2c3b307_7.conda
   sha256: 9e11170511ceeb46bc80db4a9170841488540702351258b91654ef0bc205afa1
   md5: 2cf397053f15cf3ee3b0c7f522827ec1
@@ -46524,9 +46162,9 @@ packages:
   license: BSD-3-Clause
   size: 24513
   timestamp: 1736209363615
-- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-common-interfaces-4.2.4-np126py311h7d8ee0e_8.conda
-  sha256: 0d8c93a2586717cab264a6d0c73867d1efda33262084a5dd1c64be655ad945e7
-  md5: aed8b06433aaf1da1fc66ea4662921f1
+- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-common-interfaces-4.9.0-np126py311hd5de103_13.conda
+  sha256: 4ce6917e9f62a8c05ca352492c3599964605423545f81db592f2d689819f10de
+  md5: 046a2638a4bb0358e8ba17e29b37fe2f
   depends:
   - python
   - ros-humble-actionlib-msgs
@@ -46542,19 +46180,19 @@ packages:
   - ros-humble-stereo-msgs
   - ros-humble-trajectory-msgs
   - ros-humble-visualization-msgs
-  - ros2-distro-mutex 0.6.* humble_*
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - ros2-distro-mutex 0.7.* humble_*
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - ros2-distro-mutex >=0.6.0,<0.7.0a0
   - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
   - python_abi 3.11.* *_cp311
   license: BSD-3-Clause
-  size: 21187
-  timestamp: 1736232765644
+  size: 22526
+  timestamp: 1753329356216
 - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-composition-interfaces-1.2.1-np126py311h2c3b307_7.conda
   sha256: d13d6f840377179db1c67748abc1f72efdd0ca56c5a06242af5f63c22502ee77
   md5: 9424fc9b5cb27f53c394d1c7e9976a18
@@ -46627,27 +46265,27 @@ packages:
   license: BSD-3-Clause
   size: 126256
   timestamp: 1736208698543
-- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-composition-interfaces-1.2.1-np126py311h7d8ee0e_8.conda
-  sha256: 307884ffe0369aba287af5a88b0228eb3e0e050170f7bd7a555ba510041b267f
-  md5: 665fb545b4aac87294db23740a18509f
+- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-composition-interfaces-1.2.1-np126py311hd5de103_13.conda
+  sha256: 344b6b7a172888d12069bbcf497e1d3833781e89a563cd3b1d1b8cde0fd79174
+  md5: f52706faeaa726256c30eff101ac10ee
   depends:
   - python
   - ros-humble-rcl-interfaces
   - ros-humble-ros-workspace
   - ros-humble-rosidl-default-runtime
-  - ros2-distro-mutex 0.6.* humble_*
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - ros2-distro-mutex 0.7.* humble_*
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - ros2-distro-mutex >=0.6.0,<0.7.0a0
-  - numpy >=1.26.4,<2.0a0
   - python_abi 3.11.* *_cp311
+  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
   license: BSD-3-Clause
-  size: 136740
-  timestamp: 1736230986583
+  size: 138907
+  timestamp: 1753325189144
 - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-console-bridge-vendor-1.4.1-np126py311h2c3b307_7.conda
   sha256: b07b322e7989bf18e6620b1f7f7d264879b278a72f55932cdf237aa411314925
   md5: ee1ebfe510641ab2d581b3aceb17bcd9
@@ -46719,27 +46357,27 @@ packages:
   license: BSD-3-Clause
   size: 25029
   timestamp: 1736207520858
-- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-console-bridge-vendor-1.4.1-np126py311h7d8ee0e_8.conda
-  sha256: c36c1541d69670b52cf0e1139163b1054748376798a351948a8e636bc36ba12e
-  md5: 0a4767cce0b5dc8365b640f5fedf22c8
+- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-console-bridge-vendor-1.4.1-np126py311hd5de103_13.conda
+  sha256: 0940de9ab8d4c4e03dea3577e4a1939b677a94c16697904b6a15882f635e273b
+  md5: d017e3a7d9e9ab37c2476aec344d7959
   depends:
   - console_bridge
   - python
   - ros-humble-ros-workspace
-  - ros2-distro-mutex 0.6.* humble_*
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - ros2-distro-mutex 0.7.* humble_*
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - numpy >=1.26.4,<2.0a0
-  - ros2-distro-mutex >=0.6.0,<0.7.0a0
   - python_abi 3.11.* *_cp311
   - console_bridge >=1.0.2,<1.1.0a0
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
+  - numpy >=1.26.4,<2.0a0
   license: BSD-3-Clause
-  size: 21709
-  timestamp: 1736226865905
+  size: 23083
+  timestamp: 1753318860213
 - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-control-msgs-4.7.0-np126py311h2c3b307_7.conda
   sha256: e2065714250ee20e79b153b5453409c4027a50770e16aabb377d53fb5df50d3c
   md5: 8057b35aed0fd0d762013c4bfb04cb1c
@@ -46830,9 +46468,9 @@ packages:
   license: BSD-3-Clause
   size: 546084
   timestamp: 1736209042167
-- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-control-msgs-4.7.0-np126py311h7d8ee0e_8.conda
-  sha256: ea8bbbb89ececbb7d20e35d09a842db942a9128267d011d75fe52b61136aef79
-  md5: 1691728c4e8d5ffe75ff1dcb594031fc
+- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-control-msgs-4.8.0-np126py311hd5de103_13.conda
+  sha256: 977281e7503be46668cab4734ceb658932a5fd723280965203dffee28c21d5c8
+  md5: 100438a14c3871f234a1d30f6f4adbc0
   depends:
   - python
   - ros-humble-action-msgs
@@ -46843,19 +46481,19 @@ packages:
   - ros-humble-sensor-msgs
   - ros-humble-std-msgs
   - ros-humble-trajectory-msgs
-  - ros2-distro-mutex 0.6.* humble_*
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - ros2-distro-mutex 0.7.* humble_*
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - python_abi 3.11.* *_cp311
   - numpy >=1.26.4,<2.0a0
-  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
+  - python_abi 3.11.* *_cp311
   license: BSD-3-Clause
-  size: 570557
-  timestamp: 1736231879183
+  size: 569627
+  timestamp: 1753328080129
 - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-controller-interface-2.47.0-np126py311h2c3b307_7.conda
   sha256: cebd0aa766f6ba60663998a28f4eeca98ae29b9aefc527d8d920e3b1184d8a0c
   md5: 9f7ec595f020a37084b30686efcb4705
@@ -46930,28 +46568,28 @@ packages:
   license: BSD-3-Clause
   size: 53918
   timestamp: 1736210555752
-- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-controller-interface-2.47.0-np126py311h7d8ee0e_8.conda
-  sha256: 435781aa08239865bb30b7898b0ee84c09f3c8069fe1a535a25295518b1af9d8
-  md5: 114c3667b91af197b488eb916d76e4d2
+- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-controller-interface-2.51.0-np126py311hd5de103_13.conda
+  sha256: 3c1894c8fbadec112d0ef01411ab4e02ed7830b75d919155e90d12c61c650a39
+  md5: 7343cd9ce8c828a2e5d216ec7c137467
   depends:
   - python
   - ros-humble-hardware-interface
   - ros-humble-rclcpp-lifecycle
   - ros-humble-ros-workspace
   - ros-humble-sensor-msgs
-  - ros2-distro-mutex 0.6.* humble_*
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - ros2-distro-mutex 0.7.* humble_*
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - numpy >=1.26.4,<2.0a0
   - python_abi 3.11.* *_cp311
-  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
+  - numpy >=1.26.4,<2.0a0
   license: BSD-3-Clause
-  size: 57827
-  timestamp: 1736235205017
+  size: 57225
+  timestamp: 1753334714094
 - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-controller-manager-2.47.0-np126py311h2c3b307_7.conda
   sha256: 3a2c0778e1575126fade1cc6b15403e9a13ff68c269e9ae629142acdbb5db4d7
   md5: 07e5e173786c9101ae7e546114116b6b
@@ -47075,9 +46713,9 @@ packages:
   license: BSD-3-Clause
   size: 379962
   timestamp: 1736211216281
-- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-controller-manager-2.47.0-np126py311h7d8ee0e_8.conda
-  sha256: d6a968dfe5acee493eb60352a1cdf4df8e5cf686fd804781e97444d11b46c52b
-  md5: 5b323d89f5c06ed92f3b56f0a33cd8e2
+- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-controller-manager-2.51.0-np126py311hd5de103_13.conda
+  sha256: 847944bf56117164aff3561cbe45e74b3b97ff70281b6c379e2387e1021ecf40
+  md5: a2666b54a8c357d707cc3cf2c3b4d6fd
   depends:
   - python
   - ros-humble-ament-index-cpp
@@ -47096,19 +46734,19 @@ packages:
   - ros-humble-ros2param
   - ros-humble-ros2run
   - ros-humble-std-msgs
-  - ros2-distro-mutex 0.6.* humble_*
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - ros2-distro-mutex 0.7.* humble_*
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - python_abi 3.11.* *_cp311
   - numpy >=1.26.4,<2.0a0
-  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
+  - python_abi 3.11.* *_cp311
   license: BSD-3-Clause
-  size: 316813
-  timestamp: 1736236665651
+  size: 327931
+  timestamp: 1753338008498
 - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-controller-manager-msgs-2.47.0-np126py311h2c3b307_7.conda
   sha256: f41a7ea2a6a2175f399005ee6759f248b484d648d305a1cbf7be9884022c78b0
   md5: 88aa6e9ed844f179ebb1b216369f43f8
@@ -47184,28 +46822,28 @@ packages:
   license: BSD-3-Clause
   size: 253468
   timestamp: 1736208559414
-- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-controller-manager-msgs-2.47.0-np126py311h7d8ee0e_8.conda
-  sha256: e283f6e6fbf5a1ca5698db7f7a6c3f7ab95f6a5eb3dd9c2dc4a750e4fbd448ab
-  md5: 09338060c46bd1f18d1cae6a2448478f
+- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-controller-manager-msgs-2.51.0-np126py311hd5de103_13.conda
+  sha256: 46b1541e43d761813748228e2bf25918f50d7caff8e0b71fc5219c77083ea4cd
+  md5: 96daa166e7bdcfe4a6f8e557f5117341
   depends:
   - python
   - ros-humble-builtin-interfaces
   - ros-humble-lifecycle-msgs
   - ros-humble-ros-workspace
   - ros-humble-rosidl-default-runtime
-  - ros2-distro-mutex 0.6.* humble_*
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - ros2-distro-mutex 0.7.* humble_*
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - ros2-distro-mutex >=0.6.0,<0.7.0a0
   - python_abi 3.11.* *_cp311
   - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
   license: BSD-3-Clause
-  size: 261013
-  timestamp: 1736230489398
+  size: 263546
+  timestamp: 1753324540652
 - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-cyclonedds-0.10.5-np126py311h2c3b307_7.conda
   sha256: dea06c33ee49a50cee3864c7c5f3b16315fd5ad1f1dfe11ed791d2860dbe7ec3
   md5: 78e1a3671b5ae1a9c497bd2d0be9c328
@@ -47289,9 +46927,9 @@ packages:
   license: BSD-3-Clause
   size: 1057936
   timestamp: 1736206365039
-- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-cyclonedds-0.10.5-np126py311h7d8ee0e_8.conda
-  sha256: 51e99a6509521b76bac95bc442e6a8b7be89a97d5a7db2a40117f549d094a4c6
-  md5: 4dff2d58bb182d62df04e3cb5c9831d4
+- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-cyclonedds-0.10.5-np126py311hd5de103_13.conda
+  sha256: 8e3471137d6adb34c102441ee80a74d5e24705471d329b83c237867d6b27ad88
+  md5: eb2993288c968a370cf8eff73f87329b
   depends:
   - openssl
   - python
@@ -47299,20 +46937,20 @@ packages:
   - ros-humble-iceoryx-hoofs
   - ros-humble-iceoryx-posh
   - ros-humble-ros-workspace
-  - ros2-distro-mutex 0.6.* humble_*
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - ros2-distro-mutex 0.7.* humble_*
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - openssl >=3.4.0,<4.0a0
-  - numpy >=1.26.4,<2.0a0
-  - ros2-distro-mutex >=0.6.0,<0.7.0a0
   - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
+  - numpy >=1.26.4,<2.0a0
+  - openssl >=3.5.1,<4.0a0
   license: BSD-3-Clause
-  size: 1090723
-  timestamp: 1736207252950
+  size: 1080300
+  timestamp: 1753310855102
 - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-diagnostic-msgs-4.2.4-np126py311h2c3b307_7.conda
   sha256: 5e321107092de710d4aed553f2f7a9247043398564cc85dd3f3152e4ea488f21
   md5: b5ef8b6a73455eb1f41227f3d663275d
@@ -47392,9 +47030,9 @@ packages:
   license: BSD-3-Clause
   size: 128238
   timestamp: 1736208823253
-- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-diagnostic-msgs-4.2.4-np126py311h7d8ee0e_8.conda
-  sha256: 10a43e863e58f9d1581e8cdca9c2e911a2c6b8fea61035fdd284e5016f9621d0
-  md5: 59760c4f4dea4fa13c94b029b23ad39f
+- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-diagnostic-msgs-4.9.0-np126py311hd5de103_13.conda
+  sha256: cc0d20d5ab2c0405c52161ba90ba218af69d750ff71737a06d9bf0859034efee
+  md5: f9fd3917cef9cf96a71d7809163c1c7e
   depends:
   - python
   - ros-humble-builtin-interfaces
@@ -47402,19 +47040,19 @@ packages:
   - ros-humble-ros-workspace
   - ros-humble-rosidl-default-runtime
   - ros-humble-std-msgs
-  - ros2-distro-mutex 0.6.* humble_*
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - ros2-distro-mutex 0.7.* humble_*
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - numpy >=1.26.4,<2.0a0
   - python_abi 3.11.* *_cp311
-  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
+  - numpy >=1.26.4,<2.0a0
   license: BSD-3-Clause
-  size: 139334
-  timestamp: 1736231285860
+  size: 141218
+  timestamp: 1753326265950
 - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-domain-coordinator-0.10.0-np126py311h2c3b307_7.conda
   sha256: 8b1fb60edca06f7a4d6319391df40ae6ce0fde4325337c2a8c654a1014653e1e
   md5: e2753ddd9c03cea55d3ebffd1452d2d8
@@ -47477,25 +47115,25 @@ packages:
   license: BSD-3-Clause
   size: 20084
   timestamp: 1736206348440
-- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-domain-coordinator-0.10.0-np126py311h7d8ee0e_8.conda
-  sha256: 90143c85e852113e72952ab013650a7cd3670cb8ffa3f0df0dabb9c54425ab80
-  md5: 41a08e03498566594576781f05a2a80d
+- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-domain-coordinator-0.10.0-np126py311hd5de103_13.conda
+  sha256: c22c3921ace4a60d2ab2efa598c71625316b68cc9eb660a56bf29ec7d8e98917
+  md5: f5fc0dee43393873f3d4d3c1a881a58c
   depends:
   - python
   - ros-humble-ros-workspace
-  - ros2-distro-mutex 0.6.* humble_*
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - ros2-distro-mutex 0.7.* humble_*
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - numpy >=1.26.4,<2.0a0
-  - ros2-distro-mutex >=0.6.0,<0.7.0a0
   - python_abi 3.11.* *_cp311
+  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
   license: BSD-3-Clause
-  size: 17060
-  timestamp: 1736207505208
+  size: 17464
+  timestamp: 1753312127526
 - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-eigen-stl-containers-1.0.0-np126py311h2c3b307_7.conda
   sha256: ff51d8e5e1d64eb7a0688e6c344db233702641e115c9705f5c40b700e9ee2533
   md5: 72c2b2d8ebc25ccb0838f0a026ce1d54
@@ -47562,26 +47200,26 @@ packages:
   license: BSD-3-Clause
   size: 22888
   timestamp: 1736206509234
-- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-eigen-stl-containers-1.0.0-np126py311h7d8ee0e_8.conda
-  sha256: fc37b6b347a426a10b23ebfde5089996c05df36f71195f56ef588c8084c49817
-  md5: 88248163ad49af1cd3c6c863ff301427
+- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-eigen-stl-containers-1.1.0-np126py311hd5de103_13.conda
+  sha256: bd002d8d97017b546b092939b910f0153357f6b126ad1ab4d166035a024e2084
+  md5: 1b89dc24edeb7c550f5ddd6821acd6b7
   depends:
   - eigen
   - python
   - ros-humble-ros-workspace
-  - ros2-distro-mutex 0.6.* humble_*
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - ros2-distro-mutex 0.7.* humble_*
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - ros2-distro-mutex >=0.6.0,<0.7.0a0
   - numpy >=1.26.4,<2.0a0
   - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
   license: BSD-3-Clause
-  size: 19677
-  timestamp: 1736208156813
+  size: 23205
+  timestamp: 1753313047037
 - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-eigen3-cmake-module-0.1.1-np126py311h2c3b307_7.conda
   sha256: 3c7e72f4d291050a517134afb2027fb4c33ff08eda40560bb170502e609e62dc
   md5: 1e600abdbb322a07723876b96027575b
@@ -47645,25 +47283,25 @@ packages:
   license: BSD-3-Clause
   size: 22252
   timestamp: 1736206860266
-- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-eigen3-cmake-module-0.1.1-np126py311h7d8ee0e_8.conda
-  sha256: 40f6446d5b1ebd66763c77ff4672f29a4a7f2d63b078397cb44354e353dadf5a
-  md5: 23cf8dcef6c6ba698a1bc7a60cbb9047
+- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-eigen3-cmake-module-0.1.1-np126py311hd5de103_13.conda
+  sha256: 1de8a8de2c539df4a41531514e33b6fd6a07429731aeedd35c086a322f321bb3
+  md5: cb051696679dfb7e784cd69ba24dc887
   depends:
   - python
   - ros-humble-ros-workspace
-  - ros2-distro-mutex 0.6.* humble_*
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - ros2-distro-mutex 0.7.* humble_*
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - ros2-distro-mutex >=0.6.0,<0.7.0a0
-  - python_abi 3.11.* *_cp311
   - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
   license: BSD-3-Clause
-  size: 19008
-  timestamp: 1736208829967
+  size: 20120
+  timestamp: 1753315281985
 - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-fastcdr-1.0.24-np126py311h2c3b307_7.conda
   sha256: 9ce292efa7fd3bcfa46588ffd97bf10eaab68868dd26343c4e8d733e542320ee
   md5: 64e89087daf71b4ba149c9d36d2e0956
@@ -47727,25 +47365,25 @@ packages:
   license: BSD-3-Clause
   size: 57441
   timestamp: 1736205455774
-- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-fastcdr-1.0.24-np126py311h7d8ee0e_8.conda
-  sha256: 5b048e04074cbe7e8f2f1a64834f6a652c4ba4c87ce6900fc691a17895affcf1
-  md5: c580c490e3fe86bc642ae64b0f76ea2e
+- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-fastcdr-1.0.24-np126py311hd5de103_13.conda
+  sha256: 948c23dc48dd99e944173e96b15918f62980716abcc414d45c597af10104d1df
+  md5: a39224903a76da3d3ddae7571b499923
   depends:
   - python
   - ros-humble-ros-workspace
-  - ros2-distro-mutex 0.6.* humble_*
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - ros2-distro-mutex 0.7.* humble_*
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - python_abi 3.11.* *_cp311
   - numpy >=1.26.4,<2.0a0
-  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
   license: BSD-3-Clause
-  size: 75108
-  timestamp: 1736205689124
+  size: 76739
+  timestamp: 1753308508705
 - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-fastrtps-2.6.9-np126py311h2c3b307_7.conda
   sha256: ab27ecedbb6daa3a9279dd4a3f30c4232b1e9f6d362c000e52f71816aed7ad3d
   md5: a84e4173c3c42bfa39e0fdfd8930db45
@@ -47834,31 +47472,31 @@ packages:
   license: BSD-3-Clause
   size: 2524357
   timestamp: 1736207254529
-- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-fastrtps-2.6.9-np126py311h7d8ee0e_8.conda
-  sha256: 88a4abee6ce09405250ff05c49564f6d823efad9dc0082e963805a222d9763cf
-  md5: 33b30cc8759e9a978a4ab966717a7db3
+- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-fastrtps-2.6.10-np126py311hd5de103_13.conda
+  sha256: a09f749ffa93ff2223543092d8f5c2f67c9cc3d36aecefc693ca1fda42f1cf9a
+  md5: 8dd3a16363a63855a8b109e7478e54dd
   depends:
   - openssl
   - python
   - ros-humble-fastcdr
   - ros-humble-foonathan-memory-vendor
   - ros-humble-ros-workspace
-  - ros2-distro-mutex 0.6.* humble_*
+  - ros2-distro-mutex 0.7.* humble_*
   - tinyxml2
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - tinyxml2 >=10.0.0,<11.0a0
-  - numpy >=1.26.4,<2.0a0
-  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
   - python_abi 3.11.* *_cp311
-  - openssl >=3.4.0,<4.0a0
+  - tinyxml2 >=11.0.0,<11.1.0a0
+  - openssl >=3.5.1,<4.0a0
+  - numpy >=1.26.4,<2.0a0
   license: BSD-3-Clause
-  size: 2757184
-  timestamp: 1736226346471
+  size: 2805787
+  timestamp: 1753317884716
 - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-fastrtps-cmake-module-2.2.2-np126py311h2c3b307_7.conda
   sha256: f33b599bb53ae0213dd9d54a91cb58f0c67cea4170d9912c4260272ca8d63554
   md5: 6ab94c87b6d06d78b76fdc99cc538379
@@ -47922,25 +47560,25 @@ packages:
   license: BSD-3-Clause
   size: 25343
   timestamp: 1736207243255
-- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-fastrtps-cmake-module-2.2.2-np126py311h7d8ee0e_8.conda
-  sha256: d724adbfd8d2d24958a596ba393e4f4978a1df3dabe7b53a37be7b05e347c64b
-  md5: c428df1ba4eca3ac79509905a7c714da
+- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-fastrtps-cmake-module-2.2.2-np126py311hd5de103_13.conda
+  sha256: 02c65336766634b364ef00a33112fafcc02b8fa337aa63087aa8cf0e225a28a4
+  md5: 32c1d2488a1ebf97c021be21cfde0421
   depends:
   - python
   - ros-humble-ros-workspace
-  - ros2-distro-mutex 0.6.* humble_*
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - ros2-distro-mutex 0.7.* humble_*
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - numpy >=1.26.4,<2.0a0
-  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
   - python_abi 3.11.* *_cp311
+  - numpy >=1.26.4,<2.0a0
   license: BSD-3-Clause
-  size: 21967
-  timestamp: 1736226516073
+  size: 23332
+  timestamp: 1753317820679
 - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-foonathan-memory-vendor-1.2.0-np126py311h2c3b307_7.conda
   sha256: dc0c9b825ec3ef343657c88bfcdb2113973ffac58cc3424eee2cef22b17596fb
   md5: 009e93a727744a6c53f718fe8b318804
@@ -48016,135 +47654,28 @@ packages:
   license: BSD-3-Clause
   size: 18588
   timestamp: 1736206928835
-- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-foonathan-memory-vendor-1.2.0-np126py311h7d8ee0e_8.conda
-  sha256: 6011e66fd5b69c0ffd5508ece7c3b6c3d500c69d38ed4dcd5e1d741ecdb8d4e4
-  md5: 92971787774128600df1b759dcdc2448
+- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-foonathan-memory-vendor-1.2.0-np126py311hd5de103_13.conda
+  sha256: 3f162f403113afa54214718618a28b28354064166f91af3dbf2b94485e043378
+  md5: bfcd974cf05625ecce3fa3d41a732a62
   depends:
-  - cmake
   - foonathan-memory
   - python
   - ros-humble-ros-workspace
-  - ros2-distro-mutex 0.6.* humble_*
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - ros2-distro-mutex 0.7.* humble_*
+  - cmake
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
   - numpy >=1.26.4,<2.0a0
   - foonathan-memory >=0.7.3,<0.7.4.0a0
-  - python_abi 3.11.* *_cp311
-  - ros2-distro-mutex >=0.6.0,<0.7.0a0
   license: BSD-3-Clause
-  size: 16225
-  timestamp: 1736209078152
-- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-gazebo-msgs-3.7.0-np126py311h2c3b307_7.conda
-  sha256: 2539d37bbdba2d15f1a77f2bd8d40c8d463bd1979da903d77803fdba67c26f87
-  md5: 2932b7aba42253266a29fbd840e5f36f
-  depends:
-  - python
-  - ros-humble-builtin-interfaces
-  - ros-humble-geometry-msgs
-  - ros-humble-ros-workspace
-  - ros-humble-rosidl-default-runtime
-  - ros-humble-std-msgs
-  - ros-humble-trajectory-msgs
-  - ros2-distro-mutex 0.6.* humble_*
-  - libgcc >=14
-  - __glibc >=2.17,<3.0.a0
-  - libstdcxx >=14
-  - libgcc >=14
-  - ros2-distro-mutex >=0.6.0,<0.7.0a0
-  - numpy >=1.26.4,<2.0a0
-  - python_abi 3.11.* *_cp311
-  license: BSD-3-Clause
-  size: 735412
-  timestamp: 1736209658028
-- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-gazebo-msgs-3.7.0-np126py311h65a17ee_5.conda
-  sha256: c9fbe22ae823f681af08c8c9054104252a59ee3d067e8afe302b995c392df649
-  md5: 240f8a17434f44df4687b5d399c8ece3
-  depends:
-  - python
-  - ros-humble-builtin-interfaces
-  - ros-humble-geometry-msgs
-  - ros-humble-ros-workspace
-  - ros-humble-rosidl-default-runtime
-  - ros-humble-std-msgs
-  - ros-humble-trajectory-msgs
-  - ros2-distro-mutex 0.6.* humble_*
-  - libstdcxx >=14
-  - libgcc >=14
-  - ros2-distro-mutex >=0.6.0,<0.7.0a0
-  - numpy >=1.26.4,<2.0a0
-  - python_abi 3.11.* *_cp311
-  license: BSD-3-Clause
-  size: 771738
-  timestamp: 1736212379204
-- conda: https://conda.anaconda.org/robostack-humble/osx-64/ros-humble-gazebo-msgs-3.7.0-np126py311h8a2294f_7.conda
-  sha256: 5c7349c3e9ded2266efa1c2f063e8031afc9256ad0cb9e82cdb34b31037c15f7
-  md5: ee14f034ae4f0a81f65d36959840a0af
-  depends:
-  - python
-  - ros-humble-builtin-interfaces
-  - ros-humble-geometry-msgs
-  - ros-humble-ros-workspace
-  - ros-humble-rosidl-default-runtime
-  - ros-humble-std-msgs
-  - ros-humble-trajectory-msgs
-  - ros2-distro-mutex 0.6.* humble_*
-  - __osx >=10.14
-  - libcxx >=19
-  - __osx >=10.14
-  - numpy >=1.26.4,<2.0a0
-  - python_abi 3.11.* *_cp311
-  - ros2-distro-mutex >=0.6.0,<0.7.0a0
-  license: BSD-3-Clause
-  size: 611174
-  timestamp: 1736213136936
-- conda: https://conda.anaconda.org/robostack-humble/osx-arm64/ros-humble-gazebo-msgs-3.7.0-np126py311h38cf310_6.conda
-  sha256: 5776323c1976aa45bed9d771b6b53855892bcd368fc64d3925c200e65f0ca239
-  md5: 36ce92c3b7dca0173d75cfc0830b6fa5
-  depends:
-  - python
-  - ros-humble-builtin-interfaces
-  - ros-humble-geometry-msgs
-  - ros-humble-ros-workspace
-  - ros-humble-rosidl-default-runtime
-  - ros-humble-std-msgs
-  - ros-humble-trajectory-msgs
-  - ros2-distro-mutex 0.6.* humble_*
-  - libcxx >=19
-  - __osx >=11.0
-  - numpy >=1.26.4,<2.0a0
-  - python_abi 3.11.* *_cp311
-  - ros2-distro-mutex >=0.6.0,<0.7.0a0
-  license: BSD-3-Clause
-  size: 588163
-  timestamp: 1736208983802
-- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-gazebo-msgs-3.7.0-np126py311h7d8ee0e_8.conda
-  sha256: 3abb22dfa09f66eab72ac3f13c306e942ff51a2f96b21e2658985529b16695e8
-  md5: c8ac451996935ebb39f1db2a9d639ec6
-  depends:
-  - python
-  - ros-humble-builtin-interfaces
-  - ros-humble-geometry-msgs
-  - ros-humble-ros-workspace
-  - ros-humble-rosidl-default-runtime
-  - ros-humble-std-msgs
-  - ros-humble-trajectory-msgs
-  - ros2-distro-mutex 0.6.* humble_*
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  - ucrt >=10.0.20348.0
-  - numpy >=1.26.4,<2.0a0
-  - ros2-distro-mutex >=0.6.0,<0.7.0a0
-  - python_abi 3.11.* *_cp311
-  license: BSD-3-Clause
-  size: 600372
-  timestamp: 1736231871926
+  size: 16712
+  timestamp: 1753315711328
 - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-generate-parameter-library-0.3.9-np126py311h2c3b307_7.conda
   sha256: 5331034634fd7b609048f6b72c45554bac5c7c6f292fd0059e7855c0f0a362c7
   md5: ac0edf5a6d6ac57256b5d17a62116e62
@@ -48249,9 +47780,9 @@ packages:
   license: BSD-3-Clause
   size: 40196
   timestamp: 1736210618469
-- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-generate-parameter-library-0.3.9-np126py311h7d8ee0e_8.conda
-  sha256: 264766da43b4b56dbddf41d4ef5b48c9dae6326eab43dd9ca9bbadb1a9a10767
-  md5: cbe2c1117c38a749a925af8deb18987d
+- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-generate-parameter-library-0.5.0-np126py311hd5de103_13.conda
+  sha256: b9221f92edbce2ac8cfc34f003a9293a6c3ec16f7fc89e4b69440fec8913ceb9
+  md5: 8dc1f933196a74422889f90e9b394552
   depends:
   - fmt
   - python
@@ -48264,20 +47795,20 @@ packages:
   - ros-humble-rsl
   - ros-humble-tcb-span
   - ros-humble-tl-expected
-  - ros2-distro-mutex 0.6.* humble_*
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - ros2-distro-mutex 0.7.* humble_*
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - numpy >=1.26.4,<2.0a0
-  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
+  - fmt >=11.2.0,<11.3.0a0
   - python_abi 3.11.* *_cp311
-  - fmt >=11.0.2,<12.0a0
+  - numpy >=1.26.4,<2.0a0
   license: BSD-3-Clause
-  size: 39488
-  timestamp: 1736235421791
+  size: 41436
+  timestamp: 1753334519274
 - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-generate-parameter-library-py-0.3.9-np126py311h2c3b307_7.conda
   sha256: 7418591c6ecc10fc9fcd7069dfc4dc222c7b30b16a5228c23342ab7d140011c1
   md5: 51566b31515a5dd67b84a01b777815b2
@@ -48353,28 +47884,28 @@ packages:
   license: BSD-3-Clause
   size: 71024
   timestamp: 1736206398845
-- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-generate-parameter-library-py-0.3.9-np126py311h7d8ee0e_8.conda
-  sha256: 88cd45bfa727962cd4865b290de24dfd22a048ad17cd04b246868a1973e6c9fc
-  md5: 5453f256f58baff52a98a0616ba06ee6
+- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-generate-parameter-library-py-0.5.0-np126py311hd5de103_13.conda
+  sha256: 0b71b50b619946cf70ab448f47cd5d0bb7dca80872918613890dceac419867b9
+  md5: 25ce3ce565a30a3c8c5a2d819b08d62f
   depends:
   - jinja2
   - python
   - pyyaml
   - ros-humble-ros-workspace
-  - ros2-distro-mutex 0.6.* humble_*
+  - ros2-distro-mutex 0.7.* humble_*
   - typeguard
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
   - numpy >=1.26.4,<2.0a0
-  - ros2-distro-mutex >=0.6.0,<0.7.0a0
   - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
   license: BSD-3-Clause
-  size: 75239
-  timestamp: 1736207570916
+  size: 76496
+  timestamp: 1753312185913
 - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-geometric-shapes-2.3.1-np126py311h2c3b307_7.conda
   sha256: 8ec16d5e5a19e1a2b1dac5cce8dac49e33bdab3bd5fa4383ec251c75a1f4ae23
   md5: 5dcec734708549c2d390ffaf1dc83979
@@ -48518,9 +48049,9 @@ packages:
   license: BSD-3-Clause
   size: 158789
   timestamp: 1736209663161
-- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-geometric-shapes-2.3.1-np126py311h7d8ee0e_8.conda
-  sha256: 6b21073e15a7a3985ff8011f7c4c8509a8fa57df57eba5e5d33319af8432bc97
-  md5: b92ca098452d47cf8aea6e754ff9f142
+- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-geometric-shapes-2.3.2-np126py311hd5de103_13.conda
+  sha256: beb9a46fc9496900efa9e172bde10fc5f072550fe0db39ecce90d0dcd16d5cfc
+  md5: bbcd9ce0971b1ce7b0f160a8c6c83a52
   depends:
   - assimp
   - eigen
@@ -48539,24 +48070,24 @@ packages:
   - ros-humble-rosidl-default-runtime
   - ros-humble-shape-msgs
   - ros-humble-visualization-msgs
-  - ros2-distro-mutex 0.6.* humble_*
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - ros2-distro-mutex 0.7.* humble_*
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
   - octomap >=1.10.0,<1.11.0a0
-  - python_abi 3.11.* *_cp311
-  - assimp >=5.4.3,<5.4.4.0a0
-  - ros2-distro-mutex >=0.6.0,<0.7.0a0
   - qhull >=2020.2,<2020.3.0a0
-  - numpy >=1.26.4,<2.0a0
-  - libboost >=1.86.0,<1.87.0a0
   - fcl >=0.7.0,<0.8.0a0
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
+  - numpy >=1.26.4,<2.0a0
+  - assimp >=5.4.3,<5.4.4.0a0
+  - python_abi 3.11.* *_cp311
+  - libboost >=1.86.0,<1.87.0a0
   license: BSD-3-Clause
-  size: 211838
-  timestamp: 1736234192738
+  size: 207383
+  timestamp: 1753331934882
 - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-geometry-msgs-4.2.4-np126py311h2c3b307_7.conda
   sha256: 5c8e2795ce033322eb101ca70ba3f3f13013048e32c81eb9fc57ab19b5252be7
   md5: 03ed2e763e19685b4579019ed8c7b918
@@ -48628,27 +48159,27 @@ packages:
   license: BSD-3-Clause
   size: 262280
   timestamp: 1736208712026
-- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-geometry-msgs-4.2.4-np126py311h7d8ee0e_8.conda
-  sha256: 4ad795f412e4e8dd6c33d56773634434a83b7f7a3454e214fe5898909e342773
-  md5: 3b124394a6df49b37e76273dcfa31a4e
+- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-geometry-msgs-4.9.0-np126py311hd5de103_13.conda
+  sha256: 15676d587583827aac5f36a7f3bda5f7cc7324fdfb83ff2c5922612936798e1d
+  md5: e41bdd25df43765145b9a720818d5a82
   depends:
   - python
   - ros-humble-ros-workspace
   - ros-humble-rosidl-default-runtime
   - ros-humble-std-msgs
-  - ros2-distro-mutex 0.6.* humble_*
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - ros2-distro-mutex 0.7.* humble_*
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - numpy >=1.26.4,<2.0a0
   - python_abi 3.11.* *_cp311
-  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
+  - numpy >=1.26.4,<2.0a0
   license: BSD-3-Clause
-  size: 277425
-  timestamp: 1736231029042
+  size: 291672
+  timestamp: 1753325310886
 - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-geometry2-0.25.10-np126py311h2c3b307_7.conda
   sha256: 384532b59ca4347103dd01db9391c340b0df22c2ee71987e3f71109a6f33ebe7
   md5: 687ba2097131c3db7bf12866c6e1192f
@@ -48755,9 +48286,9 @@ packages:
   license: BSD-3-Clause
   size: 21157
   timestamp: 1736211269952
-- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-geometry2-0.25.10-np126py311h7d8ee0e_8.conda
-  sha256: a1ee11759f7fd948e6aeb28bf865b384438d3108946a1e105ba266d80fc0a22b
-  md5: eadbfc7358847af6b3255e2497861255
+- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-geometry2-0.25.14-np126py311hd5de103_13.conda
+  sha256: eced31846691608f6034c6dff1b032fcf7a4b81e3d80a411330d7e8dc17489db
+  md5: b4989e0cd22accda6a8ed38636665cc4
   depends:
   - python
   - ros-humble-ros-workspace
@@ -48772,19 +48303,19 @@ packages:
   - ros-humble-tf2-ros
   - ros-humble-tf2-sensor-msgs
   - ros-humble-tf2-tools
-  - ros2-distro-mutex 0.6.* humble_*
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - ros2-distro-mutex 0.7.* humble_*
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
   - numpy >=1.26.4,<2.0a0
   - python_abi 3.11.* *_cp311
-  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
   license: BSD-3-Clause
-  size: 17984
-  timestamp: 1736236752898
+  size: 19127
+  timestamp: 1753338228216
 - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-gmock-vendor-1.10.9006-np126py311h2c3b307_7.conda
   sha256: 6e745bfc64adde2254dbd03167be77b3b19e4997dbd81b817b73e16f63a5e57b
   md5: adbb4d01192a0586c5b1c6e5cef017e0
@@ -48853,26 +48384,26 @@ packages:
   license: BSD-3-Clause
   size: 113148
   timestamp: 1736205424626
-- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-gmock-vendor-1.10.9006-np126py311h7d8ee0e_8.conda
-  sha256: c27239310ab94c9a521bcc0a514bd7a054deff5603fb24b2b11153055fcee14f
-  md5: 44743e57a5fa278677893ff4b4f31673
+- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-gmock-vendor-1.10.9006-np126py311hd5de103_13.conda
+  sha256: 498d72419568c66d6ece3ae062270fc9e0b43435125d67b283ec214abd1a7f59
+  md5: ad97cd17b2008d3f6c441d4024c630de
   depends:
   - python
   - ros-humble-gtest-vendor
   - ros-humble-ros-workspace
-  - ros2-distro-mutex 0.6.* humble_*
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - ros2-distro-mutex 0.7.* humble_*
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - numpy >=1.26.4,<2.0a0
-  - ros2-distro-mutex >=0.6.0,<0.7.0a0
   - python_abi 3.11.* *_cp311
+  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
   license: BSD-3-Clause
-  size: 111103
-  timestamp: 1736206360794
+  size: 111574
+  timestamp: 1753309472060
 - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-graph-msgs-0.2.0-np126py311h2c3b307_7.conda
   sha256: 2a68f3a3b9a96c899cc6026c3226e49f149b884be4941462b8a258ef5cea0893
   md5: 9e317da8c1a8c2770364c041ddfef9a1
@@ -48948,28 +48479,28 @@ packages:
   license: BSD-3-Clause
   size: 86345
   timestamp: 1736208863418
-- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-graph-msgs-0.2.0-np126py311h7d8ee0e_8.conda
-  sha256: 929c39cd650df20bacedea87e29d41f54901021485c4678c44b2759f9bf56d48
-  md5: 6627b19815f890471f0382cb08e2aa2f
+- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-graph-msgs-0.2.0-np126py311hd5de103_13.conda
+  sha256: ad70be834d2bc01f2d2603f63e86d442343c83f7ba8628219fdfcb76ca9c8cc9
+  md5: 62d6a73982c6a373c0462144f410d125
   depends:
   - python
   - ros-humble-geometry-msgs
   - ros-humble-ros-workspace
   - ros-humble-rosidl-default-runtime
   - ros-humble-std-msgs
-  - ros2-distro-mutex 0.6.* humble_*
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - ros2-distro-mutex 0.7.* humble_*
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
   - python_abi 3.11.* *_cp311
   - numpy >=1.26.4,<2.0a0
-  - ros2-distro-mutex >=0.6.0,<0.7.0a0
   license: BSD-3-Clause
-  size: 96322
-  timestamp: 1736231594547
+  size: 97628
+  timestamp: 1753327399416
 - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-gtest-vendor-1.10.9006-np126py311h2c3b307_7.conda
   sha256: 2002ad1acf1b4aaf571f5eb356d96b40ac27ad6329f6cf8742f2561c17791428
   md5: eb25b0ccf69f820fbcf1dd59217950ff
@@ -49032,25 +48563,25 @@ packages:
   license: BSD-3-Clause
   size: 199514
   timestamp: 1736205227568
-- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-gtest-vendor-1.10.9006-np126py311h7d8ee0e_8.conda
-  sha256: 5a68d738f99111220b8ab451b09c89b3e01cc967a0f0afaa7a7828f534fd86c8
-  md5: 24c59f8e2af02304c13c9a8bf205b221
+- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-gtest-vendor-1.10.9006-np126py311hd5de103_13.conda
+  sha256: 49cf349d55028f4504317911f8ff2b60e4a7c56dc97093f046220a3d87dba143
+  md5: 9bb13dd8c7aa3a7bb17291dc84c98322
   depends:
   - python
   - ros-humble-ros-workspace
-  - ros2-distro-mutex 0.6.* humble_*
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - ros2-distro-mutex 0.7.* humble_*
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
   - numpy >=1.26.4,<2.0a0
-  - ros2-distro-mutex >=0.6.0,<0.7.0a0
   - python_abi 3.11.* *_cp311
   license: BSD-3-Clause
-  size: 197971
-  timestamp: 1736205716204
+  size: 198439
+  timestamp: 1753308448430
 - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-hardware-interface-2.47.0-np126py311h2c3b307_7.conda
   sha256: b5947e08cc38e1c733d56b4c4538981efaa441b1f25fda1b7056499eb977ea79
   md5: f21d5ba9e1c4a17ff2b47163a2797ed2
@@ -49141,9 +48672,9 @@ packages:
   license: BSD-3-Clause
   size: 230673
   timestamp: 1736210290606
-- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-hardware-interface-2.47.0-np126py311h7d8ee0e_8.conda
-  sha256: eca6aa8c89e2ee741b0736e2e779349c5dbc8f5c2cc78e63a287c13200df7acd
-  md5: 3b68067bfb5e81e2cc596bdc7085a076
+- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-hardware-interface-2.51.0-np126py311hd5de103_13.conda
+  sha256: 24ea95ee46eb358961054048a6172898bc425fce0791a86c2b05d0dcbf692a0f
+  md5: 4c62f9e668ca72f8a45debe2d5224663
   depends:
   - python
   - ros-humble-control-msgs
@@ -49154,19 +48685,19 @@ packages:
   - ros-humble-rcutils
   - ros-humble-ros-workspace
   - ros-humble-tinyxml2-vendor
-  - ros2-distro-mutex 0.6.* humble_*
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - ros2-distro-mutex 0.7.* humble_*
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - numpy >=1.26.4,<2.0a0
-  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
   - python_abi 3.11.* *_cp311
+  - numpy >=1.26.4,<2.0a0
   license: BSD-3-Clause
-  size: 217948
-  timestamp: 1736234711957
+  size: 222320
+  timestamp: 1753333449108
 - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-iceoryx-binding-c-2.0.5-np126py311h2c3b307_7.conda
   sha256: fa41746dcf44cd7be420d92f37349feee786d59ad94317ebda352c49ec1c91a0
   md5: 3e091d9261c88114e8956f86d7a005cc
@@ -49229,25 +48760,25 @@ packages:
   license: BSD-3-Clause
   size: 80874
   timestamp: 1736206312421
-- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-iceoryx-binding-c-2.0.5-np126py311h7d8ee0e_8.conda
-  sha256: 02485e99adb48141d7439bcc7d62f2439cb97e9dd2298af87a4fa34e1b5ddac9
-  md5: 006960c7d4080f55f01a0b2cae376142
+- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-iceoryx-binding-c-2.0.5-np126py311hd5de103_13.conda
+  sha256: fc26d3c9428019598cc562249ecd2037b44539a7a591fbe9e850857fefdb9d6d
+  md5: c3a72c8411af79452559e2bb89a5215b
   depends:
   - python
   - ros-humble-ros-workspace
-  - ros2-distro-mutex 0.6.* humble_*
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - ros2-distro-mutex 0.7.* humble_*
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
   - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
   - numpy >=1.26.4,<2.0a0
-  - ros2-distro-mutex >=0.6.0,<0.7.0a0
   license: BSD-3-Clause
-  size: 223934
-  timestamp: 1736206823593
+  size: 218308
+  timestamp: 1753310097738
 - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-iceoryx-hoofs-2.0.5-np126py311h2c3b307_7.conda
   sha256: fb294d9f14e1568cf929db2dafb28dca242b0dcc6ad955b12797b2d80e37f046
   md5: 9005953fc6a519ab808c0d846ed5bd19
@@ -49315,25 +48846,25 @@ packages:
   license: BSD-3-Clause
   size: 259326
   timestamp: 1736205463284
-- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-iceoryx-hoofs-2.0.5-np126py311h7d8ee0e_8.conda
-  sha256: 945d5ae5b02211ffc633f53ffef4b975fa584edc0d83578ee693aab6b29c4ce4
-  md5: 6de98683e18213ee75a3f2159302f0c9
+- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-iceoryx-hoofs-2.0.5-np126py311hd5de103_13.conda
+  sha256: a24825f5878d87147576618de3bddcbacb628afe2a68b56ec331ef64b365f657
+  md5: 1a1a3f30eb1cb06674748e43bd3acf26
   depends:
   - python
   - ros-humble-ros-workspace
-  - ros2-distro-mutex 0.6.* humble_*
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - ros2-distro-mutex 0.7.* humble_*
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
   - python_abi 3.11.* *_cp311
-  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - numpy >=1.26.4,<2.0a0
   license: BSD-3-Clause
-  size: 756508
-  timestamp: 1736205716167
+  size: 729897
+  timestamp: 1753308539200
 - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-iceoryx-posh-2.0.5-np126py311h2c3b307_7.conda
   sha256: 7890f0ef1007b02328fc65ff6c6b225b8692ae64bb1bd3a67c8004bce7fae862
   md5: 098bc41d1d9526de7350d5797ad245db
@@ -49401,26 +48932,26 @@ packages:
   license: BSD-3-Clause
   size: 437419
   timestamp: 1736206172120
-- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-iceoryx-posh-2.0.5-np126py311h7d8ee0e_8.conda
-  sha256: b274f34786182e714adeb006c7bc38ab919f0028e627a516efd4fe952b6dddb0
-  md5: 1d3872681b2bd6a2aec6f34cc398d2eb
+- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-iceoryx-posh-2.0.5-np126py311hd5de103_13.conda
+  sha256: e8785dd36d286f5d2714c87ca81d79e1147c3215a4f7844cc68264d5904336cb
+  md5: af0fd29c29ff6db3f453d14a0ef876d4
   depends:
   - python
   - ros-humble-iceoryx-hoofs
   - ros-humble-ros-workspace
-  - ros2-distro-mutex 0.6.* humble_*
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - ros2-distro-mutex 0.7.* humble_*
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
   - python_abi 3.11.* *_cp311
-  - ros2-distro-mutex >=0.6.0,<0.7.0a0
   - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
   license: BSD-3-Clause
-  size: 2174681
-  timestamp: 1736206380192
+  size: 2163996
+  timestamp: 1753309506390
 - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-ignition-cmake2-vendor-0.0.2-np126py311h2c3b307_7.conda
   sha256: 87e4c55ebed9c2833e71f001f6418dbfb3698f99375ae355755fd7c936021ce8
   md5: af96d5bab1c8b7a7e26b0e47231fbeab
@@ -49496,28 +49027,28 @@ packages:
   license: BSD-3-Clause
   size: 22871
   timestamp: 1736207193891
-- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-ignition-cmake2-vendor-0.0.2-np126py311h7d8ee0e_8.conda
-  sha256: f5cb5d707ff5badd140f64a47e3fe2df31620977978ff1a5cd9108cb601b64ef
-  md5: eddd2ebe2ac9f6f02e5ba6c64ed65a69
+- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-ignition-cmake2-vendor-0.0.2-np126py311h4715f36_13.conda
+  sha256: 53e5e3c8ff60ead128e38df9dc38608f0cbf3eacca263d12acc76f19d8b90c6f
+  md5: 8989e1169f066cc5f412b0435947f6d0
   depends:
   - libignition-cmake2
   - python
   - ros-humble-ros-workspace
-  - ros2-distro-mutex 0.6.* humble_*
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - ros2-distro-mutex 0.7.* humble_*
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - libignition-cmake2 >=2.17.2,<3.0a0
-  - numpy >=1.26.4,<2.0a0
-  - graphviz >=12.0.0,<13.0a0
-  - ros2-distro-mutex >=0.6.0,<0.7.0a0
   - python_abi 3.11.* *_cp311
+  - libignition-cmake2 >=2.17.2,<3.0a0
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
+  - graphviz >=12.2.1,<13.0a0
+  - numpy >=1.26.4,<2.0a0
   license: BSD-3-Clause
-  size: 20003
-  timestamp: 1736210261220
+  size: 20787
+  timestamp: 1753317212592
 - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-ignition-math6-vendor-0.0.2-np126py311h2c3b307_7.conda
   sha256: fb80366dbf9affa275ddd1ec5c5d83d83856746a9d28ea6d68d61343d5e6d48a
   md5: 764b99e49096a1639081bae5b23c75a6
@@ -49592,28 +49123,28 @@ packages:
   license: BSD-3-Clause
   size: 21522
   timestamp: 1736207244524
-- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-ignition-math6-vendor-0.0.2-np126py311h7d8ee0e_8.conda
-  sha256: d7678eb717d59829990f574d6d474ad78f03e7c7861f2d5a3841170b96f98b73
-  md5: fd5e9c903b1d9382050c37591e101e07
+- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-ignition-math6-vendor-0.0.2-np126py311hd5de103_13.conda
+  sha256: ec463cc2a4a0d91df966dded5717f69d54f3ab12d33f67592f3a2750c061c9e3
+  md5: 4ac64b247548bb01e5fdf7f5b4aa25b5
   depends:
   - libignition-math6
   - python
   - ros-humble-ignition-cmake2-vendor
   - ros-humble-ros-workspace
-  - ros2-distro-mutex 0.6.* humble_*
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - ros2-distro-mutex 0.7.* humble_*
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
   - libignition-math6 >=6.15.1,<7.0a0
   - python_abi 3.11.* *_cp311
-  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
   - numpy >=1.26.4,<2.0a0
   license: BSD-3-Clause
-  size: 20317
-  timestamp: 1736210556638
+  size: 21126
+  timestamp: 1753317837916
 - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-image-transport-3.1.10-np126py311h2c3b307_7.conda
   sha256: 9afd15b17faa8631c2d3250bb80d0bab9dd1bad59a926116cad44725a5118032
   md5: f49b17afe8b8b7bc7d4082dafc2d4744
@@ -49693,9 +49224,9 @@ packages:
   license: BSD-3-Clause
   size: 391118
   timestamp: 1736210620029
-- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-image-transport-3.1.10-np126py311h7d8ee0e_8.conda
-  sha256: de49dd6339b27208feb792b78ae44bf01778ab84c2aaddc0869d38591b40be20
-  md5: 0fd8c2304d304d23d233a8a0cfee1050
+- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-image-transport-3.1.12-np126py311hd5de103_13.conda
+  sha256: 1d42370d4dc266407c8f7e95012a216e2cbd41926d426b941bbc2a4483286a8e
+  md5: 8e84543b96cd3ebc6bd88fc77218d382
   depends:
   - python
   - ros-humble-message-filters
@@ -49703,19 +49234,19 @@ packages:
   - ros-humble-rclcpp
   - ros-humble-ros-workspace
   - ros-humble-sensor-msgs
-  - ros2-distro-mutex 0.6.* humble_*
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - ros2-distro-mutex 0.7.* humble_*
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - python_abi 3.11.* *_cp311
-  - ros2-distro-mutex >=0.6.0,<0.7.0a0
   - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
   license: BSD-3-Clause
-  size: 328926
-  timestamp: 1736235385024
+  size: 328118
+  timestamp: 1753334887585
 - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-interactive-markers-2.3.2-np126py311h2c3b307_7.conda
   sha256: f67305f3ba1dbd8bc42fa29df62f06fae7cf89d4bb7e94f26eeaae9432a8664c
   md5: 882ff76314900b20851d22d7f9f8557d
@@ -49806,9 +49337,9 @@ packages:
   license: BSD-3-Clause
   size: 251681
   timestamp: 1736211318454
-- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-interactive-markers-2.3.2-np126py311h7d8ee0e_8.conda
-  sha256: 5067d67a84d336071e7c57ba8a2ef93a832177b807ae1af73af9656918908c58
-  md5: cd9c54dc5fc3493f4d4a517991ff346b
+- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-interactive-markers-2.3.2-np126py311hd5de103_13.conda
+  sha256: 7b637c7bd232fd29c8b801c7b3da3e39620dd834a9c281a19b748b673069c934
+  md5: c598a39099cd785ef256825365db3b1e
   depends:
   - python
   - ros-humble-builtin-interfaces
@@ -49819,19 +49350,19 @@ packages:
   - ros-humble-tf2
   - ros-humble-tf2-geometry-msgs
   - ros-humble-visualization-msgs
-  - ros2-distro-mutex 0.6.* humble_*
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - ros2-distro-mutex 0.7.* humble_*
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
   - numpy >=1.26.4,<2.0a0
   - python_abi 3.11.* *_cp311
-  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
   license: BSD-3-Clause
-  size: 206461
-  timestamp: 1736236933720
+  size: 210357
+  timestamp: 1753337423740
 - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-kdl-parser-2.6.4-np126py311h2c3b307_7.conda
   sha256: 8ff2d51c7e29f1a9678e9260aa07145a41e39935293f71c9cad3328b2f83b659
   md5: c020caded3011ff328847f3809cca230
@@ -49911,9 +49442,9 @@ packages:
   license: BSD-3-Clause
   size: 45889
   timestamp: 1736208218922
-- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-kdl-parser-2.6.4-np126py311h7d8ee0e_8.conda
-  sha256: d0e0fa7a2a1688b40e12edd1aa6940018d61150835cc7792bc91b1f62eef4a2b
-  md5: d5ea8f5ca58dc9575a1266fb3d0fed26
+- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-kdl-parser-2.6.4-np126py311hd5de103_13.conda
+  sha256: a90fe12e892d048cdca9676d20da17236d6ce6428263bd9925c052a2b271309a
+  md5: 15e306d3a025c326d5b9987285fe748b
   depends:
   - python
   - ros-humble-orocos-kdl-vendor
@@ -49921,19 +49452,19 @@ packages:
   - ros-humble-ros-workspace
   - ros-humble-urdf
   - ros-humble-urdfdom-headers
-  - ros2-distro-mutex 0.6.* humble_*
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - ros2-distro-mutex 0.7.* humble_*
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - numpy >=1.26.4,<2.0a0
   - python_abi 3.11.* *_cp311
-  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
+  - numpy >=1.26.4,<2.0a0
   license: BSD-3-Clause
-  size: 54654
-  timestamp: 1736228768513
+  size: 56734
+  timestamp: 1753322147979
 - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-keyboard-handler-0.0.5-np126py311h2c3b307_7.conda
   sha256: ddb1d8c3c0b002e53d3b7fc90ca64241bb97ce005db5645cfeffba333fe50d4f
   md5: a15dbe2ba162e61f6dbf79089b4fff74
@@ -49997,25 +49528,25 @@ packages:
   license: BSD-3-Clause
   size: 54184
   timestamp: 1736207266968
-- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-keyboard-handler-0.0.5-np126py311h7d8ee0e_8.conda
-  sha256: 7f28c40bc336f7bf424fd917e5f6103b74dc1ef0488c9be5215f99c2aba98943
-  md5: 0526bbe2965b05cc656b33b70c77956c
+- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-keyboard-handler-0.0.5-np126py311hd5de103_13.conda
+  sha256: 34ab0a5acbc691cf9ef05ee4b3ec154de7b60b4bad9e7ff41dda53f864acafbf
+  md5: b1f1e90bf1ecf8774b4bd1a984a83847
   depends:
   - python
   - ros-humble-ros-workspace
-  - ros2-distro-mutex 0.6.* humble_*
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - ros2-distro-mutex 0.7.* humble_*
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - numpy >=1.26.4,<2.0a0
   - python_abi 3.11.* *_cp311
-  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
+  - numpy >=1.26.4,<2.0a0
   license: BSD-3-Clause
-  size: 50244
-  timestamp: 1736210635190
+  size: 52034
+  timestamp: 1753317950749
 - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-laser-geometry-2.4.0-np126py311h2c3b307_7.conda
   sha256: 16570ba41be209ec1d073abb7bd1c8ac22a5092981ad5d92fa6adef44b78a2ef
   md5: bf499b5a0f15e19e8d07a86054a62ebb
@@ -50110,9 +49641,9 @@ packages:
   license: BSD-3-Clause
   size: 54237
   timestamp: 1736209755007
-- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-laser-geometry-2.4.0-np126py311h7d8ee0e_8.conda
-  sha256: 1aabb9ffa88715d7047844a01b462cc44e7ba7e8d4b04a09436c4c65ac341898
-  md5: 867bf221711919246b05e7968e7178fc
+- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-laser-geometry-2.4.0-np126py311hd5de103_13.conda
+  sha256: ee68a6a6bebc975df5acdcaee0ee67a690a460c137f165e773c75a116f4802a4
+  md5: 0b2b17ec88201e9d85967b3eb1796d8c
   depends:
   - eigen
   - numpy
@@ -50124,19 +49655,19 @@ packages:
   - ros-humble-sensor-msgs
   - ros-humble-sensor-msgs-py
   - ros-humble-tf2
-  - ros2-distro-mutex 0.6.* humble_*
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - ros2-distro-mutex 0.7.* humble_*
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - python_abi 3.11.* *_cp311
-  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
   - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
   license: BSD-3-Clause
-  size: 56807
-  timestamp: 1736234138017
+  size: 56493
+  timestamp: 1753331435453
 - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-launch-1.0.7-np126py311h2c3b307_7.conda
   sha256: 46d0b6ef86bcfa5701cd15bf83ea708745db953bba0ae2c6a19cbff5e7ec080c
   md5: 361e826595ab7a9dcb4d57971ed77aef
@@ -50218,9 +49749,9 @@ packages:
   license: BSD-3-Clause
   size: 224540
   timestamp: 1736206648030
-- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-launch-1.0.7-np126py311h7d8ee0e_8.conda
-  sha256: 382b880960d36854736b767788204bd067e72b6baed1c8c7824358ed9c262623
-  md5: 2bff526abf8a2247bd48145095c71373
+- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-launch-1.0.9-np126py311hd5de103_13.conda
+  sha256: 1f88e9ea34debfd449111e110edcccf0a970e4a6708eff1b07d3e29847639e43
+  md5: 64655858c450cdf59c1208135072e4de
   depends:
   - importlib-metadata
   - lark-parser
@@ -50229,19 +49760,19 @@ packages:
   - ros-humble-ament-index-python
   - ros-humble-osrf-pycommon
   - ros-humble-ros-workspace
-  - ros2-distro-mutex 0.6.* humble_*
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - ros2-distro-mutex 0.7.* humble_*
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - ros2-distro-mutex >=0.6.0,<0.7.0a0
-  - numpy >=1.26.4,<2.0a0
   - python_abi 3.11.* *_cp311
+  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
   license: BSD-3-Clause
-  size: 220068
-  timestamp: 1736207981965
+  size: 227342
+  timestamp: 1753312821874
 - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-launch-param-builder-0.1.1-np126py311h2c3b307_7.conda
   sha256: cb371ed2e131714c85311f689a904efee0ca9e59209a175cdf2916a61bc989f9
   md5: 08aab70eca931a35e714cefae7422204
@@ -50320,9 +49851,9 @@ packages:
   license: BSD-3-Clause
   size: 26518
   timestamp: 1736209698084
-- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-launch-param-builder-0.1.1-np126py311h7d8ee0e_8.conda
-  sha256: 446d29732cecabe8bf523f90f207ba3ed5fd40a20e21118641a55e14df63ec7c
-  md5: 9f398d7fcf2dde959628ec2cb06b8080
+- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-launch-param-builder-0.1.1-np126py311hd5de103_13.conda
+  sha256: c8f87866d1d9fe4ab649f975872c75ea52dfda5512be1ad03c0883e2a6cc97b9
+  md5: 97900278348f5eb9d47c995c628acd86
   depends:
   - python
   - pyyaml
@@ -50330,19 +49861,19 @@ packages:
   - ros-humble-rclpy
   - ros-humble-ros-workspace
   - ros-humble-xacro
-  - ros2-distro-mutex 0.6.* humble_*
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - ros2-distro-mutex 0.7.* humble_*
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - ros2-distro-mutex >=0.6.0,<0.7.0a0
-  - python_abi 3.11.* *_cp311
   - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
   license: BSD-3-Clause
-  size: 22852
-  timestamp: 1736234308480
+  size: 23287
+  timestamp: 1753332141688
 - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-launch-ros-0.19.8-np126py311h2c3b307_7.conda
   sha256: 27065230af004e4d7d14ada51dd999234b4b7e9ee87be6f70e044c9f2e4b1ec6
   md5: 4699fb1043e7a0b5f77e80d29a9c32c0
@@ -50437,9 +49968,9 @@ packages:
   license: BSD-3-Clause
   size: 114508
   timestamp: 1736209616186
-- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-launch-ros-0.19.8-np126py311h7d8ee0e_8.conda
-  sha256: 260affb64ad964b5510c2cee8b1debbbd4158ea5ad8af74758d809a961cb0424
-  md5: fca5a86d9772f260d8eef067bfda783e
+- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-launch-ros-0.19.10-np126py311hd5de103_13.conda
+  sha256: 3241ce93f62a96ad4916eab9e7a78b3b5179e51a178e80410660b974fd220f59
+  md5: 459a97a2f608a15eb41fdd6fa9dbf50d
   depends:
   - importlib-metadata
   - python
@@ -50451,19 +49982,19 @@ packages:
   - ros-humble-osrf-pycommon
   - ros-humble-rclpy
   - ros-humble-ros-workspace
-  - ros2-distro-mutex 0.6.* humble_*
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - ros2-distro-mutex 0.7.* humble_*
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
   - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
   - python_abi 3.11.* *_cp311
-  - ros2-distro-mutex >=0.6.0,<0.7.0a0
   license: BSD-3-Clause
-  size: 110932
-  timestamp: 1736233969765
+  size: 111793
+  timestamp: 1753331185807
 - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-launch-testing-1.0.7-np126py311h2c3b307_7.conda
   sha256: ead8b0e478b6a8b4ad223de2fbf608bd5f23e7574c226d32de584677565cf59d
   md5: d2d7d34750ba222db776c6786d91e98b
@@ -50551,9 +50082,9 @@ packages:
   license: BSD-3-Clause
   size: 117472
   timestamp: 1736206853135
-- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-launch-testing-1.0.7-np126py311h7d8ee0e_8.conda
-  sha256: a1eaf1b68b71b0c53d3aea76ced638a55ebf1e03f0e9a96143ad0d2296274b14
-  md5: 4ea952c0e23d237171734d8773614090
+- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-launch-testing-1.0.9-np126py311hd5de103_13.conda
+  sha256: 237cf388cc22629a952a2dbb1a7ffa59b4e032b96240b3ea7cb379edd182c187
+  md5: cfb303f0d970b90f5493c065cbe00bd6
   depends:
   - pytest
   - python
@@ -50563,19 +50094,19 @@ packages:
   - ros-humble-launch-yaml
   - ros-humble-osrf-pycommon
   - ros-humble-ros-workspace
-  - ros2-distro-mutex 0.6.* humble_*
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - ros2-distro-mutex 0.7.* humble_*
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - python_abi 3.11.* *_cp311
   - numpy >=1.26.4,<2.0a0
-  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
   license: BSD-3-Clause
-  size: 121395
-  timestamp: 1736208803097
+  size: 121773
+  timestamp: 1753315218953
 - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-launch-testing-ament-cmake-1.0.7-np126py311h2c3b307_7.conda
   sha256: 1c04e2cc953cf784d33803c94c04f9d78072b4b841e6076e9874477e5e3aa593
   md5: bf667f8cdfc0821fa6b469414ecc9e17
@@ -50652,28 +50183,28 @@ packages:
   license: BSD-3-Clause
   size: 25688
   timestamp: 1736207485270
-- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-launch-testing-ament-cmake-1.0.7-np126py311h7d8ee0e_8.conda
-  sha256: 501685e20a638bc8d96276d31dd3196a70ee25c7e73ce075fe7880ce33457df6
-  md5: fa487c0ecfb96648445f4c658c4bf330
+- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-launch-testing-ament-cmake-1.0.9-np126py311hd5de103_13.conda
+  sha256: e44c0fe954926f83cc0a52b2c54c82c2ad866fc3bf7c0d78163fdd79a7731671
+  md5: 764857bcf89062bb93b13ef8e340ba5b
   depends:
   - python
   - ros-humble-ament-cmake-test
   - ros-humble-launch-testing
   - ros-humble-python-cmake-module
   - ros-humble-ros-workspace
-  - ros2-distro-mutex 0.6.* humble_*
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - ros2-distro-mutex 0.7.* humble_*
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - ros2-distro-mutex >=0.6.0,<0.7.0a0
   - numpy >=1.26.4,<2.0a0
   - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
   license: BSD-3-Clause
-  size: 22454
-  timestamp: 1736226349946
+  size: 23954
+  timestamp: 1753318682735
 - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-launch-testing-ros-0.19.8-np126py311h2c3b307_7.conda
   sha256: 43d719e0995cd2499c7ceae5bdb10032571b8bb3cac92f621bb99881ee26c6d8
   md5: 78e8623c1f28ddc113da2d625bb5a8c1
@@ -50749,28 +50280,28 @@ packages:
   license: BSD-3-Clause
   size: 49228
   timestamp: 1736210236549
-- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-launch-testing-ros-0.19.8-np126py311h7d8ee0e_8.conda
-  sha256: d8cd8e5d48ecca5af66541fcfb9c58e727fa9fe66f646f144c468f539c03392e
-  md5: d0c5c758ab78c3caa7c91a1be6d46556
+- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-launch-testing-ros-0.19.10-np126py311hd5de103_13.conda
+  sha256: 40b73a865dcd867736943214d847617d1f639bab9a3320a5ea74c30e7c0e89b2
+  md5: 00282d061de930e79b78b737727d0509
   depends:
   - python
   - ros-humble-launch-ros
   - ros-humble-launch-testing
   - ros-humble-rclpy
   - ros-humble-ros-workspace
-  - ros2-distro-mutex 0.6.* humble_*
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - ros2-distro-mutex 0.7.* humble_*
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
   - python_abi 3.11.* *_cp311
-  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
   - numpy >=1.26.4,<2.0a0
   license: BSD-3-Clause
-  size: 47027
-  timestamp: 1736234518123
+  size: 47583
+  timestamp: 1753332858969
 - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-launch-xml-1.0.7-np126py311h2c3b307_7.conda
   sha256: ad86b74d2750171a3f08d1a8a28799cc33ff68cf48096e74640d7fb519917c1b
   md5: 700df14b6e285c51ea4a22dc464f8c65
@@ -50837,26 +50368,26 @@ packages:
   license: BSD-3-Clause
   size: 25279
   timestamp: 1736206786052
-- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-launch-xml-1.0.7-np126py311h7d8ee0e_8.conda
-  sha256: 5f22500b0bb6039f1e8a4c412b3323d1eaedfeee5198296ec1ae340f37a54565
-  md5: 88f19c9eead1dd5574f5517acd3b4145
+- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-launch-xml-1.0.9-np126py311hd5de103_13.conda
+  sha256: 21a5aefafcb5f7fce5c1ee305191e14b0e5d6299e9a8bec68dda7d015ee86011
+  md5: 713f2ab984354d1e9dc93b15960e16eb
   depends:
   - python
   - ros-humble-launch
   - ros-humble-ros-workspace
-  - ros2-distro-mutex 0.6.* humble_*
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - ros2-distro-mutex 0.7.* humble_*
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - python_abi 3.11.* *_cp311
   - numpy >=1.26.4,<2.0a0
-  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
   license: BSD-3-Clause
-  size: 22050
-  timestamp: 1736208503047
+  size: 22611
+  timestamp: 1753314086635
 - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-launch-yaml-1.0.7-np126py311h2c3b307_7.conda
   sha256: 005bc5ec38eaf5b0d5b2c23527522e9db94f8dfceeb9f031090e49c2df06b9db
   md5: df2fca91466c34a67bcd404174edc9d7
@@ -50923,26 +50454,26 @@ packages:
   license: BSD-3-Clause
   size: 25930
   timestamp: 1736206778510
-- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-launch-yaml-1.0.7-np126py311h7d8ee0e_8.conda
-  sha256: 7f6f9d00223a5af4fc632aec685870f31bce8789c3f6f84fde0c8a2a0eb3997d
-  md5: c6a392b9166499c9f0dc3d1617620ff7
+- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-launch-yaml-1.0.9-np126py311hd5de103_13.conda
+  sha256: e2eb65bae8c9927438701631e54a131add13b1838672ac698efa2b3239d5fd29
+  md5: ad2b199ba10339abee6bb56c58911a64
   depends:
   - python
   - ros-humble-launch
   - ros-humble-ros-workspace
-  - ros2-distro-mutex 0.6.* humble_*
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - ros2-distro-mutex 0.7.* humble_*
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - numpy >=1.26.4,<2.0a0
-  - ros2-distro-mutex >=0.6.0,<0.7.0a0
   - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
+  - numpy >=1.26.4,<2.0a0
   license: BSD-3-Clause
-  size: 22643
-  timestamp: 1736208478012
+  size: 23201
+  timestamp: 1753314026196
 - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-libcurl-vendor-3.1.2-np126py311h2c3b307_7.conda
   sha256: f9d73d6d18924ec1bd1e125919e7b3cc8e8c9ad24d914966bd1bc7f41dc78a88
   md5: 41d80515765ff5a0480caa6b02ddbc81
@@ -51018,28 +50549,28 @@ packages:
   license: BSD-3-Clause
   size: 21995
   timestamp: 1736206442633
-- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-libcurl-vendor-3.1.2-np126py311h7d8ee0e_8.conda
-  sha256: 22a4f1206b5d7cd225dc144fd0242c4dd3e390d02664502668ba60c58eab9962
-  md5: a8e0d58057651227d10f144a10eb0669
+- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-libcurl-vendor-3.1.3-np126py311hd5de103_13.conda
+  sha256: c2b7e804f1f20b8bc100f3513da69298cc7437385433a2e5577c5c1496ea2fb4
+  md5: d387fc39a6362271abf274550a8d1a9f
   depends:
   - libcurl
   - pkg-config
   - python
   - ros-humble-ros-workspace
-  - ros2-distro-mutex 0.6.* humble_*
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - ros2-distro-mutex 0.7.* humble_*
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - libcurl >=8.11.1,<9.0a0
-  - numpy >=1.26.4,<2.0a0
+  - libcurl >=8.14.1,<9.0a0
   - python_abi 3.11.* *_cp311
-  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
+  - numpy >=1.26.4,<2.0a0
   license: BSD-3-Clause
-  size: 18591
-  timestamp: 1736207883372
+  size: 19770
+  timestamp: 1753312807031
 - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-libstatistics-collector-1.3.4-np126py311h2c3b307_7.conda
   sha256: e96c470373add551ea9673c0260446629f419429fca0ec94309a258ee07b08c6
   md5: a217de8feb508598958c9baa1586de9e
@@ -51126,9 +50657,9 @@ packages:
   license: BSD-3-Clause
   size: 52619
   timestamp: 1736209452584
-- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-libstatistics-collector-1.3.4-np126py311h7d8ee0e_8.conda
-  sha256: f3079be5981e2887c16feda69949c63bcee9d0b1e6a940faf181ca0725344a57
-  md5: 5d0320a7d752e6be76f8083bb29c7902
+- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-libstatistics-collector-1.3.4-np126py311hd5de103_13.conda
+  sha256: 17543c43fc68d2ee8c476db226d98a7c35ff2895b06765a78b050c82447ce496
+  md5: 244f21f171d06349607842112ed772bc
   depends:
   - python
   - ros-humble-builtin-interfaces
@@ -51138,19 +50669,19 @@ packages:
   - ros-humble-rosidl-default-runtime
   - ros-humble-statistics-msgs
   - ros-humble-std-msgs
-  - ros2-distro-mutex 0.6.* humble_*
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - ros2-distro-mutex 0.7.* humble_*
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - ros2-distro-mutex >=0.6.0,<0.7.0a0
-  - numpy >=1.26.4,<2.0a0
   - python_abi 3.11.* *_cp311
+  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
   license: BSD-3-Clause
-  size: 56002
-  timestamp: 1736233195430
+  size: 57589
+  timestamp: 1753330454550
 - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-libyaml-vendor-1.2.2-np126py311h2c3b307_7.conda
   sha256: 3846ff5714b983f17bc19db0f7dd54154a902455f6c1d3175d3933db097c4709
   md5: 871cf3643c829980a4796b1a659b64e9
@@ -51231,29 +50762,29 @@ packages:
   license: BSD-3-Clause
   size: 29083
   timestamp: 1736207924279
-- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-libyaml-vendor-1.2.2-np126py311h7d8ee0e_8.conda
-  sha256: c11666de05386691aa4f74791b987f02b25ccaadf8a9158200a85fa8d7867146
-  md5: aace8ba2bb210d8a7bbf1bc9cc9b99a7
+- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-libyaml-vendor-1.2.2-np126py311hd5de103_13.conda
+  sha256: a3a7356462fdf0696cd23bd02ad4d242c9d4cae860dad4918c0475c1bf67a69b
+  md5: a06da76b19342726d0ad4baf04da03c0
   depends:
   - python
   - ros-humble-ros-workspace
-  - ros2-distro-mutex 0.6.* humble_*
+  - ros2-distro-mutex 0.7.* humble_*
   - yaml
   - yaml-cpp
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - yaml >=0.2.5,<0.3.0a0
-  - numpy >=1.26.4,<2.0a0
-  - yaml-cpp >=0.8.0,<0.9.0a0
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
   - python_abi 3.11.* *_cp311
-  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - yaml-cpp >=0.8.0,<0.9.0a0
+  - numpy >=1.26.4,<2.0a0
+  - yaml >=0.2.5,<0.3.0a0
   license: BSD-3-Clause
-  size: 25915
-  timestamp: 1736228082506
+  size: 26864
+  timestamp: 1753320841580
 - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-lifecycle-msgs-1.2.1-np126py311h2c3b307_7.conda
   sha256: 03ca4c0d1fc6bb91e07b554d2f38770dbfcbbdf2872942f46a44a79cfee4b300
   md5: 75e9418889db1f60ae1197e2ef48c033
@@ -51321,26 +50852,26 @@ packages:
   license: BSD-3-Clause
   size: 153379
   timestamp: 1736208438771
-- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-lifecycle-msgs-1.2.1-np126py311h7d8ee0e_8.conda
-  sha256: d470d56238c27fddb445d287bc3a94e0f7eeaa5cec1e303588927e4903cd4978
-  md5: 0c5e1e59022703393a7e56407e5dad6b
+- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-lifecycle-msgs-1.2.1-np126py311hd5de103_13.conda
+  sha256: a90b8ae4ab83c2f27bf7903e0d2b08b0811dfbe5a0063c354edddad07ca56194
+  md5: 856b8b9b907f6f6f6d0c3cb146e32b3d
   depends:
   - python
   - ros-humble-ros-workspace
   - ros-humble-rosidl-default-runtime
-  - ros2-distro-mutex 0.6.* humble_*
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - ros2-distro-mutex 0.7.* humble_*
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - python_abi 3.11.* *_cp311
-  - ros2-distro-mutex >=0.6.0,<0.7.0a0
   - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
   license: BSD-3-Clause
-  size: 165957
-  timestamp: 1736229955069
+  size: 168301
+  timestamp: 1753323253537
 - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-map-msgs-2.1.0-np126py311h2c3b307_7.conda
   sha256: 8b4921aa5ea18a0a52b2b900d5d5d047be56149fa1b9e6fc9d33740cbc1e69d4
   md5: 79821836c50ed9b479434e9fae91d65a
@@ -51419,9 +50950,9 @@ packages:
   license: BSD-3-Clause
   size: 179152
   timestamp: 1736208988039
-- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-map-msgs-2.1.0-np126py311h7d8ee0e_8.conda
-  sha256: 0b62a1015b5087b5a7d9072e5285da705cdfe5a564f891153ca3338098cfc327
-  md5: 0dd9f7b2fa0e0873c9b3a67f8e49cefd
+- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-map-msgs-2.1.0-np126py311hd5de103_13.conda
+  sha256: 407cfbef79e5e8369c0547c33a6169917046b33fc66d13de9fcfa33fb0af1e5f
+  md5: ba505de80e42d69dbdcbf764a7f6de2c
   depends:
   - python
   - ros-humble-nav-msgs
@@ -51429,19 +50960,19 @@ packages:
   - ros-humble-rosidl-default-runtime
   - ros-humble-sensor-msgs
   - ros-humble-std-msgs
-  - ros2-distro-mutex 0.6.* humble_*
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - ros2-distro-mutex 0.7.* humble_*
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
   - numpy >=1.26.4,<2.0a0
-  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
   - python_abi 3.11.* *_cp311
   license: BSD-3-Clause
-  size: 191971
-  timestamp: 1736231770200
+  size: 194283
+  timestamp: 1753328003512
 - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-message-filters-4.3.5-np126py311h2c3b307_7.conda
   sha256: 3fd35f9f8c8034afd220130f2dcab1b40e51287a6c6979afdb866565ad489754
   md5: a365a500e291eb81d1f2d601f3aca985
@@ -51522,9 +51053,9 @@ packages:
   license: BSD-3-Clause
   size: 69817
   timestamp: 1736210247832
-- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-message-filters-4.3.5-np126py311h7d8ee0e_8.conda
-  sha256: 98ccdbf2f3fc316da61023225a0aaf9bc7059db67975ce0983ad7e9f39263337
-  md5: a67d111da22f668d5f58d4ca2f57e80b
+- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-message-filters-4.3.7-np126py311hd5de103_13.conda
+  sha256: a10ee275866eda6708220beb19de049970c9c534ff20fb19923b577f30658cc1
+  md5: 56cc51f9fc5b0efbed77d7f31401ef67
   depends:
   - python
   - ros-humble-builtin-interfaces
@@ -51532,19 +51063,19 @@ packages:
   - ros-humble-rclpy
   - ros-humble-rcutils
   - ros-humble-ros-workspace
-  - ros2-distro-mutex 0.6.* humble_*
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - ros2-distro-mutex 0.7.* humble_*
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
   - python_abi 3.11.* *_cp311
-  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
   - numpy >=1.26.4,<2.0a0
   license: BSD-3-Clause
-  size: 71778
-  timestamp: 1736234596575
+  size: 75284
+  timestamp: 1753332944404
 - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-moveit-2.5.7-np126py311h2c3b307_7.conda
   sha256: 299a5341f3cfb61506dfc12ccb0029e5f0c56168754df612bebbd9d644710d86
   md5: ff2303458bd9db71c4d68919eae124dc
@@ -51648,9 +51179,9 @@ packages:
   license: BSD-3-Clause
   size: 25196
   timestamp: 1736216747395
-- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-moveit-2.5.7-np126py311h7d8ee0e_8.conda
-  sha256: 16f7a7c52f5c2e029862ae3bd4399eb74a08abfadedf002e61237e8db052959c
-  md5: 7a1ea1b011ea9ad3b41f01d90314bb01
+- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-moveit-2.5.9-np126py311hd5de103_13.conda
+  sha256: a4eaeffc9a1d32446626f83892cef61315d133e5502f50b67a20bb4851b28c63
+  md5: 83dbec31c04074f1ee15edc428df3436
   depends:
   - python
   - ros-humble-moveit-core
@@ -51659,19 +51190,19 @@ packages:
   - ros-humble-moveit-ros
   - ros-humble-moveit-setup-assistant
   - ros-humble-ros-workspace
-  - ros2-distro-mutex 0.6.* humble_*
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - ros2-distro-mutex 0.7.* humble_*
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
   - numpy >=1.26.4,<2.0a0
   - python_abi 3.11.* *_cp311
-  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
   license: BSD-3-Clause
-  size: 21127
-  timestamp: 1736246989872
+  size: 22474
+  timestamp: 1753360055684
 - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-moveit-common-2.5.7-np126py311h2c3b307_7.conda
   sha256: 61cd65b3775ab2c9a992e78d2245592ea4434143e053ee2eee03427fe1eb2f76
   md5: 9194f2c0923de18b934b84eb5e3d3973
@@ -51738,26 +51269,26 @@ packages:
   license: BSD-3-Clause
   size: 25971
   timestamp: 1736207273574
-- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-moveit-common-2.5.7-np126py311h7d8ee0e_8.conda
-  sha256: 3c8ef73acbfeaeb843e17108c3bf646408146b790e0d8748240e088b94c19c6e
-  md5: f17af46a0018c55517c9f56630dd709f
+- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-moveit-common-2.5.9-np126py311hd5de103_13.conda
+  sha256: 9df84450efcacddf5e3af27196fe93fc6253cb5827b01afc41a4f713c6e65cf3
+  md5: 944f3c0e65ba5d9d34df17d95e9aad24
   depends:
   - python
   - ros-humble-backward-ros
   - ros-humble-ros-workspace
-  - ros2-distro-mutex 0.6.* humble_*
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - ros2-distro-mutex 0.7.* humble_*
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - python_abi 3.11.* *_cp311
-  - ros2-distro-mutex >=0.6.0,<0.7.0a0
   - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
   license: BSD-3-Clause
-  size: 23205
-  timestamp: 1736210618276
+  size: 24204
+  timestamp: 1753317736476
 - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-moveit-configs-utils-2.5.7-np126py311h2c3b307_7.conda
   sha256: da67fdea98a678798ef3e37d712090371b813412fa7788fa4707ff1ad8242cb8
   md5: 8403c4e029e7503390f50db615f88b3c
@@ -51840,9 +51371,9 @@ packages:
   license: BSD-3-Clause
   size: 45300
   timestamp: 1736210635664
-- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-moveit-configs-utils-2.5.7-np126py311h7d8ee0e_8.conda
-  sha256: 3b74a094a24e3b29d0fc2ddf67e11f36495230c984fc2b90b2f77b40c6a6aeff
-  md5: d7c72299ab32fab4f7ee77bda49b287b
+- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-moveit-configs-utils-2.5.9-np126py311hd5de103_13.conda
+  sha256: d9cf14a59cfe9c86a50ecafdca567c748dab7447dadc4a031f3aac688efa904c
+  md5: d3bbe57f70685117df623e0b567e0660
   depends:
   - python
   - ros-humble-ament-index-python
@@ -51851,19 +51382,19 @@ packages:
   - ros-humble-launch-ros
   - ros-humble-ros-workspace
   - ros-humble-srdfdom
-  - ros2-distro-mutex 0.6.* humble_*
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - ros2-distro-mutex 0.7.* humble_*
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - ros2-distro-mutex >=0.6.0,<0.7.0a0
   - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
   - numpy >=1.26.4,<2.0a0
   license: BSD-3-Clause
-  size: 42204
-  timestamp: 1736235486369
+  size: 42614
+  timestamp: 1753334689660
 - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-moveit-core-2.5.7-np126py311h2c3b307_7.conda
   sha256: e55fd10f8bf2b810bdda5bff4e726b426fbc137bc95ea9ff4583c44fb4b364b0
   md5: 51b8a9bf70c4e3e2b3943cf482b28f37
@@ -52082,9 +51613,9 @@ packages:
   license: BSD-3-Clause
   size: 1230251
   timestamp: 1736212064489
-- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-moveit-core-2.5.7-np126py311h7d8ee0e_8.conda
-  sha256: 6448ad73fc1e0ee4a71609d279cc8164c44867bd0d3b4052fc3128f12bf5f99e
-  md5: 9acde201e60f4ac8d063c60ab5cd485f
+- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-moveit-core-2.5.9-np126py311hd5de103_13.conda
+  sha256: ef0d8ebd3fcd02205d4f6e98d83ff48c59af8d3814bd7371ac9e210a605595ec
+  md5: b528c01a5f6cf6854f323ee25a3715b3
   depends:
   - assimp
   - bullet
@@ -52103,6 +51634,7 @@ packages:
   - ros-humble-kdl-parser
   - ros-humble-moveit-common
   - ros-humble-moveit-msgs
+  - ros-humble-octomap
   - ros-humble-octomap-msgs
   - ros-humble-pluginlib
   - ros-humble-pybind11-vendor
@@ -52123,23 +51655,23 @@ packages:
   - ros-humble-urdfdom
   - ros-humble-urdfdom-headers
   - ros-humble-visualization-msgs
-  - ros2-distro-mutex 0.6.* humble_*
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - ros2-distro-mutex 0.7.* humble_*
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - fcl >=0.7.0,<0.8.0a0
-  - libboost-python >=1.86.0,<1.87.0a0
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
   - libboost >=1.86.0,<1.87.0a0
   - python_abi 3.11.* *_cp311
-  - ros2-distro-mutex >=0.6.0,<0.7.0a0
   - assimp >=5.4.3,<5.4.4.0a0
+  - libboost-python >=1.86.0,<1.87.0a0
+  - fcl >=0.7.0,<0.8.0a0
   - numpy >=1.26.4,<2.0a0
   license: BSD-3-Clause
-  size: 1912122
-  timestamp: 1736238059347
+  size: 1892950
+  timestamp: 1753341269027
 - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-moveit-kinematics-2.5.7-np126py311h2c3b307_7.conda
   sha256: 8a2999994b1dead47ed29ed0f50723bcaab984a839474b83718a5e09016ea674
   md5: e9ca73cd6dfbd7b2007e4b1426786ea1
@@ -52246,9 +51778,9 @@ packages:
   license: BSD-3-Clause
   size: 288873
   timestamp: 1736213617713
-- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-moveit-kinematics-2.5.7-np126py311h7d8ee0e_8.conda
-  sha256: 026927b2ed44a361f20008dd9a25969d0ce91f8ed399bb2cc375cf19b6519314
-  md5: 1f3cb29cd0241cce37431d3830831f28
+- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-moveit-kinematics-2.5.9-np126py311hd5de103_13.conda
+  sha256: 8baaa1cb3938411c7fe00ec37c13a4f7df61aa434c1b55b0fb7634e73fa36688
+  md5: 32c6394b86c3fa65a7a399968706ff6d
   depends:
   - eigen
   - lxml
@@ -52263,19 +51795,19 @@ packages:
   - ros-humble-tf2
   - ros-humble-tf2-kdl
   - ros-humble-urdfdom
-  - ros2-distro-mutex 0.6.* humble_*
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - ros2-distro-mutex 0.7.* humble_*
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
   - python_abi 3.11.* *_cp311
   - numpy >=1.26.4,<2.0a0
-  - ros2-distro-mutex >=0.6.0,<0.7.0a0
   license: BSD-3-Clause
-  size: 428543
-  timestamp: 1736241540979
+  size: 439804
+  timestamp: 1753349347433
 - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-moveit-msgs-2.2.1-np126py311h2c3b307_7.conda
   sha256: aaf9aacce907e23a953d306857d5d073f8b79f706b0e5007220447cce1fba4c0
   md5: aac141ba40c54037473e3ab2f82bf6d2
@@ -52375,9 +51907,9 @@ packages:
   license: BSD-3-Clause
   size: 1286076
   timestamp: 1736209265320
-- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-moveit-msgs-2.2.1-np126py311h7d8ee0e_8.conda
-  sha256: 1127eddae04a5081fcfc901ae53e2a9b8b562b4a2f849e19cb4ae0d11d0b3188
-  md5: 0baf877c6e816b669788fdcd9c6633c1
+- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-moveit-msgs-2.2.1-np126py311hd5de103_13.conda
+  sha256: b16e50ab31a2f5739ae04223c8a6700ce13e9a2c4058bfc6fa4e6d9d76ee3d59
+  md5: 7c7bd2d1a8e338e5eb96aa7c29e002da
   depends:
   - python
   - ros-humble-action-msgs
@@ -52390,19 +51922,19 @@ packages:
   - ros-humble-shape-msgs
   - ros-humble-std-msgs
   - ros-humble-trajectory-msgs
-  - ros2-distro-mutex 0.6.* humble_*
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - ros2-distro-mutex 0.7.* humble_*
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - numpy >=1.26.4,<2.0a0
-  - ros2-distro-mutex >=0.6.0,<0.7.0a0
   - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
+  - numpy >=1.26.4,<2.0a0
   license: BSD-3-Clause
-  size: 1273198
-  timestamp: 1736232555437
+  size: 1261368
+  timestamp: 1753329088996
 - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-moveit-planners-2.5.7-np126py311h2c3b307_7.conda
   sha256: 11ea65a28f5fefd410a186dfb42858043f60ef6d7a3d2fa3678d398972e3edfd
   md5: 699b486de52d7024bc4835b70646ba24
@@ -52474,26 +52006,52 @@ packages:
   license: BSD-3-Clause
   size: 24314
   timestamp: 1736215181762
-- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-moveit-planners-2.5.7-np126py311h7d8ee0e_8.conda
-  sha256: b8e9c6b3a1cde3ff0fa8f233077e3b601ecf85fa5dc8b3d940f0fd76d4e961e5
-  md5: a9cc8aef5a66ae061d88e863731ff2ee
+- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-moveit-planners-2.5.9-np126py311hd5de103_13.conda
+  sha256: 02f1e019de5f9a9926c4fc1e01ef931654a5bda46d1f285d553f6fdc6cfe08a7
+  md5: 169b6e5bf3ea8abb8c0c8c8af0aee212
   depends:
   - python
+  - ros-humble-moveit-planners-chomp
   - ros-humble-moveit-planners-ompl
+  - ros-humble-pilz-industrial-motion-planner
   - ros-humble-ros-workspace
-  - ros2-distro-mutex 0.6.* humble_*
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - ros2-distro-mutex 0.7.* humble_*
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - ros2-distro-mutex >=0.6.0,<0.7.0a0
   - numpy >=1.26.4,<2.0a0
   - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
   license: BSD-3-Clause
-  size: 21014
-  timestamp: 1736243038870
+  size: 22365
+  timestamp: 1753359511852
+- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-moveit-planners-chomp-2.5.9-np126py311hd5de103_13.conda
+  sha256: 9e33c1b48ed0e70acf5a26a5b641cfeb7e37ec1efd9780e1991cca457883b134
+  md5: 3e1e98e5a7dea42012ff927474370f08
+  depends:
+  - python
+  - ros-humble-chomp-motion-planner
+  - ros-humble-moveit-common
+  - ros-humble-moveit-core
+  - ros-humble-pluginlib
+  - ros-humble-rclcpp
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.7.* humble_*
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  - ucrt >=10.0.20348.0
+  - python_abi 3.11.* *_cp311
+  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
+  license: BSD-3-Clause
+  size: 89539
+  timestamp: 1753348307097
 - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-moveit-planners-ompl-2.5.7-np126py311h2c3b307_7.conda
   sha256: 733ae64a0cc32c616b783ef611e45fbb4d96f39a44bfab1f04a23c64d9ccc4c7
   md5: 8a294da3cabe1e50a9613c2ccd624602
@@ -52600,9 +52158,9 @@ packages:
   license: BSD-3-Clause
   size: 386804
   timestamp: 1736213743253
-- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-moveit-planners-ompl-2.5.7-np126py311h7d8ee0e_8.conda
-  sha256: 8768e0f39589dbd4bdaefb3179cb1c4bf65f2ce292fec8e1f34f8c8ebf4008a3
-  md5: 597c04f6440419156840b40f854e5a7a
+- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-moveit-planners-ompl-2.5.9-np126py311hd5de103_13.conda
+  sha256: 484a21e79285a4cf4cfbdc6f000a75e31b4cca63f904fd3664b479da8cba3204
+  md5: 7ed78d68c2a0e2618c15a3d092469551
   depends:
   - python
   - ros-humble-moveit-common
@@ -52615,19 +52173,19 @@ packages:
   - ros-humble-ros-workspace
   - ros-humble-tf2-eigen
   - ros-humble-tf2-ros
-  - ros2-distro-mutex 0.6.* humble_*
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - ros2-distro-mutex 0.7.* humble_*
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
   - python_abi 3.11.* *_cp311
-  - ros2-distro-mutex >=0.6.0,<0.7.0a0
   - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
   license: BSD-3-Clause
-  size: 1090156
-  timestamp: 1736241896624
+  size: 1130042
+  timestamp: 1753350151007
 - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-moveit-plugins-2.5.7-np126py311h2c3b307_7.conda
   sha256: 52c328dbaa749b05e281c1d0a69254d32adbbae6460cb5ab07a7eab0e115802c
   md5: 695c780ff66709c6c4a46d843d0e3c82
@@ -52694,26 +52252,26 @@ packages:
   license: BSD-3-Clause
   size: 24251
   timestamp: 1736213226036
-- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-moveit-plugins-2.5.7-np126py311h7d8ee0e_8.conda
-  sha256: 417d3d1898c3beefea88ac17b98680e0f4be28c561e5c866c91687384c1d17d0
-  md5: ecf3be83b0b991a06dfa624673fab434
+- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-moveit-plugins-2.5.9-np126py311hd5de103_13.conda
+  sha256: e15d5e6a88355f38f09cfd5e3818fcf3bf76db3ffd02ad38c89ce5573258ab1f
+  md5: a4768765b8eb737ee2d95cce9b9ba931
   depends:
   - python
   - ros-humble-moveit-simple-controller-manager
   - ros-humble-ros-workspace
-  - ros2-distro-mutex 0.6.* humble_*
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - ros2-distro-mutex 0.7.* humble_*
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - python_abi 3.11.* *_cp311
   - numpy >=1.26.4,<2.0a0
-  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
   license: BSD-3-Clause
-  size: 20953
-  timestamp: 1736240795445
+  size: 22292
+  timestamp: 1753348734771
 - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-moveit-ros-2.5.7-np126py311h2c3b307_7.conda
   sha256: e57a7cf84a388c5870b60f089b0f35f18dd816e9ec22fa14d94c77fca106f932
   md5: 3f8f29589fc4df74e005e87d267eeb6f
@@ -52805,9 +52363,9 @@ packages:
   license: BSD-3-Clause
   size: 24515
   timestamp: 1736214875592
-- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-moveit-ros-2.5.7-np126py311h7d8ee0e_8.conda
-  sha256: fad5b73a07ef16fcea8efdac116a858f428806a64fa7bbba4a0fc1887e551226
-  md5: 689e0520ddbbd9b4a38ca541a280cc13
+- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-moveit-ros-2.5.9-np126py311hd5de103_13.conda
+  sha256: 325aee7bba571b18c2fe5805c5754ebe1009b5610e4d2e79b034c53b479720e7
+  md5: 6bc2218d0d2c925c36e5ed9d02cda23c
   depends:
   - python
   - ros-humble-moveit-ros-benchmarks
@@ -52818,19 +52376,19 @@ packages:
   - ros-humble-moveit-ros-visualization
   - ros-humble-moveit-ros-warehouse
   - ros-humble-ros-workspace
-  - ros2-distro-mutex 0.6.* humble_*
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - ros2-distro-mutex 0.7.* humble_*
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - ros2-distro-mutex >=0.6.0,<0.7.0a0
   - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
   - python_abi 3.11.* *_cp311
   license: BSD-3-Clause
-  size: 21237
-  timestamp: 1736245168764
+  size: 22538
+  timestamp: 1753357579009
 - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-moveit-ros-benchmarks-2.5.7-np126py311h2c3b307_7.conda
   sha256: 475194bd7601b98b7a6546c2396411a97701fce6ba8cfa2e358c5bcc1e4dfbc6
   md5: af61fbf2f34269e469135916c72173c5
@@ -52934,9 +52492,9 @@ packages:
   license: BSD-3-Clause
   size: 230877
   timestamp: 1736214006345
-- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-moveit-ros-benchmarks-2.5.7-np126py311h7d8ee0e_8.conda
-  sha256: d2c481603ec1c52370824fe7e3255715ef4fc9cd9ddd7af04440a86c835aaa2b
-  md5: 3b0230a1dd608ea7639bcc873d2e41bc
+- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-moveit-ros-benchmarks-2.5.9-np126py311hd5de103_13.conda
+  sha256: 9ca8731be8c69865c40909b072adc66266ffbfba603264d5b95057e6d431973d
+  md5: a2649310e2d89e4d2d0f0d39508c805e
   depends:
   - libboost
   - python
@@ -52949,20 +52507,20 @@ packages:
   - ros-humble-rclcpp
   - ros-humble-ros-workspace
   - ros-humble-tf2-eigen
-  - ros2-distro-mutex 0.6.* humble_*
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - ros2-distro-mutex 0.7.* humble_*
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - numpy >=1.26.4,<2.0a0
-  - libboost >=1.86.0,<1.87.0a0
   - python_abi 3.11.* *_cp311
-  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
+  - libboost >=1.86.0,<1.87.0a0
   license: BSD-3-Clause
-  size: 282384
-  timestamp: 1736242893593
+  size: 280023
+  timestamp: 1753352384143
 - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-moveit-ros-move-group-2.5.7-np126py311h2c3b307_7.conda
   sha256: 9097379f3dac3cc78179c0230f036a7f0267fc344a236c0a2f835d683c5a57b6
   md5: 522bc23efb8ed9eadddf9933f7eb86dd
@@ -53075,9 +52633,9 @@ packages:
   license: BSD-3-Clause
   size: 375112
   timestamp: 1736213911597
-- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-moveit-ros-move-group-2.5.7-np126py311h7d8ee0e_8.conda
-  sha256: 23e08ee2de22520f5ff9261df93b0ac3b9c8d0b1dc013450b66ffe89a0dcb13e
-  md5: be8c49188f7cc92235e118e2e386ceca
+- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-moveit-ros-move-group-2.5.9-np126py311hd5de103_13.conda
+  sha256: c0bb4286104c5b3c472f8be4ce007669d8c31f6ebaf48a101297651cf9edc124
+  md5: 67dadd39b0d1b2b003043af7f0127315
   depends:
   - python
   - ros-humble-moveit-common
@@ -53093,19 +52651,19 @@ packages:
   - ros-humble-tf2
   - ros-humble-tf2-geometry-msgs
   - ros-humble-tf2-ros
-  - ros2-distro-mutex 0.6.* humble_*
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - ros2-distro-mutex 0.7.* humble_*
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - ros2-distro-mutex >=0.6.0,<0.7.0a0
   - numpy >=1.26.4,<2.0a0
   - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
   license: BSD-3-Clause
-  size: 440904
-  timestamp: 1736242533769
+  size: 442973
+  timestamp: 1753351840136
 - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-moveit-ros-occupancy-map-monitor-2.5.7-np126py311h2c3b307_7.conda
   sha256: c188c131204edefa0e262b6e863e4e27cfee6e168aa4c68f834367a95f51a73d
   md5: dce13f611ea66a9fc3dc6fe4b38968a4
@@ -53205,9 +52763,9 @@ packages:
   license: BSD-3-Clause
   size: 290703
   timestamp: 1736212884306
-- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-moveit-ros-occupancy-map-monitor-2.5.7-np126py311h7d8ee0e_8.conda
-  sha256: 0fbd7f561200b7efa67c722df4f62b66fd72fecf6ab62281669ed7dd7497bec1
-  md5: 357e9e39f5da976bb2932e6cf0e22503
+- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-moveit-ros-occupancy-map-monitor-2.5.9-np126py311hd5de103_13.conda
+  sha256: 29a5bed7e47e988496675b8b4bb151d4eb90a01b72a4ce2a04db54c49dd9e16e
+  md5: 291354420a570956d61a1eabbc9e24fa
   depends:
   - eigen
   - python
@@ -53216,23 +52774,24 @@ packages:
   - ros-humble-moveit-common
   - ros-humble-moveit-core
   - ros-humble-moveit-msgs
+  - ros-humble-octomap
   - ros-humble-pluginlib
   - ros-humble-rclcpp
   - ros-humble-ros-workspace
   - ros-humble-tf2-ros
-  - ros2-distro-mutex 0.6.* humble_*
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - ros2-distro-mutex 0.7.* humble_*
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
   - python_abi 3.11.* *_cp311
-  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
   - numpy >=1.26.4,<2.0a0
   license: BSD-3-Clause
-  size: 302290
-  timestamp: 1736239942326
+  size: 299291
+  timestamp: 1753345232245
 - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-moveit-ros-planning-2.5.7-np126py311h2c3b307_7.conda
   sha256: fb1a4340521a4e53d24473410b13e2448da355002bef8552509a9b9d14221bc0
   md5: ca6cdbad77478bed48982b52c3bdbf0a
@@ -53369,9 +52928,9 @@ packages:
   license: BSD-3-Clause
   size: 1096212
   timestamp: 1736213376734
-- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-moveit-ros-planning-2.5.7-np126py311h7d8ee0e_8.conda
-  sha256: 7f5bd33d9aa498a5bbffc1add2a02b454d9d871e0208afa4dd40c1c965b21424
-  md5: c7864df7a16eb9e56f3aee9c98593547
+- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-moveit-ros-planning-2.5.9-np126py311hd5de103_13.conda
+  sha256: 37be2ab40e2522680bd76a7e05c10c1857480ebdee87b592e21511409f1cf83b
+  md5: 0dfe2dfa0288f7b85d23add7898a845a
   depends:
   - eigen
   - python
@@ -53393,19 +52952,19 @@ packages:
   - ros-humble-tf2-msgs
   - ros-humble-tf2-ros
   - ros-humble-urdf
-  - ros2-distro-mutex 0.6.* humble_*
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - ros2-distro-mutex 0.7.* humble_*
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
   - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
   - python_abi 3.11.* *_cp311
-  - ros2-distro-mutex >=0.6.0,<0.7.0a0
   license: BSD-3-Clause
-  size: 1541790
-  timestamp: 1736240760175
+  size: 1527130
+  timestamp: 1753347341535
 - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-moveit-ros-planning-interface-2.5.7-np126py311h2c3b307_7.conda
   sha256: 7d045c6a7dbdc674ab9cb05ccbd0e16dec26065c964cd39689015f9903dbf40f
   md5: 4a44882098912661a2da3fca25500c91
@@ -53523,9 +53082,9 @@ packages:
   license: BSD-3-Clause
   size: 297092
   timestamp: 1736214105649
-- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-moveit-ros-planning-interface-2.5.7-np126py311h7d8ee0e_8.conda
-  sha256: 09dd3959a637cfca16a46d2f470effd7e98a0b427bb5efa274afc0107d1d799d
-  md5: f46f1d5e9cccf1410b331c98303f60e1
+- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-moveit-ros-planning-interface-2.5.9-np126py311hd5de103_13.conda
+  sha256: 481d67a05267a57c5782f9b487e9900999152b08f7f9effe2e2d328a5563b539
+  md5: e59a7ffaedb4ceb2c5383b7240854309
   depends:
   - python
   - ros-humble-geometry-msgs
@@ -53543,19 +53102,19 @@ packages:
   - ros-humble-tf2-eigen
   - ros-humble-tf2-geometry-msgs
   - ros-humble-tf2-ros
-  - ros2-distro-mutex 0.6.* humble_*
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - ros2-distro-mutex 0.7.* humble_*
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
   - python_abi 3.11.* *_cp311
-  - ros2-distro-mutex >=0.6.0,<0.7.0a0
   - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
   license: BSD-3-Clause
-  size: 420243
-  timestamp: 1736243291797
+  size: 415524
+  timestamp: 1753353342773
 - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-moveit-ros-robot-interaction-2.5.7-np126py311h2c3b307_7.conda
   sha256: 6e1c6d5db90bb653da827fe919df6bfd9d7d28e101e841dceb5aa47f7ee2a972
   md5: 2aba0e7860c4644ea9a720fb239a243c
@@ -53655,9 +53214,9 @@ packages:
   license: BSD-3-Clause
   size: 222617
   timestamp: 1736213827751
-- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-moveit-ros-robot-interaction-2.5.7-np126py311h7d8ee0e_8.conda
-  sha256: 23025c6885b6c197c91605fac21b4adc9a6232bb1385ad7acd37f708fc5b2de0
-  md5: c11510959152a6b3b20a7023588e1a2d
+- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-moveit-ros-robot-interaction-2.5.9-np126py311hd5de103_13.conda
+  sha256: c9b732f421c3d326959ac3ef515801a17f30a09be044d790e9846fa2af809f9c
+  md5: 9958d8da7f0f7382c1893ea1c870afa3
   depends:
   - python
   - ros-humble-interactive-markers
@@ -53670,19 +53229,19 @@ packages:
   - ros-humble-tf2-eigen
   - ros-humble-tf2-geometry-msgs
   - ros-humble-tf2-ros
-  - ros2-distro-mutex 0.6.* humble_*
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - ros2-distro-mutex 0.7.* humble_*
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - python_abi 3.11.* *_cp311
   - numpy >=1.26.4,<2.0a0
-  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
+  - python_abi 3.11.* *_cp311
   license: BSD-3-Clause
-  size: 279447
-  timestamp: 1736242169375
+  size: 278605
+  timestamp: 1753350549156
 - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-moveit-ros-visualization-2.5.7-np126py311h2c3b307_7.conda
   sha256: b2c5c581e75bd3a0564a56f7a0158cc9ac3ad426ef07faeef10a40ddcfb12be8
   md5: 5d205242d874539e2565b4fcaa220262
@@ -53818,9 +53377,9 @@ packages:
   license: BSD-3-Clause
   size: 770721
   timestamp: 1736214253948
-- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-moveit-ros-visualization-2.5.7-np126py311h7d8ee0e_8.conda
-  sha256: 98db8ececa559ec1cd9e2d9d5e69054a46ca06a179514532088f2827fd045173
-  md5: 8cfd9473025b68e5bd436a2c33c40be4
+- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-moveit-ros-visualization-2.5.9-np126py311hd5de103_13.conda
+  sha256: 0801eedbebbdd9a21654aeecf41deccd11f8c4dcf64237aa08d0523df5814293
+  md5: 1a3a202f4ffe46b30755293467ff6b5e
   depends:
   - python
   - ros-humble-geometric-shapes
@@ -53836,20 +53395,20 @@ packages:
   - ros-humble-ros-workspace
   - ros-humble-rviz2
   - ros-humble-tf2-eigen
-  - ros2-distro-mutex 0.6.* humble_*
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - ros2-distro-mutex 0.7.* humble_*
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - ros2-distro-mutex >=0.6.0,<0.7.0a0
-  - numpy >=1.26.4,<2.0a0
-  - python_abi 3.11.* *_cp311
   - qt-main >=5.15.15,<5.16.0a0
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
+  - numpy >=1.26.4,<2.0a0
   license: BSD-3-Clause
-  size: 1049441
-  timestamp: 1736243797430
+  size: 1032168
+  timestamp: 1753354186215
 - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-moveit-ros-warehouse-2.5.7-np126py311h2c3b307_7.conda
   sha256: 254af24b3e4b2802451e693759cdaf6e19468e8fcd9f0a1a35a9fdae05af6cba
   md5: 614854120b903c8db714fa0519bf4aea
@@ -53941,9 +53500,9 @@ packages:
   license: BSD-3-Clause
   size: 482287
   timestamp: 1736213684433
-- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-moveit-ros-warehouse-2.5.7-np126py311h7d8ee0e_8.conda
-  sha256: b24480f8c7cc9331d38fca1a492ef2481ced91245c7e8b41755deacbb2433248
-  md5: 852f2810d2a9ffafdb344e43d726885b
+- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-moveit-ros-warehouse-2.5.9-np126py311hd5de103_13.conda
+  sha256: ef21a17a6bc0ae0132756266befdf172703aec512d67182f982ffa52cdaa20c2
+  md5: 4987b9939fe60ffd066d495f4bdcefe4
   depends:
   - python
   - ros-humble-moveit-common
@@ -53954,19 +53513,19 @@ packages:
   - ros-humble-tf2-eigen
   - ros-humble-tf2-ros
   - ros-humble-warehouse-ros
-  - ros2-distro-mutex 0.6.* humble_*
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - ros2-distro-mutex 0.7.* humble_*
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - numpy >=1.26.4,<2.0a0
   - python_abi 3.11.* *_cp311
-  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
+  - numpy >=1.26.4,<2.0a0
   license: BSD-3-Clause
-  size: 441421
-  timestamp: 1736241760805
+  size: 440198
+  timestamp: 1753349910886
 - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-moveit-setup-app-plugins-2.5.7-np126py311h2c3b307_7.conda
   sha256: 7fdeafe5927719756e727bad0743f43c8ab1246b2e630906dbcbf6d6a57a4e6f
   md5: 1a5f0df6d7774b682a6c9ceae605fc2f
@@ -54074,9 +53633,9 @@ packages:
   license: BSD-3-Clause
   size: 130960
   timestamp: 1736215058934
-- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-moveit-setup-app-plugins-2.5.7-np126py311h7d8ee0e_8.conda
-  sha256: b9e80076c16a47fac647fb16c377984ad854dbbbf7a6ded15d38655e155c17c5
-  md5: 8534e73d45a851cc4d8e64db649b4a3b
+- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-moveit-setup-app-plugins-2.5.9-np126py311hd5de103_13.conda
+  sha256: 1d9ebd8fd45ead74098e553989ed4ce6446c617891146a47f48d0a2f8f3fab4d
+  md5: 8c9e7e8fa49b4fa330a5471712f87786
   depends:
   - python
   - ros-humble-ament-index-cpp
@@ -54086,19 +53645,19 @@ packages:
   - ros-humble-pluginlib
   - ros-humble-rclcpp
   - ros-humble-ros-workspace
-  - ros2-distro-mutex 0.6.* humble_*
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - ros2-distro-mutex 0.7.* humble_*
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
   - numpy >=1.26.4,<2.0a0
   - python_abi 3.11.* *_cp311
-  - ros2-distro-mutex >=0.6.0,<0.7.0a0
   license: BSD-3-Clause
-  size: 162967
-  timestamp: 1736246050538
+  size: 164891
+  timestamp: 1753358868943
 - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-moveit-setup-assistant-2.5.7-np126py311h2c3b307_7.conda
   sha256: 3185ba964a8b8ca15b179cbbb31185ac7b1d2424459dece56d2bdace333d31df
   md5: edc298a525fbd38bc38d857ac1150523
@@ -54222,9 +53781,9 @@ packages:
   license: BSD-3-Clause
   size: 318774
   timestamp: 1736216670922
-- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-moveit-setup-assistant-2.5.7-np126py311h7d8ee0e_8.conda
-  sha256: 82659abf730ca4a955e2c051d239c1d05841cf7bc871fce40358c1ce87dacbee
-  md5: 24d2929b336ba61b5d830266c04d5115
+- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-moveit-setup-assistant-2.5.9-np126py311hd5de103_13.conda
+  sha256: caa944f96a3b455513829d1890d582a436afebc31edd416adb51ebe8b83f4265
+  md5: d579e3bdc0dcbd0336f114aab62a017c
   depends:
   - python
   - qt-main
@@ -54237,20 +53796,20 @@ packages:
   - ros-humble-pluginlib
   - ros-humble-rclcpp
   - ros-humble-ros-workspace
-  - ros2-distro-mutex 0.6.* humble_*
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - ros2-distro-mutex 0.7.* humble_*
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - qt-main >=5.15.15,<5.16.0a0
-  - ros2-distro-mutex >=0.6.0,<0.7.0a0
-  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
   - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
+  - qt-main >=5.15.15,<5.16.0a0
   license: BSD-3-Clause
-  size: 297737
-  timestamp: 1736246738586
+  size: 299201
+  timestamp: 1753359698433
 - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-moveit-setup-controllers-2.5.7-np126py311h2c3b307_7.conda
   sha256: f668a9bcc4a74e955b8b5b5a86b03d8235b436d9e2d0dbd55d73a40d4b5cadcc
   md5: 7a8fe2d534b25e2936b03a37fe17f708
@@ -54349,9 +53908,9 @@ packages:
   license: BSD-3-Clause
   size: 213370
   timestamp: 1736214998111
-- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-moveit-setup-controllers-2.5.7-np126py311h7d8ee0e_8.conda
-  sha256: 23b4ed58b20f2be8fa8b4aaf199db9211feba111f2f3e96969a48f1c278b9f8b
-  md5: c95f980e0dd57e70ac0e009f7e502f46
+- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-moveit-setup-controllers-2.5.9-np126py311hd5de103_13.conda
+  sha256: 0bc86fa59aeb85e2451b81fd43b7f5b3b6e5952c35f18b63ac86b61f2a87dce5
+  md5: 7b284f2d462803d8e8230c5d43c23b16
   depends:
   - python
   - ros-humble-ament-index-cpp
@@ -54359,19 +53918,19 @@ packages:
   - ros-humble-pluginlib
   - ros-humble-rclcpp
   - ros-humble-ros-workspace
-  - ros2-distro-mutex 0.6.* humble_*
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - ros2-distro-mutex 0.7.* humble_*
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
   - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
   - numpy >=1.26.4,<2.0a0
-  - ros2-distro-mutex >=0.6.0,<0.7.0a0
   license: BSD-3-Clause
-  size: 266366
-  timestamp: 1736245808761
+  size: 266869
+  timestamp: 1753358535780
 - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-moveit-setup-core-plugins-2.5.7-np126py311h2c3b307_7.conda
   sha256: dc9a9e6d48bc26a98ae3e2c7be796dc1116964cc84a4795e03b2934d19715e25
   md5: 8eb6dba7c1914bcd4d4d499f0235dd49
@@ -54483,9 +54042,9 @@ packages:
   license: BSD-3-Clause
   size: 116680
   timestamp: 1736214922341
-- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-moveit-setup-core-plugins-2.5.7-np126py311h7d8ee0e_8.conda
-  sha256: 9e0bb904483bc241f72eacaceeed0d242424eb09a021a5dab12335d8c48acff2
-  md5: 4877aefc35985cf3859db0bd099682b1
+- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-moveit-setup-core-plugins-2.5.9-np126py311hd5de103_13.conda
+  sha256: 896e4fe950b268074dfb23be52e01972655bef609d08792adde3ffe4299ab980
+  md5: d330e723d9a07ee9f9058bf93bb1b013
   depends:
   - python
   - ros-humble-ament-index-cpp
@@ -54496,19 +54055,19 @@ packages:
   - ros-humble-ros-workspace
   - ros-humble-srdfdom
   - ros-humble-urdf
-  - ros2-distro-mutex 0.6.* humble_*
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - ros2-distro-mutex 0.7.* humble_*
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - ros2-distro-mutex >=0.6.0,<0.7.0a0
-  - python_abi 3.11.* *_cp311
   - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
   license: BSD-3-Clause
-  size: 147520
-  timestamp: 1736245485793
+  size: 150498
+  timestamp: 1753357987314
 - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-moveit-setup-framework-2.5.7-np126py311h2c3b307_7.conda
   sha256: fd7a1d328030de42d71b478e52391af5fd2c21b286e2173a7d3d6cd92259a87e
   md5: f621fb8e809c01cee7de5b40494a3605
@@ -54637,9 +54196,9 @@ packages:
   license: BSD-3-Clause
   size: 251609
   timestamp: 1736214728821
-- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-moveit-setup-framework-2.5.7-np126py311h7d8ee0e_8.conda
-  sha256: 6d95f6f516cdf065c0328334e7507aee1d18a0505acf8564b7834e6045536792
-  md5: 66cca4f0796840b1339a063a39b9a7c5
+- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-moveit-setup-framework-2.5.9-np126py311hd5de103_13.conda
+  sha256: d2ce63190eb4f91f84d5f56026b73091d6842963e2879f9c4cf5f42a1af1a510
+  md5: 173abbb345f0e7299d2191ce9740a290
   depends:
   - python
   - ros-humble-ament-index-cpp
@@ -54654,19 +54213,19 @@ packages:
   - ros-humble-rviz-rendering
   - ros-humble-srdfdom
   - ros-humble-urdf
-  - ros2-distro-mutex 0.6.* humble_*
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - ros2-distro-mutex 0.7.* humble_*
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - numpy >=1.26.4,<2.0a0
-  - ros2-distro-mutex >=0.6.0,<0.7.0a0
   - python_abi 3.11.* *_cp311
+  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
   license: BSD-3-Clause
-  size: 302029
-  timestamp: 1736244872658
+  size: 303957
+  timestamp: 1753356854009
 - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-moveit-setup-srdf-plugins-2.5.7-np126py311h2c3b307_7.conda
   sha256: f5831c78a3548fa20d0ae2369a28342c79875292fc3829d792fb0ce040fd76e3
   md5: d2ce1b0ba0cdedfd02138639bef0703e
@@ -54759,27 +54318,27 @@ packages:
   license: BSD-3-Clause
   size: 371427
   timestamp: 1736215099211
-- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-moveit-setup-srdf-plugins-2.5.7-np126py311h7d8ee0e_8.conda
-  sha256: 723e07a96b8598e5a3f4f4febe2a26814a3ce7a883115f2da37389747952cd73
-  md5: 7126fab2eb397906bcbe40ccdd9245e9
+- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-moveit-setup-srdf-plugins-2.5.9-np126py311hd5de103_13.conda
+  sha256: adc4bbd8fa108fe21006729a42dd08c787f11ed2e5184592d6ea047453924fb8
+  md5: b0f32ef786126ed6affff1c4f3b3665c
   depends:
   - python
   - ros-humble-moveit-setup-framework
   - ros-humble-pluginlib
   - ros-humble-ros-workspace
-  - ros2-distro-mutex 0.6.* humble_*
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - ros2-distro-mutex 0.7.* humble_*
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - numpy >=1.26.4,<2.0a0
   - python_abi 3.11.* *_cp311
-  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
   license: BSD-3-Clause
-  size: 459329
-  timestamp: 1736246189037
+  size: 460348
+  timestamp: 1753359073144
 - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-moveit-simple-controller-manager-2.5.7-np126py311h2c3b307_7.conda
   sha256: a24e29ddced7bffc4bfccfd5433e355654557e53b9350b7d07cded8480a20268
   md5: f8329023f7297de86718395d080e171f
@@ -54867,9 +54426,9 @@ packages:
   license: BSD-3-Clause
   size: 145176
   timestamp: 1736213136536
-- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-moveit-simple-controller-manager-2.5.7-np126py311h7d8ee0e_8.conda
-  sha256: 029120233470a8ecb06def6f92e8c98607d54ed8e76230dd24223f4af4ead4d7
-  md5: eb952b136d7b282f2a4820d2d847bafc
+- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-moveit-simple-controller-manager-2.5.9-np126py311hd5de103_13.conda
+  sha256: e28e507ac40b096d88bcca90f2469c45904be1ce97443334e88f3de66bc7594f
+  md5: 44d032cf65dfd074a7985a2048768abf
   depends:
   - python
   - ros-humble-control-msgs
@@ -54879,19 +54438,19 @@ packages:
   - ros-humble-rclcpp
   - ros-humble-rclcpp-action
   - ros-humble-ros-workspace
-  - ros2-distro-mutex 0.6.* humble_*
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - ros2-distro-mutex 0.7.* humble_*
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
   - python_abi 3.11.* *_cp311
   - numpy >=1.26.4,<2.0a0
-  - ros2-distro-mutex >=0.6.0,<0.7.0a0
   license: BSD-3-Clause
-  size: 186574
-  timestamp: 1736240184352
+  size: 185664
+  timestamp: 1753345752948
 - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-moveit-visual-tools-4.1.1-np126py311h2c3b307_7.conda
   sha256: 82f538ecde0ca6896ef04ece7ffed90fc4fdcec25f1894a2bbf30aa7fc31d266
   md5: bd6d6abcc135e83f279aa56bbb62e03f
@@ -55022,9 +54581,9 @@ packages:
   license: BSD-3-Clause
   size: 372224
   timestamp: 1736213693983
-- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-moveit-visual-tools-4.1.1-np126py311h7d8ee0e_8.conda
-  sha256: cf75eb57d4dc9ad6036c5907e91cb3f6a0f072d31c60e1471ed4a23c3c28415f
-  md5: 5d5ae71a14cb4f3bbc3548ec915533d3
+- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-moveit-visual-tools-4.1.2-np126py311hd5de103_13.conda
+  sha256: 0e2371f5ea1f7bb5440f45fd4921297d1e76616eba39520db85b095eac86fc9e
+  md5: 3e85afa11ee3d2efc194e51691447208
   depends:
   - python
   - ros-humble-geometry-msgs
@@ -55040,19 +54599,19 @@ packages:
   - ros-humble-tf2-ros
   - ros-humble-trajectory-msgs
   - ros-humble-visualization-msgs
-  - ros2-distro-mutex 0.6.* humble_*
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - ros2-distro-mutex 0.7.* humble_*
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - python_abi 3.11.* *_cp311
-  - ros2-distro-mutex >=0.6.0,<0.7.0a0
   - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
   license: BSD-3-Clause
-  size: 284602
-  timestamp: 1736241836224
+  size: 284474
+  timestamp: 1753351410519
 - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-nav-msgs-4.2.4-np126py311h2c3b307_7.conda
   sha256: f3e50164fcddfe4351700d0e428ddb22f2a0e36d2f3814a934ce015cc29bcd33
   md5: d0679e17f3ac9c1f60f3cc0d6836d7c3
@@ -55131,9 +54690,9 @@ packages:
   license: BSD-3-Clause
   size: 172704
   timestamp: 1736208886550
-- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-nav-msgs-4.2.4-np126py311h7d8ee0e_8.conda
-  sha256: dde8c08829da5291a3136a8c6269d3e5c9a2d3fa74c0582edf7b1d821f72a593
-  md5: 8089ebb1f3dc3635df1e33fd7addd2b2
+- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-nav-msgs-4.9.0-np126py311hd5de103_13.conda
+  sha256: fd769147010e3f2982a2bdc061ad85ce58f9c19ecc1ef85598b06ad7d8004b00
+  md5: dc91ffc3bd16c309711933d835817179
   depends:
   - python
   - ros-humble-builtin-interfaces
@@ -55141,19 +54700,19 @@ packages:
   - ros-humble-ros-workspace
   - ros-humble-rosidl-default-runtime
   - ros-humble-std-msgs
-  - ros2-distro-mutex 0.6.* humble_*
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - ros2-distro-mutex 0.7.* humble_*
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
   - numpy >=1.26.4,<2.0a0
-  - ros2-distro-mutex >=0.6.0,<0.7.0a0
   - python_abi 3.11.* *_cp311
   license: BSD-3-Clause
-  size: 187064
-  timestamp: 1736231559999
+  size: 194949
+  timestamp: 1753326968026
 - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-object-recognition-msgs-2.0.0-np126py311h2c3b307_7.conda
   sha256: 09df1c4c431040eb85540a0cbc65cbdac2d1bd227473a0fae0cdebdd8ffac16b
   md5: 3f65eb675eed8b5caea2595e869d6293
@@ -55241,9 +54800,9 @@ packages:
   license: BSD-3-Clause
   size: 202737
   timestamp: 1736209002378
-- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-object-recognition-msgs-2.0.0-np126py311h7d8ee0e_8.conda
-  sha256: 10eb674e6b92d63d9b73c93aff5e4bb80e59bcf9be94d4d2d4d6203cd92291bc
-  md5: a3026bb17fb3a15d26bc9146190d0488
+- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-object-recognition-msgs-2.0.0-np126py311hd5de103_13.conda
+  sha256: f3ac45fb5411f14fa88ea29c49f22c81df3675f2b31de4bc02082f4cfdb4de07
+  md5: 00d52b65e776865f2842de8aa877de1e
   depends:
   - python
   - ros-humble-action-msgs
@@ -55253,19 +54812,32 @@ packages:
   - ros-humble-sensor-msgs
   - ros-humble-shape-msgs
   - ros-humble-std-msgs
-  - ros2-distro-mutex 0.6.* humble_*
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - ros2-distro-mutex 0.7.* humble_*
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - ros2-distro-mutex >=0.6.0,<0.7.0a0
-  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
   - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
   license: BSD-3-Clause
-  size: 218261
-  timestamp: 1736231951207
+  size: 219526
+  timestamp: 1753327732971
+- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-octomap-1.10.0-py311hb04609a_13.conda
+  sha256: a8960e2ee7611d8b35cfc668b64d026421cfdd9430f9ef51447ca854f844d4f8
+  md5: f43b9d4a2df87b1605099d91ba858062
+  depends:
+  - octomap >=1.10.0,<1.11.0a0
+  - python
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.7.* humble_*
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  size: 6575
+  timestamp: 1753308382966
 - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-octomap-msgs-2.0.1-np126py311h2c3b307_7.conda
   sha256: 3f98b094c416beb95ed7750e0573895ada788dc0822559dc33109c25a93b0e5c
   md5: 6d86983b9eb1dae1865e5300e68d1463
@@ -55341,28 +54913,28 @@ packages:
   license: BSD-3-Clause
   size: 112709
   timestamp: 1736208873746
-- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-octomap-msgs-2.0.1-np126py311h7d8ee0e_8.conda
-  sha256: 8891b3d785ed09794d7fd4cc1fb6170b763010e840a51d69d3fac62fc84181a7
-  md5: 8ef33b06f64ce3a0fa6cff4ed704404a
+- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-octomap-msgs-2.0.1-np126py311hd5de103_13.conda
+  sha256: 4ae22893a8a4f8c35b01ecd1163d5e7577b32432ecef4cb53050f627b419c456
+  md5: 05bea2dc8113ac0e981413856f59517f
   depends:
   - python
   - ros-humble-geometry-msgs
   - ros-humble-ros-workspace
   - ros-humble-rosidl-default-runtime
   - ros-humble-std-msgs
-  - ros2-distro-mutex 0.6.* humble_*
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - ros2-distro-mutex 0.7.* humble_*
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - ros2-distro-mutex >=0.6.0,<0.7.0a0
-  - numpy >=1.26.4,<2.0a0
   - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
+  - numpy >=1.26.4,<2.0a0
   license: BSD-3-Clause
-  size: 124215
-  timestamp: 1736231517400
+  size: 127049
+  timestamp: 1753326901547
 - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-ompl-1.6.0-np126py311h2c3b307_7.conda
   sha256: bddd8fed85b33ca21c40342138f0bb219b9ef0fcf5720efc351315038b0658dc
   md5: 4b3655d0e4b72c2fa37fcf05efde4a58
@@ -55458,33 +55030,27 @@ packages:
   license: BSD-3-Clause
   size: 16890
   timestamp: 1736205486469
-- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-ompl-1.6.0-np126py311h7d8ee0e_8.conda
-  sha256: b0976a791814c54ba2b3445b9daeb3604f4b9ab427c73ab446dc2faf1b884478
-  md5: bd6d62efeacade3e0c2fb551c2932e80
+- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-ompl-1.7.0-py311h2efc760_13.conda
+  sha256: b04da59aed07f10e4b04d2e33616b4a6a2225077c1c01919542ec56308711e79
+  md5: ea119230045fb603e90674f12cb98864
   depends:
   - eigen
   - flann
   - libboost-devel
   - libboost-python-devel
+  - ompl >=1.7.0,<1.8.0a0
   - python
   - ros-humble-ros-workspace
-  - ros2-distro-mutex 0.6.* humble_*
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  - ucrt >=10.0.20348.0
-  - ompl >=1.6.0,<1.7.0a0
+  - ros2-distro-mutex 0.7.* humble_*
+  - ompl >=1.7.0,<1.8.0a0
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
   - flann >=1.9.2,<1.9.3.0a0
-  - python_abi 3.11.* *_cp311
-  - libboost >=1.86.0,<1.87.0a0
   - libboost-python >=1.86.0,<1.87.0a0
-  - ros2-distro-mutex >=0.6.0,<0.7.0a0
-  - numpy >=1.26.4,<2.0a0
+  - libboost >=1.86.0,<1.87.0a0
+  - python_abi 3.11.* *_cp311
   license: BSD-3-Clause
-  size: 14563
-  timestamp: 1736205629987
+  size: 9627
+  timestamp: 1753308404017
 - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-orocos-kdl-vendor-0.2.5-np126py311h2c3b307_7.conda
   sha256: e997964f67ff46ca7706bc1089356fa53fbd5bf16884276db9e81847d1f1ce61
   md5: 47a09379786898355d869b4530a39e33
@@ -55563,29 +55129,29 @@ packages:
   license: BSD-3-Clause
   size: 25427
   timestamp: 1736207250763
-- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-orocos-kdl-vendor-0.2.5-np126py311h7d8ee0e_8.conda
-  sha256: d368f19c578e819baa51044d5e2562e1a332efed372c5d4b934bc34d0196ae37
-  md5: be4ce02ce58ed46c39153b261c3c3cb1
+- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-orocos-kdl-vendor-0.2.5-np126py311hd5de103_13.conda
+  sha256: a4bfebb23fe07bcb67263e841004db72e2bbc2df9186d621581eb4675e0ea923
+  md5: d10b3efc18ef0c4496d810af9fe3f5be
   depends:
   - eigen
   - orocos-kdl
   - python
   - ros-humble-eigen3-cmake-module
   - ros-humble-ros-workspace
-  - ros2-distro-mutex 0.6.* humble_*
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - ros2-distro-mutex 0.7.* humble_*
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
   - orocos-kdl >=1.5.1,<1.6.0a0
-  - ros2-distro-mutex >=0.6.0,<0.7.0a0
-  - python_abi 3.11.* *_cp311
   - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
+  - python_abi 3.11.* *_cp311
   license: BSD-3-Clause
-  size: 22110
-  timestamp: 1736210529013
+  size: 23472
+  timestamp: 1753317577873
 - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-osrf-pycommon-2.1.4-np126py311h2c3b307_7.conda
   sha256: 863033b9e42aa983c3cba4d9508dee8e067290a43a97dcab4dd4782e5ba2f835
   md5: 83f4d44a2e14278611c2f27643e71529
@@ -55653,26 +55219,26 @@ packages:
   license: BSD-3-Clause
   size: 65431
   timestamp: 1736205471780
-- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-osrf-pycommon-2.1.4-np126py311h7d8ee0e_8.conda
-  sha256: 2fdb762270a15452c84b118e74ef113915a8f4ea9e3e377793f176fdabaafe51
-  md5: 247dfe667c0b813565832ba48f983265
+- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-osrf-pycommon-2.1.6-np126py311hd5de103_13.conda
+  sha256: dcc6d89ffc1c8dde48b949dff460289469203a212311637808b3a93c6983b3f0
+  md5: 4dcea92f752c9652eac060045e38f361
   depends:
   - importlib-metadata
   - python
   - ros-humble-ros-workspace
-  - ros2-distro-mutex 0.6.* humble_*
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - ros2-distro-mutex 0.7.* humble_*
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - python_abi 3.11.* *_cp311
   - numpy >=1.26.4,<2.0a0
-  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
+  - python_abi 3.11.* *_cp311
   license: BSD-3-Clause
-  size: 60432
-  timestamp: 1736205699363
+  size: 60683
+  timestamp: 1753308348592
 - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-parameter-traits-0.3.9-np126py311h2c3b307_7.conda
   sha256: 6c6bbdae36805ce8c31a633e44268091a305173cb0e929488e2090c83ff444ec
   md5: 105fc6b8ec67226d5673c6d3bb92a920
@@ -55761,9 +55327,9 @@ packages:
   license: BSD-3-Clause
   size: 40076
   timestamp: 1736210266393
-- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-parameter-traits-0.3.9-np126py311h7d8ee0e_8.conda
-  sha256: 7a626e164c97c335811ca61c0039d618be45ee3fa248d7d4cfce69971e810df0
-  md5: 2391a9648216a6b3a137212217b32bac
+- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-parameter-traits-0.5.0-np126py311hd5de103_13.conda
+  sha256: 351f6991c0ed85150ee38f1bc44eef35ea432281cbce6374229ee70874740ebd
+  md5: c34d547c39ca373da6d6b329e02c9244
   depends:
   - fmt
   - python
@@ -55772,20 +55338,20 @@ packages:
   - ros-humble-rsl
   - ros-humble-tcb-span
   - ros-humble-tl-expected
-  - ros2-distro-mutex 0.6.* humble_*
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - ros2-distro-mutex 0.7.* humble_*
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - ros2-distro-mutex >=0.6.0,<0.7.0a0
-  - fmt >=11.0.2,<12.0a0
-  - python_abi 3.11.* *_cp311
+  - fmt >=11.2.0,<11.3.0a0
   - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
+  - python_abi 3.11.* *_cp311
   license: BSD-3-Clause
-  size: 38013
-  timestamp: 1736234693238
+  size: 39632
+  timestamp: 1753333068107
 - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-pilz-industrial-motion-planner-2.5.7-np126py311h2c3b307_7.conda
   sha256: 6ecfe83d6157948a810cacca37f9dee7f30a34047bf0c4eb4861618c7a6b8a42
   md5: 37fea712820ca1393b9e8b47e8cd4334
@@ -55926,6 +55492,44 @@ packages:
   license: BSD-3-Clause
   size: 389667
   timestamp: 1736214803350
+- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-pilz-industrial-motion-planner-2.5.9-np126py311hd5de103_13.conda
+  sha256: 6eb92772dbb980cfdcee04a763095580dce7dad0e3cf2be95421b612285bed61
+  md5: b04dc9f302f27a94d5a10dd1079534bd
+  depends:
+  - python
+  - ros-humble-eigen3-cmake-module
+  - ros-humble-geometry-msgs
+  - ros-humble-moveit-common
+  - ros-humble-moveit-core
+  - ros-humble-moveit-msgs
+  - ros-humble-moveit-ros-move-group
+  - ros-humble-moveit-ros-planning
+  - ros-humble-moveit-ros-planning-interface
+  - ros-humble-orocos-kdl-vendor
+  - ros-humble-pluginlib
+  - ros-humble-rclcpp
+  - ros-humble-ros-workspace
+  - ros-humble-tf2
+  - ros-humble-tf2-eigen
+  - ros-humble-tf2-eigen-kdl
+  - ros-humble-tf2-geometry-msgs
+  - ros-humble-tf2-kdl
+  - ros-humble-tf2-ros
+  - ros2-distro-mutex 0.7.* humble_*
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  - ucrt >=10.0.20348.0
+  - libboost >=1.86.0,<1.87.0a0
+  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
+  - libboost-python >=1.86.0,<1.87.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  size: 511726
+  timestamp: 1753357285006
 - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-pluginlib-5.1.0-np126py311h2c3b307_7.conda
   sha256: 821465f133cb315c28a4d7a71518ad93996ec315d58879202ddeca42523d02ae
   md5: 8a0ad18dba8f14429363c82b394ffbe7
@@ -56007,9 +55611,9 @@ packages:
   license: BSD-3-Clause
   size: 39889
   timestamp: 1736208019378
-- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-pluginlib-5.1.0-np126py311h7d8ee0e_8.conda
-  sha256: b883f8c249ce0c40559fd2ef8bc7b02fad5a6eef19812830bb539c777d8f0340
-  md5: cf32e54b94d3b3f0dedc38c2dd1b33f1
+- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-pluginlib-5.1.0-np126py311hd5de103_13.conda
+  sha256: bec6955cd4d338e529b07cee63a2d34706636a3bae85cf32a42d027a8ca78861
+  md5: b25514d33f0ad30568b973acd797c989
   depends:
   - python
   - ros-humble-ament-index-cpp
@@ -56018,19 +55622,19 @@ packages:
   - ros-humble-rcutils
   - ros-humble-ros-workspace
   - ros-humble-tinyxml2-vendor
-  - ros2-distro-mutex 0.6.* humble_*
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - ros2-distro-mutex 0.7.* humble_*
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - numpy >=1.26.4,<2.0a0
-  - ros2-distro-mutex >=0.6.0,<0.7.0a0
   - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
+  - numpy >=1.26.4,<2.0a0
   license: BSD-3-Clause
-  size: 36681
-  timestamp: 1736228418641
+  size: 37957
+  timestamp: 1753321541610
 - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-pybind11-vendor-2.4.2-np126py311h2c3b307_7.conda
   sha256: d7f4c3cebea413e40f40847e9e4f0511ab3058d5137c7f950c16139fb762a60a
   md5: 326e34fc0e60d584efd941678efbe030
@@ -56098,26 +55702,26 @@ packages:
   license: BSD-3-Clause
   size: 21191
   timestamp: 1736206441239
-- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-pybind11-vendor-2.4.2-np126py311h7d8ee0e_8.conda
-  sha256: 43edc9275d294ac17713614243cf8f3f4c2b3e0621af373e5ec6509d62525c0f
-  md5: e2aa6817b59b63a27cbc2271188a30bc
+- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-pybind11-vendor-2.4.2-np126py311hd5de103_13.conda
+  sha256: c1d31e48ad6a035f7baa5efb104087021f415b2b85994e16f5ab359419477b11
+  md5: d113fafee46ebb90e3af7b2f60a083d1
   depends:
   - pybind11
   - python
   - ros-humble-ros-workspace
-  - ros2-distro-mutex 0.6.* humble_*
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - ros2-distro-mutex 0.7.* humble_*
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
   - python_abi 3.11.* *_cp311
   - numpy >=1.26.4,<2.0a0
-  - ros2-distro-mutex >=0.6.0,<0.7.0a0
   license: BSD-3-Clause
-  size: 17964
-  timestamp: 1736207842787
+  size: 19166
+  timestamp: 1753312981015
 - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-python-cmake-module-0.10.0-np126py311h2c3b307_7.conda
   sha256: 040ed75c114ffa7178b74812316b1dcfe81e046abbd6afcd87e395fd681f5072
   md5: 21c05e6bb72f74510b4a74d29d220c46
@@ -56181,25 +55785,48 @@ packages:
   license: BSD-3-Clause
   size: 26414
   timestamp: 1736207224539
-- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-python-cmake-module-0.10.0-np126py311h7d8ee0e_8.conda
-  sha256: 83b6c21507d05546781c03252ed03786bbe8f0d5f46ab5fccae1ea1d2cfbcc25
-  md5: d1d29dd5cc5a45415734b11f3b233ec9
+- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-python-cmake-module-0.10.0-np126py311hd5de103_13.conda
+  sha256: f2ce8f1c5867c19a1de7d249fd3b8f87f1db2e63be152da56bde6ad59ad7c329
+  md5: 2ed431dded2a08a43f8071964a722aaa
   depends:
   - python
   - ros-humble-ros-workspace
-  - ros2-distro-mutex 0.6.* humble_*
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - ros2-distro-mutex 0.7.* humble_*
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - python_abi 3.11.* *_cp311
-  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
   - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
   license: BSD-3-Clause
-  size: 23075
-  timestamp: 1736210433092
+  size: 24422
+  timestamp: 1753317472308
+- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-python-orocos-kdl-vendor-0.2.5-np126py311hd5de103_13.conda
+  sha256: 5206eedccc925183e29cc15766b337b6da91432e242a3dd3133e71201ab2df31
+  md5: a6bf34439cabae8383860d5228bfab7e
+  depends:
+  - python
+  - python-orocos-kdl
+  - ros-humble-orocos-kdl-vendor
+  - ros-humble-pybind11-vendor
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.7.* humble_*
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  - ucrt >=10.0.20348.0
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
+  - python-orocos-kdl >=1.5.1,<1.6.0a0
+  license: BSD-3-Clause
+  size: 23574
+  timestamp: 1753318949933
 - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-random-numbers-2.0.1-np126py311h2c3b307_7.conda
   sha256: fdbdcac69c7468e288822dc59e47c586a5a8e96a189ac622706554ed7f7de2b4
   md5: 89f440244dfc37e87436e4854a7a2e5e
@@ -56274,28 +55901,28 @@ packages:
   license: BSD-3-Clause
   size: 40106
   timestamp: 1736206493605
-- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-random-numbers-2.0.1-np126py311h7d8ee0e_8.conda
-  sha256: deea91df2c74b0eee9c4b2f71f99e757a628544cb34de3b6b920bba7fe23eebd
-  md5: 4822436ed5bd685c5267b0140384ae06
+- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-random-numbers-2.0.1-np126py311hd5de103_13.conda
+  sha256: 2764aeb19f0676071241cd8d0a87ab11740f10210c3df8e47c5d4a5d0c5699cc
+  md5: 4a890062f0ee3623f06a232aa880b44b
   depends:
   - libboost
   - libboost-devel
   - python
   - ros-humble-ros-workspace
-  - ros2-distro-mutex 0.6.* humble_*
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - ros2-distro-mutex 0.7.* humble_*
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - numpy >=1.26.4,<2.0a0
-  - libboost >=1.86.0,<1.87.0a0
-  - ros2-distro-mutex >=0.6.0,<0.7.0a0
   - python_abi 3.11.* *_cp311
+  - libboost >=1.86.0,<1.87.0a0
+  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
   license: BSD-3-Clause
-  size: 53773
-  timestamp: 1736208008796
+  size: 53501
+  timestamp: 1753312947737
 - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-rcl-5.3.9-np126py311h2c3b307_7.conda
   sha256: 10ae7ba2e260747d811a79f9bac167d78b906180b4345dfe4ec34405eaa4eb6c
   md5: a13422c002b683a1ff44d8ebd63d45b3
@@ -56396,9 +56023,9 @@ packages:
   license: BSD-3-Clause
   size: 158794
   timestamp: 1736209244299
-- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-rcl-5.3.9-np126py311h7d8ee0e_8.conda
-  sha256: 968d621c49f49ec065c5c16a1a0db8643615dd96fa39975dd5773ac87dc3d677
-  md5: 2a6a6cb02f1c4c75b4e6f43de7992606
+- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-rcl-5.3.9-np126py311hd5de103_13.conda
+  sha256: 3e5b958c700e8d031b4b8033350cdbac633c17176f93037d80392e5f231a3fc8
+  md5: 9ff8a1acad810a154fb68762ea715ba2
   depends:
   - python
   - ros-humble-rcl-interfaces
@@ -56411,19 +56038,19 @@ packages:
   - ros-humble-ros-workspace
   - ros-humble-rosidl-runtime-c
   - ros-humble-tracetools
-  - ros2-distro-mutex 0.6.* humble_*
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - ros2-distro-mutex 0.7.* humble_*
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - ros2-distro-mutex >=0.6.0,<0.7.0a0
-  - numpy >=1.26.4,<2.0a0
   - python_abi 3.11.* *_cp311
+  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
   license: BSD-3-Clause
-  size: 175656
-  timestamp: 1736232420068
+  size: 173366
+  timestamp: 1753328900761
 - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-rcl-action-5.3.9-np126py311h2c3b307_7.conda
   sha256: 1d9c675c6c935f1accde23409dd94692da59aa0c7f39c93bf55b1ec9a5f26b9a
   md5: f735d3c83c48ffb6fbfd2a989a9d2325
@@ -56506,9 +56133,9 @@ packages:
   license: BSD-3-Clause
   size: 71402
   timestamp: 1736209441144
-- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-rcl-action-5.3.9-np126py311h7d8ee0e_8.conda
-  sha256: 52315fc6ec016b118ee36acaa728cab2bdf61b4b8b7cca52b5cd6e74fac07c3b
-  md5: ba8df64dac3465af63782f9e2f5447d0
+- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-rcl-action-5.3.9-np126py311hd5de103_13.conda
+  sha256: ee4b1d50c860f8eaacca0e092a519909a60f955063e31d2131564e0b5dfc91e8
+  md5: 3e74a7576218ff4693353cf1f4750757
   depends:
   - python
   - ros-humble-action-msgs
@@ -56517,19 +56144,19 @@ packages:
   - ros-humble-rmw
   - ros-humble-ros-workspace
   - ros-humble-rosidl-runtime-c
-  - ros2-distro-mutex 0.6.* humble_*
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - ros2-distro-mutex 0.7.* humble_*
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - ros2-distro-mutex >=0.6.0,<0.7.0a0
   - numpy >=1.26.4,<2.0a0
   - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
   license: BSD-3-Clause
-  size: 78518
-  timestamp: 1736233159043
+  size: 79978
+  timestamp: 1753330353128
 - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-rcl-interfaces-1.2.1-np126py311h2c3b307_7.conda
   sha256: f7ee5507ab4d45876a5aa65cb1dd06b704556dbcae158ec66571032488e94566
   md5: 96f7f4a23f6f1fdfa3716244d2c6a003
@@ -56601,27 +56228,27 @@ packages:
   license: BSD-3-Clause
   size: 279971
   timestamp: 1736208559697
-- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-rcl-interfaces-1.2.1-np126py311h7d8ee0e_8.conda
-  sha256: 9f838fcc95b72784e549a91f1b81051f5e237524682d24412145d929534d0464
-  md5: 445733b8f84d94348ba16766492f4433
+- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-rcl-interfaces-1.2.1-np126py311hd5de103_13.conda
+  sha256: 91e3a3b8e5125fbe93d1ed3b11968c0aabfa45738638942904ababc447f71424
+  md5: ca443aca57d2a760490c1e8327d35b9b
   depends:
   - python
   - ros-humble-builtin-interfaces
   - ros-humble-ros-workspace
   - ros-humble-rosidl-default-runtime
-  - ros2-distro-mutex 0.6.* humble_*
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - ros2-distro-mutex 0.7.* humble_*
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - python_abi 3.11.* *_cp311
   - numpy >=1.26.4,<2.0a0
-  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
   license: BSD-3-Clause
-  size: 290056
-  timestamp: 1736230511942
+  size: 293584
+  timestamp: 1753324150773
 - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-rcl-lifecycle-5.3.9-np126py311h2c3b307_7.conda
   sha256: 0442516d972104da2fca112d46cf52d5c1c8d3c1d786a45e1b23205a796a851f
   md5: 093a73d1b590288701b83b85acd5c6da
@@ -56709,9 +56336,9 @@ packages:
   license: BSD-3-Clause
   size: 51102
   timestamp: 1736209417787
-- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-rcl-lifecycle-5.3.9-np126py311h7d8ee0e_8.conda
-  sha256: 072dbaedc2463e7e1897baa56dca748449e168ad5b511d88f839e324b874c048
-  md5: 4d7cce199ef61f0b6c8fa5ae4e4c172e
+- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-rcl-lifecycle-5.3.9-np126py311hd5de103_13.conda
+  sha256: 673678008c9033f145e337329129384eabb05147e46ced6936688953c956bd6e
+  md5: 316b628523f1f54d4e4da4f4d8f3e69c
   depends:
   - python
   - ros-humble-lifecycle-msgs
@@ -56721,19 +56348,19 @@ packages:
   - ros-humble-ros-workspace
   - ros-humble-rosidl-runtime-c
   - ros-humble-tracetools
-  - ros2-distro-mutex 0.6.* humble_*
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - ros2-distro-mutex 0.7.* humble_*
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
   - numpy >=1.26.4,<2.0a0
-  - ros2-distro-mutex >=0.6.0,<0.7.0a0
   - python_abi 3.11.* *_cp311
   license: BSD-3-Clause
-  size: 53174
-  timestamp: 1736233050015
+  size: 54793
+  timestamp: 1753330067524
 - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-rcl-logging-interface-2.3.1-np126py311h2c3b307_7.conda
   sha256: b0d434c043b68210f7c72b498a7a8ba8803b43fa007a7585803e83eeeeef14eb
   md5: 54b78e1ff83cc6f0f6612f23ed5dcaf5
@@ -56800,26 +56427,26 @@ packages:
   license: BSD-3-Clause
   size: 32814
   timestamp: 1736207935708
-- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-rcl-logging-interface-2.3.1-np126py311h7d8ee0e_8.conda
-  sha256: 0019b305c1ac6064d12be06783b559976582c0969460a9007c40a577eaa52d3c
-  md5: 5b7ba8029a57f82472706060164da5d1
+- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-rcl-logging-interface-2.3.1-np126py311hd5de103_13.conda
+  sha256: 0fe584e991a65d3b9079b1526e9130d735be15265116e3ab7938a9216f13e476
+  md5: 69673f8fe1c5cd4295f84a4968625908
   depends:
   - python
   - ros-humble-rcutils
   - ros-humble-ros-workspace
-  - ros2-distro-mutex 0.6.* humble_*
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - ros2-distro-mutex 0.7.* humble_*
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - ros2-distro-mutex >=0.6.0,<0.7.0a0
-  - python_abi 3.11.* *_cp311
   - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
+  - python_abi 3.11.* *_cp311
   license: BSD-3-Clause
-  size: 33066
-  timestamp: 1736227977557
+  size: 34689
+  timestamp: 1753320909693
 - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-rcl-logging-spdlog-2.3.1-np126py311h6a008e1_7.conda
   sha256: 6933b2931b5a38f5e589352868e98f1598cffa12fb0f9442c58528b6cd24319f
   md5: a9866d37cdb01c4abef05ab3fe905f81
@@ -56908,9 +56535,9 @@ packages:
   license: BSD-3-Clause
   size: 37695
   timestamp: 1736208011425
-- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-rcl-logging-spdlog-2.3.1-np126py311h1c95eb5_8.conda
-  sha256: c8a42f1045286a8e18e1c6cdf4e29e83afd0f36dbdd4f52b0af1e461fcab2711
-  md5: 280af60cb77377735f928ae6c974fdea
+- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-rcl-logging-spdlog-2.3.1-np126py311hc120487_13.conda
+  sha256: 078fdb62c4f57ffe34a9dd9419e2be713f0ac3fcb7191e6e4654c08f65f2c39f
+  md5: d0b5d34c089633037b40dd8f34f83be3
   depends:
   - python
   - ros-humble-rcl-logging-interface
@@ -56918,21 +56545,21 @@ packages:
   - ros-humble-rcutils
   - ros-humble-ros-workspace
   - ros-humble-spdlog-vendor
-  - ros2-distro-mutex 0.6.* humble_*
+  - ros2-distro-mutex 0.7.* humble_*
   - spdlog
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - ros2-distro-mutex >=0.6.0,<0.7.0a0
-  - spdlog >=1.14.1,<1.15.0a0
-  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
   - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
+  - spdlog >=1.15.3,<1.16.0a0
   license: BSD-3-Clause
-  size: 37495
-  timestamp: 1736228384143
+  size: 39002
+  timestamp: 1753321462221
 - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-rcl-yaml-param-parser-5.3.9-np126py311h2c3b307_7.conda
   sha256: 6256cc8c439c4fbb71a96c954e97ab01b17dde7a9445cee784097f0d87ad49fb
   md5: e9af8ba6637a6d1260e0c042ba3f675a
@@ -57019,31 +56646,31 @@ packages:
   license: BSD-3-Clause
   size: 46923
   timestamp: 1736208002863
-- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-rcl-yaml-param-parser-5.3.9-np126py311h7d8ee0e_8.conda
-  sha256: 7a0b5875d23aaac29f1c6063fc70c66caaf38a520aefc50e290bfe78a0f87a13
-  md5: 5b024b0e98607b19d41abd8568de9a4e
+- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-rcl-yaml-param-parser-5.3.9-np126py311hd5de103_13.conda
+  sha256: 85d4c32f9e52226fa752cdf146cacc9ecb2cf1654beaca1b95bfbb25992098f0
+  md5: 256119470cd02d5929d5bd42c86deef9
   depends:
   - python
   - ros-humble-libyaml-vendor
   - ros-humble-rmw
   - ros-humble-ros-workspace
-  - ros2-distro-mutex 0.6.* humble_*
+  - ros2-distro-mutex 0.7.* humble_*
   - yaml
   - yaml-cpp
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - yaml-cpp >=0.8.0,<0.9.0a0
-  - yaml >=0.2.5,<0.3.0a0
-  - numpy >=1.26.4,<2.0a0
   - python_abi 3.11.* *_cp311
-  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
+  - yaml-cpp >=0.8.0,<0.9.0a0
+  - numpy >=1.26.4,<2.0a0
+  - yaml >=0.2.5,<0.3.0a0
   license: BSD-3-Clause
-  size: 50124
-  timestamp: 1736228353041
+  size: 51811
+  timestamp: 1753321376262
 - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-rclcpp-16.0.11-np126py311h2c3b307_7.conda
   sha256: e89abf81843882a61bb12febcc2011071dd7484808939b6a906dc1172f2ac9ec
   md5: bdafe149f67cb95d73c343c58b13420d
@@ -57166,9 +56793,9 @@ packages:
   license: BSD-3-Clause
   size: 647301
   timestamp: 1736209545747
-- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-rclcpp-16.0.11-np126py311h7d8ee0e_8.conda
-  sha256: dd971d6c532892b96a4e068320fa3a1f0da4bc046825eca2995bdb46cab1d091
-  md5: 54b3ca55d8215b2b9c6d321673a65745
+- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-rclcpp-16.0.13-np126py311hd5de103_13.conda
+  sha256: aa879880ab696995e848ef6cb7a112c3abf514c3761689777f5105bca2f07f44
+  md5: 2d45fc89bdf5467b691662c84fea25d2
   depends:
   - python
   - ros-humble-ament-index-cpp
@@ -57187,19 +56814,19 @@ packages:
   - ros-humble-rosidl-typesupport-cpp
   - ros-humble-statistics-msgs
   - ros-humble-tracetools
-  - ros2-distro-mutex 0.6.* humble_*
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - ros2-distro-mutex 0.7.* humble_*
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
   - numpy >=1.26.4,<2.0a0
   - python_abi 3.11.* *_cp311
   license: BSD-3-Clause
-  size: 589885
-  timestamp: 1736233698812
+  size: 587686
+  timestamp: 1753330840560
 - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-rclcpp-action-16.0.11-np126py311h2c3b307_7.conda
   sha256: ae76ddfe66ceed018f32162b3654b9f0744f9ab3418d73052419268590986f3a
   md5: faf068b4ec298d2edc237eec1fb0058b
@@ -57285,9 +56912,9 @@ packages:
   license: BSD-3-Clause
   size: 99273
   timestamp: 1736209671055
-- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-rclcpp-action-16.0.11-np126py311h7d8ee0e_8.conda
-  sha256: 9a0f0e8e7f247ce12b14df4aaeafe1a83f3eeaad4cc9cf8b600ec2787895af9f
-  md5: aac85beef035c1967cc57f8f56f4e03a
+- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-rclcpp-action-16.0.13-np126py311hd5de103_13.conda
+  sha256: 52c12c1f1a985809bb58ed028ccfcbcdcd7eebcb06ae21c6c8a347976cc79cd4
+  md5: 9b7d617efcbf88f7aa01fd63035af1ed
   depends:
   - python
   - ros-humble-action-msgs
@@ -57297,19 +56924,19 @@ packages:
   - ros-humble-rcpputils
   - ros-humble-ros-workspace
   - ros-humble-rosidl-runtime-c
-  - ros2-distro-mutex 0.6.* humble_*
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - ros2-distro-mutex 0.7.* humble_*
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - ros2-distro-mutex >=0.6.0,<0.7.0a0
-  - numpy >=1.26.4,<2.0a0
   - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
+  - numpy >=1.26.4,<2.0a0
   license: BSD-3-Clause
-  size: 99691
-  timestamp: 1736234195325
+  size: 101594
+  timestamp: 1753331618880
 - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-rclcpp-components-16.0.11-np126py311h2c3b307_7.conda
   sha256: 4996d9feb2950e045e62c5682f8a7a7518a2fb6926d2dec57ccb371f0e4b8a5d
   md5: 21a7182fdfca3243ff32649e2a5c2fd8
@@ -57389,9 +57016,9 @@ packages:
   license: BSD-3-Clause
   size: 114850
   timestamp: 1736209656525
-- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-rclcpp-components-16.0.11-np126py311h7d8ee0e_8.conda
-  sha256: 67e242b50afb5a51d6db5a11b48011cdbb9863e1e4af280a94c13436f58d52d3
-  md5: 35ae686a3275e8cd65d9db3972cd8a41
+- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-rclcpp-components-16.0.13-np126py311hd5de103_13.conda
+  sha256: 24f0320c3483a180c9f256fcbb71aa4a6dd0181d5ca5964db24c221b9337c28f
+  md5: 3c894422d7abef06f40d1f12c21db5c1
   depends:
   - python
   - ros-humble-ament-index-cpp
@@ -57399,19 +57026,19 @@ packages:
   - ros-humble-composition-interfaces
   - ros-humble-rclcpp
   - ros-humble-ros-workspace
-  - ros2-distro-mutex 0.6.* humble_*
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - ros2-distro-mutex 0.7.* humble_*
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
   - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
   - numpy >=1.26.4,<2.0a0
-  - ros2-distro-mutex >=0.6.0,<0.7.0a0
   license: BSD-3-Clause
-  size: 110448
-  timestamp: 1736234151125
+  size: 109708
+  timestamp: 1753331518648
 - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-rclcpp-lifecycle-16.0.11-np126py311h2c3b307_7.conda
   sha256: 977702f2e3c4cccd71a3dba3071f47a55a42997ca30ae5d2d3b39f32002cb4d9
   md5: 5756a6d5aa6a219e664706a6e2be371f
@@ -57494,9 +57121,9 @@ packages:
   license: BSD-3-Clause
   size: 106385
   timestamp: 1736209631324
-- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-rclcpp-lifecycle-16.0.11-np126py311h7d8ee0e_8.conda
-  sha256: c0bf6297b7451bbc6e747c3ccd0eb0acd44503b3766f191920e02f5a2aef48a6
-  md5: 616ae9bf4376263e6b2800a5df3fdbb8
+- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-rclcpp-lifecycle-16.0.13-np126py311hd5de103_13.conda
+  sha256: 48752c0151c218f9ea27fb9b3bfbac0c0b04404d2ed6ea62f1e7437f7c8514fc
+  md5: 44f3a3f36ed015d9c7c5fb3dde3b612b
   depends:
   - python
   - ros-humble-lifecycle-msgs
@@ -57505,19 +57132,19 @@ packages:
   - ros-humble-rmw
   - ros-humble-ros-workspace
   - ros-humble-rosidl-typesupport-cpp
-  - ros2-distro-mutex 0.6.* humble_*
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - ros2-distro-mutex 0.7.* humble_*
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
   - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
   - python_abi 3.11.* *_cp311
-  - ros2-distro-mutex >=0.6.0,<0.7.0a0
   license: BSD-3-Clause
-  size: 96588
-  timestamp: 1736234055664
+  size: 96874
+  timestamp: 1753331329373
 - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-rclpy-3.3.15-np126py311h2c3b307_7.conda
   sha256: e4aacf4314377feddd6716374afd67754887f6939b31a1a74e602c38a0cb6f14
   md5: 1f1c532e2fa65c5e7600a61c1b75dee3
@@ -57638,9 +57265,9 @@ packages:
   license: BSD-3-Clause
   size: 564299
   timestamp: 1736209485959
-- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-rclpy-3.3.15-np126py311h7d8ee0e_8.conda
-  sha256: 5fd540a80ac06744fd399188771cc1a3d8f71007a83600a17c67ee43aeb70623
-  md5: 17fe4ff9895c5c5ecde5c2e48d048c46
+- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-rclpy-3.3.16-np126py311hd5de103_13.conda
+  sha256: 944cf214aed474cc2e61558f15661678785b3d072c26591802954026e41f9882
+  md5: a91670aa7988d383483bfae2059118f2
   depends:
   - python
   - ros-humble-ament-index-python
@@ -57658,19 +57285,20 @@ packages:
   - ros-humble-rosidl-runtime-c
   - ros-humble-rpyutils
   - ros-humble-unique-identifier-msgs
-  - ros2-distro-mutex 0.6.* humble_*
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - ros2-distro-mutex 0.7.* humble_*
+  - typing_extensions
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - python_abi 3.11.* *_cp311
-  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
   - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
   license: BSD-3-Clause
-  size: 448732
-  timestamp: 1736233391752
+  size: 457552
+  timestamp: 1753330658786
 - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-rcpputils-2.4.4-np126py311h2c3b307_7.conda
   sha256: ea7cb5abd4848b5e572bbc9d2657abc6754be95851ba55a99fa5b488e1e7e689
   md5: daf7ab15c9eea467521433f40260221b
@@ -57738,26 +57366,26 @@ packages:
   license: BSD-3-Clause
   size: 75883
   timestamp: 1736207693872
-- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-rcpputils-2.4.4-np126py311h7d8ee0e_8.conda
-  sha256: 38575d38bb86ded0328e909e9396660a4d571093fb4c6d813dce0ba49c860ab5
-  md5: 9d06f77f27ef61b25a2c982dab14a741
+- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-rcpputils-2.4.5-np126py311hd5de103_13.conda
+  sha256: bd98f41b51fb8dfe2ce09b01bd76fa4e00d0476097d4289bdc858ed1cf79d09d
+  md5: 61a0d289071a13c4eabc43d20203044e
   depends:
   - python
   - ros-humble-rcutils
   - ros-humble-ros-workspace
-  - ros2-distro-mutex 0.6.* humble_*
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - ros2-distro-mutex 0.7.* humble_*
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
   - python_abi 3.11.* *_cp311
-  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - numpy >=1.26.4,<2.0a0
   license: BSD-3-Clause
-  size: 82163
-  timestamp: 1736227631845
+  size: 85781
+  timestamp: 1753319909035
 - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-rcutils-5.1.6-np126py311h2c3b307_7.conda
   sha256: 57d309d38369ed7e7b6d3d204da7efff54b97a326386a112b4a32a765a74efcb
   md5: ea3588b5f23a59c1e4d30ad0cb93cb09
@@ -57821,25 +57449,25 @@ packages:
   license: BSD-3-Clause
   size: 109229
   timestamp: 1736207572077
-- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-rcutils-5.1.6-np126py311h7d8ee0e_8.conda
-  sha256: 45212b502b32fb083c1c7a7854302872ed43faeb0426a3744de6972da0453857
-  md5: 193ec0bee51e035d30dd7d77f3998bdf
+- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-rcutils-5.1.6-np126py311hd5de103_13.conda
+  sha256: 4ae7c6c7b95615fce6ba3e38bba25ce50d53d06878730f7a796bdc45ea14da27
+  md5: 7f7bdac9548f9a1388b7f9d7d40d5509
   depends:
   - python
   - ros-humble-ros-workspace
-  - ros2-distro-mutex 0.6.* humble_*
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - ros2-distro-mutex 0.7.* humble_*
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - python_abi 3.11.* *_cp311
-  - ros2-distro-mutex >=0.6.0,<0.7.0a0
   - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
   license: BSD-3-Clause
-  size: 120846
-  timestamp: 1736227069524
+  size: 122738
+  timestamp: 1753319362169
 - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-realtime-tools-2.10.0-np126py311h2c3b307_7.conda
   sha256: 5ac4895537b18d0ded6c0b2e16f8fc599d47a41f883fd54c13b5a851db97cec3
   md5: b8ae7dc734b098738720af49bfb0bf4d
@@ -57919,28 +57547,30 @@ packages:
   license: BSD-3-Clause
   size: 58902
   timestamp: 1736210310408
-- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-realtime-tools-2.10.0-np126py311h7d8ee0e_8.conda
-  sha256: be0486d00f5abfa0a160ded6e2db252b641f30191943e65c3cd6c934aadce845
-  md5: abb33b0bf62e3b4eb03c6be0aa8b27cb
+- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-realtime-tools-2.14.0-np126py311hd5de103_13.conda
+  sha256: 6c6be40a4e68bee6c99d361ed7f5d2bb834335984f125191c11466a32715764c
+  md5: 61580e9b01bd3ad953a4f6eaef43f93e
   depends:
+  - libboost-devel
   - python
   - ros-humble-ament-cmake
   - ros-humble-rclcpp
   - ros-humble-rclcpp-action
   - ros-humble-ros-workspace
-  - ros2-distro-mutex 0.6.* humble_*
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - ros2-distro-mutex 0.7.* humble_*
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - ros2-distro-mutex >=0.6.0,<0.7.0a0
-  - numpy >=1.26.4,<2.0a0
   - python_abi 3.11.* *_cp311
+  - numpy >=1.26.4,<2.0a0
+  - libboost >=1.86.0,<1.87.0a0
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
   license: BSD-3-Clause
-  size: 76817
-  timestamp: 1736234768776
+  size: 70840
+  timestamp: 1753333529484
 - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-resource-retriever-3.1.2-np126py311h2c3b307_7.conda
   sha256: 1c09c47ff836f88bb5b16d050987b2dfd7f0b0449d5cf6f1e4d5e1a9ccf85cb7
   md5: 5d393b257fd1d2be98d0949d7e6d480b
@@ -58015,28 +57645,28 @@ packages:
   license: BSD-3-Clause
   size: 40557
   timestamp: 1736207484612
-- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-resource-retriever-3.1.2-np126py311h7d8ee0e_8.conda
-  sha256: 43d624bd4e9281febf749379893451144c3b1c79b64005f982b17a04855f4117
-  md5: 4d11b9d38fde39ab45a38431f866a535
+- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-resource-retriever-3.1.3-np126py311hd5de103_13.conda
+  sha256: 21fbe05b2b77efe6cf2ea73b70477d21409bab218852334173e8459e8ad7cf6c
+  md5: 31c3dcada28548e0ae085d51032094bd
   depends:
   - python
   - ros-humble-ament-index-cpp
   - ros-humble-ament-index-python
   - ros-humble-libcurl-vendor
   - ros-humble-ros-workspace
-  - ros2-distro-mutex 0.6.* humble_*
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - ros2-distro-mutex 0.7.* humble_*
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
   - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
   - python_abi 3.11.* *_cp311
-  - ros2-distro-mutex >=0.6.0,<0.7.0a0
   license: BSD-3-Clause
-  size: 41997
-  timestamp: 1736226346475
+  size: 45233
+  timestamp: 1753319001567
 - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-rmw-6.1.2-np126py311h2c3b307_7.conda
   sha256: b52718f33a8153f3b42703f082ddd4be86aa651fb5e451b1cdb3c0173a0194c9
   md5: c39366fc5b2a6f2add7877255b717855
@@ -58107,27 +57737,27 @@ packages:
   license: BSD-3-Clause
   size: 86870
   timestamp: 1736207908470
-- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-rmw-6.1.2-np126py311h7d8ee0e_8.conda
-  sha256: c72d99bdb14f6569b9f1bd71114407174824112f9d417e835009805a005bb703
-  md5: c4b5f8c50cffe03d9ce549d62576db6e
+- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-rmw-6.1.2-np126py311hd5de103_13.conda
+  sha256: ba14411a402b68e9bacc4307967e49a02b32deea36474b1cd6375694bb66b1cd
+  md5: 388627b5da544a429b781c7df595cfb8
   depends:
   - python
   - ros-humble-rcutils
   - ros-humble-ros-workspace
   - ros-humble-rosidl-runtime-c
-  - ros2-distro-mutex 0.6.* humble_*
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - ros2-distro-mutex 0.7.* humble_*
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - ros2-distro-mutex >=0.6.0,<0.7.0a0
   - numpy >=1.26.4,<2.0a0
   - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
   license: BSD-3-Clause
-  size: 91554
-  timestamp: 1736228001743
+  size: 93014
+  timestamp: 1753320643957
 - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-rmw-connextdds-0.11.3-np126py311h2c3b307_7.conda
   sha256: ae04af290fef3c62a8f1b21fdaeb05e082ebb817c8d3fecca0b81c9b9aa57795
   md5: c5a7885985da107e73ef7d888bd7f7ad
@@ -58199,27 +57829,27 @@ packages:
   license: BSD-3-Clause
   size: 28809
   timestamp: 1736208689978
-- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-rmw-connextdds-0.11.3-np126py311h7d8ee0e_8.conda
-  sha256: 7e42612f758733a760405eb75e9a795d242590d425569f090de3f0a48e18eec2
-  md5: 5726784f7e6f2ad02f685e20f2971013
+- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-rmw-connextdds-0.11.3-np126py311hd5de103_13.conda
+  sha256: 56cb159f2ec563c30fc75bfedf12a2a998b6a2fc1882888a540e85270eef54db
+  md5: 760150258fa6391cf20caa50df529d83
   depends:
   - python
   - ros-humble-ament-cmake
   - ros-humble-rmw-connextdds-common
   - ros-humble-ros-workspace
-  - ros2-distro-mutex 0.6.* humble_*
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - ros2-distro-mutex 0.7.* humble_*
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
   - python_abi 3.11.* *_cp311
   - numpy >=1.26.4,<2.0a0
   license: BSD-3-Clause
-  size: 25566
-  timestamp: 1736230958677
+  size: 27018
+  timestamp: 1753325094575
 - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-rmw-connextdds-common-0.11.3-np126py311h2c3b307_7.conda
   sha256: 666b87de857aed1afb0479baae9017c089b80e047fd05520bd9d8bc19d076cd1
   md5: 5bf8c723bf885e2e2cc2968628a2a5be
@@ -58334,9 +57964,9 @@ packages:
   license: BSD-3-Clause
   size: 50437
   timestamp: 1736208539707
-- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-rmw-connextdds-common-0.11.3-np126py311h7d8ee0e_8.conda
-  sha256: 02705511ee15cbd2990afef3fabc4ea1be87deb0f3e593e07dbcf03a78dbf75d
-  md5: e5f2db413f15fafc89e1d3388289c4ac
+- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-rmw-connextdds-common-0.11.3-np126py311hd5de103_13.conda
+  sha256: ad2cecd09775200e3946f34b3ba32b16885eceb04ab7c877d650a1778ed81359
+  md5: 7c91da993bfb6b48ed768123e0bd4d20
   depends:
   - python
   - ros-humble-ament-cmake
@@ -58353,19 +57983,19 @@ packages:
   - ros-humble-rosidl-typesupport-introspection-c
   - ros-humble-rosidl-typesupport-introspection-cpp
   - ros-humble-rti-connext-dds-cmake-module
-  - ros2-distro-mutex 0.6.* humble_*
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - ros2-distro-mutex 0.7.* humble_*
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
   - numpy >=1.26.4,<2.0a0
   - python_abi 3.11.* *_cp311
   license: BSD-3-Clause
-  size: 47296
-  timestamp: 1736230440991
+  size: 48568
+  timestamp: 1753323994774
 - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-rmw-cyclonedds-cpp-1.3.4-np126py311h2c3b307_7.conda
   sha256: 612debb54800d9726f553e9cb73da10185b471cf6124482095c9126c55fa8337
   md5: 9aa1791c2bc46e4b260d0b68a25743d0
@@ -58468,9 +58098,9 @@ packages:
   license: BSD-3-Clause
   size: 182617
   timestamp: 1736208547110
-- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-rmw-cyclonedds-cpp-1.3.4-np126py311h7d8ee0e_8.conda
-  sha256: 49077e9e07bcfeb2968b83028eadfac09684e832abd6868b1c918e039a7ceb05
-  md5: 5175c78186419e49274020e3288fa2fe
+- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-rmw-cyclonedds-cpp-1.3.4-np126py311hd5de103_13.conda
+  sha256: 2c7804070a7dd9b1439a9afe778867c4d538e81544214b56e1bd70a47f1fd9f8
+  md5: 44f8cf97a4c17122299ead107b66b534
   depends:
   - python
   - ros-humble-cyclonedds
@@ -58484,19 +58114,19 @@ packages:
   - ros-humble-rosidl-typesupport-introspection-c
   - ros-humble-rosidl-typesupport-introspection-cpp
   - ros-humble-tracetools
-  - ros2-distro-mutex 0.6.* humble_*
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - ros2-distro-mutex 0.7.* humble_*
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
   - python_abi 3.11.* *_cp311
-  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - numpy >=1.26.4,<2.0a0
   license: BSD-3-Clause
-  size: 172125
-  timestamp: 1736230469963
+  size: 175854
+  timestamp: 1753324075661
 - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-rmw-dds-common-1.6.0-np126py311h2c3b307_7.conda
   sha256: 08d5319babf86b0108e5ed517c6fda9accd151ec1236b98b2519629e8d7188c4
   md5: 33ec99fc1512751feb3001c085a7a170
@@ -58579,9 +58209,9 @@ packages:
   license: BSD-3-Clause
   size: 134964
   timestamp: 1736208424627
-- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-rmw-dds-common-1.6.0-np126py311h7d8ee0e_8.conda
-  sha256: 7026940da551e55e321d2f8a0f83114146f19c2a808943ef99b722abc80e5fac
-  md5: 4f173506257429bfc96b119fec312000
+- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-rmw-dds-common-1.6.0-np126py311hd5de103_13.conda
+  sha256: 5c211de5b958de7bde5613fa189256341b8cd8754d9b9f686b1bae64f36dd026
+  md5: e66fd584f3b8958e118a3f170b971c73
   depends:
   - python
   - ros-humble-rcpputils
@@ -58590,19 +58220,19 @@ packages:
   - ros-humble-ros-workspace
   - ros-humble-rosidl-default-runtime
   - ros-humble-rosidl-runtime-cpp
-  - ros2-distro-mutex 0.6.* humble_*
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - ros2-distro-mutex 0.7.* humble_*
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
   - numpy >=1.26.4,<2.0a0
   - python_abi 3.11.* *_cp311
-  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
   license: BSD-3-Clause
-  size: 145823
-  timestamp: 1736229910651
+  size: 150518
+  timestamp: 1753323163199
 - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-rmw-fastrtps-cpp-6.2.7-np126py311h2c3b307_7.conda
   sha256: bd3f3b45a201ba01a88748563554c1a89a0280847e302f4e8c0cf88eab2e9105
   md5: 6b9d566d25ca39278dbb0915a24c871e
@@ -58726,9 +58356,9 @@ packages:
   license: BSD-3-Clause
   size: 111311
   timestamp: 1736208861006
-- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-rmw-fastrtps-cpp-6.2.7-np126py311h7d8ee0e_8.conda
-  sha256: bd3b11b16616af4726c75a94dd8c7d4380718aca0bb4ba61bbb03b7f6eacd2d7
-  md5: 0c3039200d340bdd1cf9232488816f28
+- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-rmw-fastrtps-cpp-6.2.7-np126py311hd5de103_13.conda
+  sha256: 299d30573b56aab42153efc1bd617d9096e3d62734d711bb10ff3c6a7e3872e4
+  md5: 96d188a7f78b34f47a4218bdf216da32
   depends:
   - python
   - ros-humble-ament-cmake
@@ -58747,19 +58377,19 @@ packages:
   - ros-humble-rosidl-typesupport-fastrtps-c
   - ros-humble-rosidl-typesupport-fastrtps-cpp
   - ros-humble-tracetools
-  - ros2-distro-mutex 0.6.* humble_*
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - ros2-distro-mutex 0.7.* humble_*
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
   - numpy >=1.26.4,<2.0a0
-  - ros2-distro-mutex >=0.6.0,<0.7.0a0
   - python_abi 3.11.* *_cp311
   license: BSD-3-Clause
-  size: 142728
-  timestamp: 1736231473475
+  size: 140432
+  timestamp: 1753326397239
 - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-rmw-fastrtps-dynamic-cpp-6.2.7-np126py311h2c3b307_7.conda
   sha256: c51726c6a11aeca2a02cf2ce849cb9a3961dc6e3ad99c6b285097b76d6910e7a
   md5: eaff8fb243ea337bc091e058e6be6c42
@@ -58880,9 +58510,9 @@ packages:
   license: BSD-3-Clause
   size: 137995
   timestamp: 1736208823075
-- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-rmw-fastrtps-dynamic-cpp-6.2.7-np126py311h7d8ee0e_8.conda
-  sha256: 996025453d1dcffa8300c7abd850320b948c49b8a1eb2b04da261796c88d1dcc
-  md5: ab7fe7026bc086439e186fcc24a36da7
+- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-rmw-fastrtps-dynamic-cpp-6.2.7-np126py311hd5de103_13.conda
+  sha256: a3f4c0e83be8d51ba7f5a713d8544af2874c8366a3030bd28e3a36ffefa95328
+  md5: 45b63c29cd4783ad5f8d6c92cacdf41e
   depends:
   - python
   - ros-humble-ament-cmake
@@ -58900,19 +58530,19 @@ packages:
   - ros-humble-rosidl-typesupport-fastrtps-cpp
   - ros-humble-rosidl-typesupport-introspection-c
   - ros-humble-rosidl-typesupport-introspection-cpp
-  - ros2-distro-mutex 0.6.* humble_*
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - ros2-distro-mutex 0.7.* humble_*
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - ros2-distro-mutex >=0.6.0,<0.7.0a0
-  - python_abi 3.11.* *_cp311
   - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
   license: BSD-3-Clause
-  size: 178360
-  timestamp: 1736231316457
+  size: 175454
+  timestamp: 1753326252818
 - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-rmw-fastrtps-shared-cpp-6.2.7-np126py311h2c3b307_7.conda
   sha256: a4cf83a15a7046a4aaf8e71fa121323990e1d1fcc3d9673107a62e6afaca61e1
   md5: 482b56dcd7e9c65df65d8e5030d8ef49
@@ -59019,9 +58649,9 @@ packages:
   license: BSD-3-Clause
   size: 169116
   timestamp: 1736208512886
-- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-rmw-fastrtps-shared-cpp-6.2.7-np126py311h7d8ee0e_8.conda
-  sha256: d83de75243dcdc0327bcbc301e5fa9d1e904b20c222e4379684caca8a2962201
-  md5: deec094545ef36cdf1498ab5286c3cab
+- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-rmw-fastrtps-shared-cpp-6.2.7-np126py311hd5de103_13.conda
+  sha256: 6cf3dc280e3d098e36a04016f3f43b7d9666ff21a790897f087cf8caef5a5d78
+  md5: 031ae6555fd0b2dcb7eaba75ddeaf135
   depends:
   - python
   - ros-humble-ament-cmake
@@ -59036,19 +58666,19 @@ packages:
   - ros-humble-rosidl-typesupport-introspection-c
   - ros-humble-rosidl-typesupport-introspection-cpp
   - ros-humble-tracetools
-  - ros2-distro-mutex 0.6.* humble_*
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - ros2-distro-mutex 0.7.* humble_*
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
   - python_abi 3.11.* *_cp311
-  - ros2-distro-mutex >=0.6.0,<0.7.0a0
   - numpy >=1.26.4,<2.0a0
   license: BSD-3-Clause
-  size: 224926
-  timestamp: 1736230354037
+  size: 221675
+  timestamp: 1753323867527
 - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-rmw-implementation-2.8.4-np126py311h2c3b307_7.conda
   sha256: 552b10a46f29b020745a6fdc90d08c4fefc8515644f921b36b9d936c3e450c55
   md5: 90b5c1f0ad014f6bea537bd10c8d1bd3
@@ -59143,9 +58773,9 @@ packages:
   license: BSD-3-Clause
   size: 47305
   timestamp: 1736208984086
-- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-rmw-implementation-2.8.4-np126py311h7d8ee0e_8.conda
-  sha256: 5b1f22865554648b04724f14aaf3ca6d25e9ec76521fb2059e058dec9c0315dd
-  md5: 117c73bd8756480d2f11604284772fea
+- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-rmw-implementation-2.8.4-np126py311hd5de103_13.conda
+  sha256: 0e66351a21fee78d6f2bd50296562d09d86d04a11971bf018a3fe3dec61f0c42
+  md5: e32a3136ce1ec6d9eccd287c72b6c4ea
   depends:
   - python
   - ros-humble-ament-index-cpp
@@ -59157,19 +58787,20 @@ packages:
   - ros-humble-rmw-fastrtps-dynamic-cpp
   - ros-humble-rmw-implementation-cmake
   - ros-humble-ros-workspace
-  - ros2-distro-mutex 0.6.* humble_*
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - ros2-distro-mutex 0.7.* humble_*
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
+  - fmt >=11.2.0,<11.3.0a0
   - numpy >=1.26.4,<2.0a0
   - python_abi 3.11.* *_cp311
-  - ros2-distro-mutex >=0.6.0,<0.7.0a0
   license: BSD-3-Clause
-  size: 52990
-  timestamp: 1736231850752
+  size: 55097
+  timestamp: 1753327608400
 - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-rmw-implementation-cmake-6.1.2-np126py311h2c3b307_7.conda
   sha256: 9ece7a203f7e44255dfdf812e477a4fed3615f1dabfad00b6f80f09a9043b82b
   md5: e28e1792d5a96e03a9aa3bf27601cb76
@@ -59238,26 +58869,26 @@ packages:
   license: BSD-3-Clause
   size: 27259
   timestamp: 1736207418361
-- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-rmw-implementation-cmake-6.1.2-np126py311h7d8ee0e_8.conda
-  sha256: cddba0aa2802bb54a2405153b8c7a741327c6426201d6b259828daf126647db0
-  md5: f7a601d65caaf5247936a433628ec2bc
+- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-rmw-implementation-cmake-6.1.2-np126py311hd5de103_13.conda
+  sha256: 3f828b8da760faa60221465ce2a4dede5e4286bf87dabb912037f80e5cd4399a
+  md5: a0766e1d4488ceb5de41033ce2f9cfee
   depends:
   - python
   - ros-humble-ament-cmake
   - ros-humble-ros-workspace
-  - ros2-distro-mutex 0.6.* humble_*
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - ros2-distro-mutex 0.7.* humble_*
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
   - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
   - python_abi 3.11.* *_cp311
-  - ros2-distro-mutex >=0.6.0,<0.7.0a0
   license: BSD-3-Clause
-  size: 23970
-  timestamp: 1736226842091
+  size: 25248
+  timestamp: 1753318449142
 - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-robot-state-publisher-3.0.3-np126py311h2c3b307_7.conda
   sha256: a04e232d30a7fac7146a7a36776dd61fb6176c39193699f1fe4409276529e455
   md5: 64734374ee4c9bf82d8fd78dffe7d8f2
@@ -59365,9 +58996,9 @@ packages:
   license: BSD-3-Clause
   size: 219209
   timestamp: 1736210991743
-- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-robot-state-publisher-3.0.3-np126py311h7d8ee0e_8.conda
-  sha256: 1b88cc3933082a475234bfa893ce35f95f69c10482c8e10fb12a22374cb787a3
-  md5: b19787f89c9534e45ed953757496322b
+- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-robot-state-publisher-3.0.3-np126py311hd5de103_13.conda
+  sha256: e05d6bbda41e6e1c5b387c8abe3b1af7b4c5bda941db8c31450233162ae3601e
+  md5: a4b2684445c589e43d1f58a71f3ad3e3
   depends:
   - python
   - ros-humble-builtin-interfaces
@@ -59382,19 +59013,19 @@ packages:
   - ros-humble-std-msgs
   - ros-humble-tf2-ros
   - ros-humble-urdf
-  - ros2-distro-mutex 0.6.* humble_*
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - ros2-distro-mutex 0.7.* humble_*
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
   - python_abi 3.11.* *_cp311
   - numpy >=1.26.4,<2.0a0
-  - ros2-distro-mutex >=0.6.0,<0.7.0a0
   license: BSD-3-Clause
-  size: 181514
-  timestamp: 1736235986352
+  size: 182365
+  timestamp: 1753335461236
 - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-ros-base-0.10.0-np126py311h2c3b307_7.conda
   sha256: fb396d7bc78951c1828f2b68c82c600d43c116ddce42a462eb6f7af31524e16b
   md5: 82b6cb45214797a894f0276266abb79d
@@ -59481,9 +59112,9 @@ packages:
   license: BSD-3-Clause
   size: 21043
   timestamp: 1736214215983
-- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-ros-base-0.10.0-np126py311h7d8ee0e_8.conda
-  sha256: 4c80cf124ec353336f2ad4345eb4a7015c8bdc4afd00071a3ac254ca0f652762
-  md5: 9eb1cbfede9051671bdbd2264845dcff
+- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-ros-base-0.10.0-np126py311hd5de103_13.conda
+  sha256: fafc91e52ab96a1396da0cea86513ae2fd70301475b1941ef1d820ac8f39a7d8
+  md5: 9a1724b7a0685b59ff68f03c8394708e
   depends:
   - python
   - ros-humble-geometry2
@@ -59493,19 +59124,19 @@ packages:
   - ros-humble-ros-workspace
   - ros-humble-rosbag2
   - ros-humble-urdf
-  - ros2-distro-mutex 0.6.* humble_*
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - ros2-distro-mutex 0.7.* humble_*
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - ros2-distro-mutex >=0.6.0,<0.7.0a0
   - numpy >=1.26.4,<2.0a0
   - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
   license: BSD-3-Clause
-  size: 17866
-  timestamp: 1736243578312
+  size: 19026
+  timestamp: 1753353953912
 - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-ros-core-0.10.0-np126py311h2c3b307_7.conda
   sha256: de6f090a8c8b48642c74530f84c5e774c9bf7b2a04a8518c878c6a90be25d37c
   md5: d3a99c7af96484b7a63b2240f83ada73
@@ -59696,9 +59327,9 @@ packages:
   license: BSD-3-Clause
   size: 21715
   timestamp: 1736212102798
-- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-ros-core-0.10.0-np126py311h7d8ee0e_8.conda
-  sha256: 599798e233d7cced340c9e0aac39b6543106756191e222295bbc97dee2d62eba
-  md5: 3a535bccd8931796fa377d9167b666ba
+- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-ros-core-0.10.0-np126py311hd5de103_13.conda
+  sha256: 2617b21ac453ccdc3ca92e8309e04ae4910b20f5e134c0a935bb679350a303c6
+  md5: 18f7a0c81a894a0fbef113661887911d
   depends:
   - python
   - ros-humble-ament-cmake
@@ -59734,19 +59365,19 @@ packages:
   - ros-humble-rosidl-default-runtime
   - ros-humble-sros2
   - ros-humble-sros2-cmake
-  - ros2-distro-mutex 0.6.* humble_*
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - ros2-distro-mutex 0.7.* humble_*
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - numpy >=1.26.4,<2.0a0
   - python_abi 3.11.* *_cp311
-  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
+  - numpy >=1.26.4,<2.0a0
   license: BSD-3-Clause
-  size: 18547
-  timestamp: 1736238342642
+  size: 19674
+  timestamp: 1753341721767
 - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-ros-environment-3.2.2-np126py311h2c3b307_7.conda
   sha256: a3ba1ae288be4d8981a33622c7ce7934f4dbdd93a9faf65dd89f3dba9f0ff735
   md5: 2827f64436920c02631b8b3077433824
@@ -59805,24 +59436,130 @@ packages:
   license: BSD-3-Clause
   size: 20129
   timestamp: 1736205176583
-- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-ros-environment-3.2.2-np126py311h7d8ee0e_8.conda
-  sha256: 695c3f968969b05af45d53b535da9bf8dc81bc3209e1e0e88378bb4523960619
-  md5: 3e0232b6069d994acdf1b1a8836b91bf
+- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-ros-environment-3.2.2-np126py311hd5de103_13.conda
+  sha256: 71484045e7a3ce93c64ea44faf7f49aa798601ea143dcc16ef5caeddbd3dc021
+  md5: 3d3acc24039f3a82c52ecca2c0979f03
   depends:
   - python
+  - ros2-distro-mutex 0.7.* humble_*
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  - ucrt >=10.0.20348.0
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
+  - numpy >=1.26.4,<2.0a0
+  license: BSD-3-Clause
+  size: 17694
+  timestamp: 1753308114637
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-ros-gz-interfaces-0.244.16-np126py311h2c3b307_7.conda
+  sha256: 982eaa974246128811ec8ae10e558ec908b4cdbd159eb161e0b25632dc25c66a
+  md5: b4c266679ea36aabad3516b9953dbbde
+  depends:
+  - python
+  - ros-humble-builtin-interfaces
+  - ros-humble-geometry-msgs
+  - ros-humble-rcl-interfaces
+  - ros-humble-ros-workspace
+  - ros-humble-rosidl-default-runtime
+  - ros-humble-std-msgs
   - ros2-distro-mutex 0.6.* humble_*
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  - ucrt >=10.0.20348.0
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
   - numpy >=1.26.4,<2.0a0
   - python_abi 3.11.* *_cp311
   - ros2-distro-mutex >=0.6.0,<0.7.0a0
   license: BSD-3-Clause
-  size: 16591
-  timestamp: 1736205505436
+  size: 368558
+  timestamp: 1736209560803
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-ros-gz-interfaces-0.244.16-np126py311h65a17ee_5.conda
+  sha256: 73fbf2c1a4ee2004a15bd07448680e4b17b1b523f5f7a105119390e2e62b0f3f
+  md5: 5243f6d0bcb69b40c2f47146aea82e6e
+  depends:
+  - python
+  - ros-humble-builtin-interfaces
+  - ros-humble-geometry-msgs
+  - ros-humble-rcl-interfaces
+  - ros-humble-ros-workspace
+  - ros-humble-rosidl-default-runtime
+  - ros-humble-std-msgs
+  - ros2-distro-mutex 0.6.* humble_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  license: BSD-3-Clause
+  size: 373534
+  timestamp: 1736212147064
+- conda: https://conda.anaconda.org/robostack-humble/osx-64/ros-humble-ros-gz-interfaces-0.244.16-np126py311h8a2294f_7.conda
+  sha256: bbc39f49b248a4da8722d209bfeb107ca5dd5bd20db4a939f2fe724c9c1eeace
+  md5: 535a96be29bcb593657610d42d05c0d5
+  depends:
+  - python
+  - ros-humble-builtin-interfaces
+  - ros-humble-geometry-msgs
+  - ros-humble-rcl-interfaces
+  - ros-humble-ros-workspace
+  - ros-humble-rosidl-default-runtime
+  - ros-humble-std-msgs
+  - ros2-distro-mutex 0.6.* humble_*
+  - __osx >=10.14
+  - libcxx >=19
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - python_abi 3.11.* *_cp311
+  - numpy >=1.26.4,<2.0a0
+  license: BSD-3-Clause
+  size: 327812
+  timestamp: 1736212972271
+- conda: https://conda.anaconda.org/robostack-humble/osx-arm64/ros-humble-ros-gz-interfaces-0.244.16-np126py311h38cf310_6.conda
+  sha256: 6e3bdab983f8beaffc6f153c2d42658b5f34140007d24ca91e7d17da0dbc3074
+  md5: fc149211bacef8dca23f0fb59e65f711
+  depends:
+  - python
+  - ros-humble-builtin-interfaces
+  - ros-humble-geometry-msgs
+  - ros-humble-rcl-interfaces
+  - ros-humble-ros-workspace
+  - ros-humble-rosidl-default-runtime
+  - ros-humble-std-msgs
+  - ros2-distro-mutex 0.6.* humble_*
+  - libcxx >=19
+  - __osx >=11.0
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - numpy >=1.26.4,<2.0a0
+  license: BSD-3-Clause
+  size: 321476
+  timestamp: 1736208896058
+- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-ros-gz-interfaces-0.244.20-np126py311hd5de103_13.conda
+  sha256: 09179b1cb3f6ba997fdb3600fb9fc33f90a470153e5318e72e1b75015d8c7c54
+  md5: 8de2280abecf630ce021e76ed4f2abef
+  depends:
+  - python
+  - ros-humble-builtin-interfaces
+  - ros-humble-geometry-msgs
+  - ros-humble-rcl-interfaces
+  - ros-humble-ros-workspace
+  - ros-humble-rosidl-default-runtime
+  - ros-humble-std-msgs
+  - ros2-distro-mutex 0.7.* humble_*
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  - ucrt >=10.0.20348.0
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
+  - python_abi 3.11.* *_cp311
+  - numpy >=1.26.4,<2.0a0
+  license: BSD-3-Clause
+  size: 338785
+  timestamp: 1753326790710
 - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-ros-workspace-1.0.2-np126py311h2c3b307_9.conda
   sha256: 8bddb8cdc2def1c3ad6b1140e9c243572ea884934391f861ad53589e0aa897f5
   md5: 7f9633981b7c3251d8ee1732a3694909
@@ -59882,24 +59619,24 @@ packages:
   license: BSD-3-Clause
   size: 35479
   timestamp: 1736974290598
-- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-ros-workspace-1.0.2-np126py311h7d8ee0e_9.conda
-  sha256: d88479bfa0a1b8ca21285bb646bcb23a5cba9a2ac3c99f377f1dc7b51c97a377
-  md5: fbec20e37c7806078490822d33d12741
+- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-ros-workspace-1.0.2-np126py311hd5de103_13.conda
+  sha256: 463876a0060ff9ca759bd6767fa3a7c14320cb8b0ac569b1490a0253149f82d9
+  md5: 2a679ad4a38b72d1327f979f29b9afbf
   depends:
   - python
-  - ros2-distro-mutex 0.6.* humble_*
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - ros2-distro-mutex 0.7.* humble_*
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - ros2-distro-mutex >=0.6.0,<0.7.0a0
-  - numpy >=1.26.4,<2.0a0
   - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
+  - numpy >=1.26.4,<2.0a0
   license: BSD-3-Clause
-  size: 32364
-  timestamp: 1736974455726
+  size: 32597
+  timestamp: 1753308072735
 - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-ros2-control-test-assets-2.47.0-np126py311h2c3b307_7.conda
   sha256: 2d1f7e8222a18e7deaf37969ed9a02e1fe4568e380b29d08d4339fa995aa722f
   md5: 510d4d93f814c83f3275afaeca26dff6
@@ -59961,25 +59698,25 @@ packages:
   license: BSD-3-Clause
   size: 25174
   timestamp: 1736206660024
-- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-ros2-control-test-assets-2.47.0-np126py311h7d8ee0e_8.conda
-  sha256: ee5752ec58ce88a5b9ff31b2c14cb4725bca800818d4cba811b29167e426363b
-  md5: 9725d7498c75715be59b5aaad06d782d
+- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-ros2-control-test-assets-2.51.0-np126py311hd5de103_13.conda
+  sha256: cbfdbb5dd3c1676be69b2b1f8dc144dd92bc9a84710a4d1a91b4798171a73435
+  md5: cfc35eb07b2c817a43f8454f02f98bfc
   depends:
   - python
   - ros-humble-ros-workspace
-  - ros2-distro-mutex 0.6.* humble_*
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - ros2-distro-mutex 0.7.* humble_*
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - python_abi 3.11.* *_cp311
-  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
   - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
   license: BSD-3-Clause
-  size: 21967
-  timestamp: 1736207970570
+  size: 23321
+  timestamp: 1753312828016
 - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-ros2action-0.18.11-np126py311h2c3b307_7.conda
   sha256: 702442284cd1655343719759a830695f1e704ba71a399ec1dbf647d9b8beabd6
   md5: d414813c0c262a3c295ec9b5af072db6
@@ -60061,9 +59798,9 @@ packages:
   license: BSD-3-Clause
   size: 42309
   timestamp: 1736210668402
-- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-ros2action-0.18.11-np126py311h7d8ee0e_8.conda
-  sha256: 9069f93b17f99501212f4850cbee40f8e6356fa82eb576977556ba00e2fccda9
-  md5: 83894a28bf7abce1eff5f38604d28006
+- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-ros2action-0.18.12-np126py311hd5de103_13.conda
+  sha256: 3798bb5ad808e069a7d633d53233c1c92887ae82f663def998a38d61e3eb20ec
+  md5: bb40d054ee233ffe566f1f330f0bc109
   depends:
   - python
   - ros-humble-action-msgs
@@ -60072,19 +59809,19 @@ packages:
   - ros-humble-ros-workspace
   - ros-humble-ros2cli
   - ros-humble-rosidl-runtime-py
-  - ros2-distro-mutex 0.6.* humble_*
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - ros2-distro-mutex 0.7.* humble_*
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - numpy >=1.26.4,<2.0a0
-  - ros2-distro-mutex >=0.6.0,<0.7.0a0
   - python_abi 3.11.* *_cp311
+  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
   license: BSD-3-Clause
-  size: 38896
-  timestamp: 1736235205005
+  size: 39757
+  timestamp: 1753334235895
 - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-ros2bag-0.15.13-np126py311h2c3b307_7.conda
   sha256: 25a5a6c00d613418812736ef3f92c1dbb10d316b0a239bd29220a96693bb581f
   md5: ab4c4a6e4f44a36d03707d5e835febd6
@@ -60164,9 +59901,9 @@ packages:
   license: BSD-3-Clause
   size: 52705
   timestamp: 1736213578775
-- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-ros2bag-0.15.13-np126py311h7d8ee0e_8.conda
-  sha256: 64911362a7b3e3c51af77783ccd29b46031ccdb6146f064c9bf24811aa02f86e
-  md5: 7a698f5ef90efaf431594a0b42c72ffe
+- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-ros2bag-0.15.14-np126py311hd5de103_13.conda
+  sha256: 8af6872bb837bf40f493bc55c4452c0363ad89172c7b0b2eac0d7bf182ad1bab
+  md5: 2d176265562856f33b1606ebeda0690f
   depends:
   - python
   - ros-humble-ament-index-python
@@ -60174,19 +59911,19 @@ packages:
   - ros-humble-ros-workspace
   - ros-humble-ros2cli
   - ros-humble-rosbag2-py
-  - ros2-distro-mutex 0.6.* humble_*
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - ros2-distro-mutex 0.7.* humble_*
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
   - numpy >=1.26.4,<2.0a0
   - python_abi 3.11.* *_cp311
-  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
   license: BSD-3-Clause
-  size: 51870
-  timestamp: 1736241341645
+  size: 50097
+  timestamp: 1753348513705
 - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-ros2cli-0.18.11-np126py311hdfa6bdf_9.conda
   sha256: f227cf111d7180a8386b0f8b0f9ba336112b1a71f78a2cab64b202f675c5368c
   md5: eb75b044553d1f95ba04c7ffaa6e5f38
@@ -60270,9 +60007,9 @@ packages:
   license: BSD-3-Clause
   size: 73800
   timestamp: 1744204062873
-- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-ros2cli-0.18.11-np126py311h7d8ee0e_9.conda
-  sha256: b6ba352c882fbaac919dcd76c28ad0cb2a435cbcca151afbbae58a24bd29c701
-  md5: 6a4c0f896e86f8331ea2636a5041486d
+- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-ros2cli-0.18.12-np126py311hd5de103_13.conda
+  sha256: be0fc160234f629e41e09e337385250cc9ef9b715ab7c21153a1198816a4e4ae
+  md5: ec20c6da83cc68647898cc726340021a
   depends:
   - argcomplete
   - importlib-metadata
@@ -60281,19 +60018,19 @@ packages:
   - python
   - ros-humble-rclpy
   - ros-humble-ros-workspace
-  - ros2-distro-mutex 0.6.* humble_*
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - ros2-distro-mutex 0.7.* humble_*
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
   - numpy >=1.26.4,<2.0a0
-  - ros2-distro-mutex >=0.6.0,<0.7.0a0
   - python_abi 3.11.* *_cp311
   license: BSD-3-Clause
-  size: 80943
-  timestamp: 1744244165009
+  size: 81224
+  timestamp: 1753331443450
 - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-ros2cli-common-extensions-0.1.1-np126py311h2c3b307_7.conda
   sha256: dfc33f265b04a79b019f1182b373959b407f64e407a06dfa6afe4ab9f4a971e3
   md5: 3c0e29c762ae982c5243b74bc57ca544
@@ -60425,9 +60162,9 @@ packages:
   license: BSD-3-Clause
   size: 24581
   timestamp: 1736211779670
-- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-ros2cli-common-extensions-0.1.1-np126py311h7d8ee0e_8.conda
-  sha256: 34a5c4f9338a59ef63b76a51def20f5696d0e70ccc6db0e4d9a85259238e72bc
-  md5: 8c9e6709d81d227d5b168ec3660d3e52
+- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-ros2cli-common-extensions-0.1.1-np126py311hd5de103_13.conda
+  sha256: 5621d682fa1c098bc94bf36aa3f5e8b752fff1fe6917436b088556c1fa5da849
+  md5: fd37e56a7f563aec045fb04c20be98ea
   depends:
   - python
   - ros-humble-launch-xml
@@ -60448,19 +60185,19 @@ packages:
   - ros-humble-ros2service
   - ros-humble-ros2topic
   - ros-humble-sros2
-  - ros2-distro-mutex 0.6.* humble_*
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - ros2-distro-mutex 0.7.* humble_*
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
   - python_abi 3.11.* *_cp311
-  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - numpy >=1.26.4,<2.0a0
   license: BSD-3-Clause
-  size: 21292
-  timestamp: 1736237507953
+  size: 22635
+  timestamp: 1753339757386
 - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-ros2component-0.18.11-np126py311h2c3b307_7.conda
   sha256: 5c9af67fa1a3ddb8d0837065cab5698addc143c33e4b66a05723e19cc3456dbd
   md5: 75140c0d0a706c7a66609e6a0fefcdd3
@@ -60559,9 +60296,9 @@ packages:
   license: BSD-3-Clause
   size: 37808
   timestamp: 1736211188865
-- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-ros2component-0.18.11-np126py311h7d8ee0e_8.conda
-  sha256: 9dead385caa3032a87db8f4d1d990a4b101b2f1205a370465fd7951220b9211f
-  md5: f73fc4ae797b54343e212f61ac79988d
+- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-ros2component-0.18.12-np126py311hd5de103_13.conda
+  sha256: cb62876fe4e77ec5f90c0adb6082eb2374e8e7ca9210ca0e72d9a6e6b445d0a0
+  md5: 3e803f065c5779c188f9f39677d0ed43
   depends:
   - python
   - ros-humble-ament-index-python
@@ -60574,19 +60311,19 @@ packages:
   - ros-humble-ros2node
   - ros-humble-ros2param
   - ros-humble-ros2pkg
-  - ros2-distro-mutex 0.6.* humble_*
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - ros2-distro-mutex 0.7.* humble_*
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
   - python_abi 3.11.* *_cp311
-  - ros2-distro-mutex >=0.6.0,<0.7.0a0
   - numpy >=1.26.4,<2.0a0
   license: BSD-3-Clause
-  size: 34439
-  timestamp: 1736236581603
+  size: 34800
+  timestamp: 1753336827536
 - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-ros2doctor-0.18.11-np126py311h2c3b307_7.conda
   sha256: 6483f68e9ca4f7a67184857d097e1d43a6ae6fd2a88a6f37d1c2ceaf50b2c1fe
   md5: 22e7ebd646f1b1ea4306b1a2e41c4574
@@ -60681,9 +60418,9 @@ packages:
   license: BSD-3-Clause
   size: 64676
   timestamp: 1736210635057
-- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-ros2doctor-0.18.11-np126py311h7d8ee0e_8.conda
-  sha256: 05a7548d91d0d3f443a1413a098e0f3d4737302481266b5827697d2ac11d906c
-  md5: c1d4e3928d6a3912765569d1a2d43ff6
+- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-ros2doctor-0.18.12-np126py311hd5de103_13.conda
+  sha256: b19cd338cc2ab252ad3e1608bc97c73d29988f9dbc472f8b326e16428bd50792
+  md5: dd3b3bba6c811183b28e48b26265b535
   depends:
   - catkin_pkg
   - importlib-metadata
@@ -60694,20 +60431,20 @@ packages:
   - ros-humble-ros-environment
   - ros-humble-ros-workspace
   - ros-humble-ros2cli
-  - ros2-distro-mutex 0.6.* humble_*
+  - ros2-distro-mutex 0.7.* humble_*
   - rosdistro
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
   - python_abi 3.11.* *_cp311
   - numpy >=1.26.4,<2.0a0
-  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
   license: BSD-3-Clause
-  size: 61289
-  timestamp: 1736235529441
+  size: 61848
+  timestamp: 1753335137282
 - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-ros2interface-0.18.11-np126py311h2c3b307_7.conda
   sha256: 52a9c8c66a8f029f48c55ecd398973ff04ae24099bef99e69e9dc921662f04d7
   md5: 4ef5044395a11983b08931440264b9e6
@@ -60782,28 +60519,28 @@ packages:
   license: BSD-3-Clause
   size: 42819
   timestamp: 1736210623315
-- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-ros2interface-0.18.11-np126py311h7d8ee0e_8.conda
-  sha256: 1377db400d9fc1171e197338baecd040db85d8b32e3143054cfe340d2fd808bc
-  md5: 433ee4a5264e715f58abd98161a65b59
+- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-ros2interface-0.18.12-np126py311hd5de103_13.conda
+  sha256: 5aaf6321b5bb9b7459d2bbc2c7780a63ce453de9dd761e13189cc1b31d9397c2
+  md5: 28828efb7c559808c4aff8536c3cafde
   depends:
   - python
   - ros-humble-ament-index-python
   - ros-humble-ros-workspace
   - ros-humble-ros2cli
   - ros-humble-rosidl-runtime-py
-  - ros2-distro-mutex 0.6.* humble_*
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - ros2-distro-mutex 0.7.* humble_*
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
   - python_abi 3.11.* *_cp311
   - numpy >=1.26.4,<2.0a0
-  - ros2-distro-mutex >=0.6.0,<0.7.0a0
   license: BSD-3-Clause
-  size: 39381
-  timestamp: 1736235498558
+  size: 39929
+  timestamp: 1753335094226
 - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-ros2launch-0.19.8-np126py311h2c3b307_7.conda
   sha256: 172c0b28223c891cc948eca3a739bbe34b952bdd27c47525681863ee69331bbc
   md5: 956d6e255ecbb7d62c2248942ca669c9
@@ -60894,9 +60631,9 @@ packages:
   license: BSD-3-Clause
   size: 43274
   timestamp: 1736210906370
-- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-ros2launch-0.19.8-np126py311h7d8ee0e_8.conda
-  sha256: f98fc2040a8433daf405c42fdd8c5afaa344a15b24f9ca60021be349bf7e1f1a
-  md5: b7b6bd2d72b5e94b22109ab07efd5a4f
+- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-ros2launch-0.19.10-np126py311hd5de103_13.conda
+  sha256: bb198e7291595b57c3743d18e9e9a3d88c62138c1fcee30c4100aa2b6af211df
+  md5: 49a64597fe1c6a1a6e8bdc6e40aaf793
   depends:
   - python
   - ros-humble-ament-index-python
@@ -60907,19 +60644,19 @@ packages:
   - ros-humble-ros-workspace
   - ros-humble-ros2cli
   - ros-humble-ros2pkg
-  - ros2-distro-mutex 0.6.* humble_*
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - ros2-distro-mutex 0.7.* humble_*
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - ros2-distro-mutex >=0.6.0,<0.7.0a0
   - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
   - numpy >=1.26.4,<2.0a0
   license: BSD-3-Clause
-  size: 40066
-  timestamp: 1736236030581
+  size: 40783
+  timestamp: 1753335566929
 - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-ros2lifecycle-0.18.11-np126py311h2c3b307_7.conda
   sha256: f38e3b1dcbf679580b9fab3b0fbd71c0e9300a214750bc580488eb327eff42d6
   md5: f6a700d141a6fcf2a28b254f3b2cad93
@@ -61004,9 +60741,9 @@ packages:
   license: BSD-3-Clause
   size: 42198
   timestamp: 1736210921751
-- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-ros2lifecycle-0.18.11-np126py311h7d8ee0e_8.conda
-  sha256: 22c4e8559f9cca81c4e26fb4a9f9da5c6d2507c6a925449f8d62c7a22009bc0e
-  md5: aef52861d13c5d746fc36d8a0f813531
+- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-ros2lifecycle-0.18.12-np126py311hd5de103_13.conda
+  sha256: 929951b985227ff88638b5cf55bbac820cb0d975790bc004d7728b5b41f536d8
+  md5: 20985fa763b86d31d7d44b288d807280
   depends:
   - python
   - ros-humble-lifecycle-msgs
@@ -61015,19 +60752,19 @@ packages:
   - ros-humble-ros2cli
   - ros-humble-ros2node
   - ros-humble-ros2service
-  - ros2-distro-mutex 0.6.* humble_*
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - ros2-distro-mutex 0.7.* humble_*
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - python_abi 3.11.* *_cp311
   - numpy >=1.26.4,<2.0a0
-  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
   license: BSD-3-Clause
-  size: 38821
-  timestamp: 1736236124265
+  size: 39370
+  timestamp: 1753336139790
 - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-ros2multicast-0.18.11-np126py311h2c3b307_7.conda
   sha256: cbf0c41a3d84bc28b75d6ef933ca102a2774ac5a367045ba18a72b694fcb07b6
   md5: a920f865932d4b2012e9223a6e8323a9
@@ -61095,26 +60832,26 @@ packages:
   license: BSD-3-Clause
   size: 34458
   timestamp: 1736210405465
-- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-ros2multicast-0.18.11-np126py311h7d8ee0e_8.conda
-  sha256: fe5ce26d83c4450cf858a28520b39bfcf2926809dfef90b667267a2d63baeb02
-  md5: a04720fa37cd166f6eb40fa8753de0e8
+- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-ros2multicast-0.18.12-np126py311hd5de103_13.conda
+  sha256: 69e3cfdbbf13b37190b947c3ff637cd81aa69c2882eb2c09040c7add1f388d2c
+  md5: e77f99251d3e5bdeffdb30d6132e4e97
   depends:
   - python
   - ros-humble-ros-workspace
   - ros-humble-ros2cli
-  - ros2-distro-mutex 0.6.* humble_*
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - ros2-distro-mutex 0.7.* humble_*
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - ros2-distro-mutex >=0.6.0,<0.7.0a0
   - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
   - python_abi 3.11.* *_cp311
   license: BSD-3-Clause
-  size: 31149
-  timestamp: 1736234723558
+  size: 31634
+  timestamp: 1753333546104
 - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-ros2node-0.18.11-np126py311h2c3b307_7.conda
   sha256: ebd6a58dc944763ce1a5a5dc2f13e61fc527583fe684877d2db5dd8b3939a25f
   md5: 3c309f9388e247f1eda5fe60669e1e51
@@ -61181,26 +60918,26 @@ packages:
   license: BSD-3-Clause
   size: 39441
   timestamp: 1736210624431
-- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-ros2node-0.18.11-np126py311h7d8ee0e_8.conda
-  sha256: 0daf31bb4db348048abe2d92bc8a08dc9340c87f087727ce82946bcd97b6671f
-  md5: 5496a5297b14f1258eb34304d1d19447
+- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-ros2node-0.18.12-np126py311hd5de103_13.conda
+  sha256: 392cdf497b86c8ccb4c7d627d37f0ff3794fe347117c5cb0ddbc1adf7125a439
+  md5: 20189199ec2a1d90975dc0b8072aab81
   depends:
   - python
   - ros-humble-ros-workspace
   - ros-humble-ros2cli
-  - ros2-distro-mutex 0.6.* humble_*
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - ros2-distro-mutex 0.7.* humble_*
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - ros2-distro-mutex >=0.6.0,<0.7.0a0
   - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
   - numpy >=1.26.4,<2.0a0
   license: BSD-3-Clause
-  size: 36226
-  timestamp: 1736235418038
+  size: 36723
+  timestamp: 1753334594074
 - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-ros2param-0.18.11-np126py311h2c3b307_7.conda
   sha256: 8627e009f9489542b994b7a7b96262462772b49d2a99af694bb080b1b8a0d54c
   md5: f10244623c6974fe9057b55b12d8eeb3
@@ -61283,9 +61020,9 @@ packages:
   license: BSD-3-Clause
   size: 51288
   timestamp: 1736210931320
-- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-ros2param-0.18.11-np126py311h7d8ee0e_8.conda
-  sha256: 7f5dda7c3bdd4deb0bd00c56e3a231f4041c849a94bdbdd1aadcfb1cbb5a1a6d
-  md5: 830d0f4089a7a5dd6d7ab69cbf9e02e5
+- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-ros2param-0.18.12-np126py311hd5de103_13.conda
+  sha256: 6917a21906308b1c6cd34097c31cde2a3634d6cd2b81d24332a86d8f304d79ab
+  md5: 27b8c9fe1a76dc4342f59abfe9659304
   depends:
   - python
   - ros-humble-rcl-interfaces
@@ -61294,19 +61031,19 @@ packages:
   - ros-humble-ros2cli
   - ros-humble-ros2node
   - ros-humble-ros2service
-  - ros2-distro-mutex 0.6.* humble_*
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - ros2-distro-mutex 0.7.* humble_*
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - python_abi 3.11.* *_cp311
-  - ros2-distro-mutex >=0.6.0,<0.7.0a0
   - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
   license: BSD-3-Clause
-  size: 48005
-  timestamp: 1736236133246
+  size: 48564
+  timestamp: 1753335949802
 - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-ros2pkg-0.18.11-np126py311h2c3b307_7.conda
   sha256: d43bfa5c332fa6a0e3f58565791e510c90c5dce84df3d0018b30836eef04ce2b
   md5: ee6870f4f5d70f691435c2d43f71c889
@@ -61395,9 +61132,9 @@ packages:
   license: BSD-3-Clause
   size: 54865
   timestamp: 1736210599943
-- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-ros2pkg-0.18.11-np126py311h7d8ee0e_8.conda
-  sha256: db5c9af38ca51ea4f94a9550d9984301edd8d11c2821f8fe9dd761d24cdf6951
-  md5: ff1014d64da446e560c7ba6950e804a6
+- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-ros2pkg-0.18.12-np126py311hd5de103_13.conda
+  sha256: 65d7a529680d8c0b67f622b18f29035f0dbf397175d2d452f58f2cccd383835a
+  md5: 7545f6013362af37519323b6e7592437
   depends:
   - catkin_pkg
   - empy
@@ -61407,19 +61144,19 @@ packages:
   - ros-humble-ament-index-python
   - ros-humble-ros-workspace
   - ros-humble-ros2cli
-  - ros2-distro-mutex 0.6.* humble_*
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - ros2-distro-mutex 0.7.* humble_*
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - ros2-distro-mutex >=0.6.0,<0.7.0a0
-  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
   - python_abi 3.11.* *_cp311
+  - numpy >=1.26.4,<2.0a0
   license: BSD-3-Clause
-  size: 50572
-  timestamp: 1736235358103
+  size: 51134
+  timestamp: 1753334490814
 - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-ros2run-0.18.11-np126py311h2c3b307_7.conda
   sha256: 24b87ef1beaca243be01db42b96f8015f31055b825d356da786c439f755d6e92
   md5: a74c92bd393eca91a6217da5443a45a5
@@ -61491,27 +61228,27 @@ packages:
   license: BSD-3-Clause
   size: 34342
   timestamp: 1736210922249
-- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-ros2run-0.18.11-np126py311h7d8ee0e_8.conda
-  sha256: f417cfb2766ed0f7d386dc5925cfc345f5b41b1edd1a2967228f6cd4cb4d0475
-  md5: e1d684a7b619464ea0074f3f38ad7c67
+- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-ros2run-0.18.12-np126py311hd5de103_13.conda
+  sha256: 11b99249514e721248e3d24e2daac3cee2847f3aef9599e6e88f6843529227bc
+  md5: 9582dfb14d767b4ec858a00222497fd4
   depends:
   - python
   - ros-humble-ros-workspace
   - ros-humble-ros2cli
   - ros-humble-ros2pkg
-  - ros2-distro-mutex 0.6.* humble_*
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - ros2-distro-mutex 0.7.* humble_*
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - ros2-distro-mutex >=0.6.0,<0.7.0a0
   - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
   - numpy >=1.26.4,<2.0a0
   license: BSD-3-Clause
-  size: 31198
-  timestamp: 1736236103638
+  size: 31671
+  timestamp: 1753335903605
 - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-ros2service-0.18.11-np126py311h2c3b307_7.conda
   sha256: a5273739c31cb1e5eaf01cfa2554d6120fb4a8dd4615d892d219dcc28c92a74f
   md5: fbac42edc31e04c92ef3627433941c4c
@@ -61591,9 +61328,9 @@ packages:
   license: BSD-3-Clause
   size: 41116
   timestamp: 1736210613473
-- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-ros2service-0.18.11-np126py311h7d8ee0e_8.conda
-  sha256: 2a42b606645073c0b8c1d1a3259dc6f11e28ddface9d09f05568132d05511e1c
-  md5: fe6a117da1b3c9ac53d1acc15b76ba92
+- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-ros2service-0.18.12-np126py311hd5de103_13.conda
+  sha256: 859b6185095eaf0b49e9cef3c9e132c4151329571cbf2800bb74fcba2c4e814a
+  md5: 6d32c727fb3937902e13f4e93ec9e98d
   depends:
   - python
   - pyyaml
@@ -61601,19 +61338,19 @@ packages:
   - ros-humble-ros-workspace
   - ros-humble-ros2cli
   - ros-humble-rosidl-runtime-py
-  - ros2-distro-mutex 0.6.* humble_*
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - ros2-distro-mutex 0.7.* humble_*
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - python_abi 3.11.* *_cp311
-  - ros2-distro-mutex >=0.6.0,<0.7.0a0
   - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
   license: BSD-3-Clause
-  size: 37661
-  timestamp: 1736235387817
+  size: 38237
+  timestamp: 1753334542685
 - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-ros2topic-0.18.11-np126py311h2c3b307_7.conda
   sha256: a4366b135a7b816df5c9420365d306a7b6ae670d9aeef28bc29be62d69058be2
   md5: e25c14d5c059c13795f49db31f9ba909
@@ -61697,9 +61434,9 @@ packages:
   license: BSD-3-Clause
   size: 71556
   timestamp: 1736210556899
-- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-ros2topic-0.18.11-np126py311h7d8ee0e_8.conda
-  sha256: 728657328a1d20f403a7f568efa6183d542c97aa58418bf04fdd8c7082b12a07
-  md5: 8de0fe83a65926759ce28a92f8bc11e8
+- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-ros2topic-0.18.12-np126py311hd5de103_13.conda
+  sha256: d15e040b02ec0638cc04b6a31ac26de966702c4e46a7587e76aad7469766deae
+  md5: de487c5d8b6eb3f756dc3c8138c83838
   depends:
   - numpy
   - python
@@ -61708,19 +61445,19 @@ packages:
   - ros-humble-ros-workspace
   - ros-humble-ros2cli
   - ros-humble-rosidl-runtime-py
-  - ros2-distro-mutex 0.6.* humble_*
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - ros2-distro-mutex 0.7.* humble_*
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
   - python_abi 3.11.* *_cp311
-  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - numpy >=1.26.4,<2.0a0
   license: BSD-3-Clause
-  size: 68149
-  timestamp: 1736235216464
+  size: 68934
+  timestamp: 1753334229820
 - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-rosbag2-0.15.13-np126py311h2c3b307_7.conda
   sha256: 95be952c1860a70310af699d06e3b23b0d8f5e518de22a0c5d710da53eb6d60d
   md5: 5c1ca0b5498829a6cc63d02fedcd3d87
@@ -61823,9 +61560,9 @@ packages:
   license: BSD-3-Clause
   size: 29815
   timestamp: 1736214070672
-- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-rosbag2-0.15.13-np126py311h7d8ee0e_8.conda
-  sha256: 1703fc5123b02ea939273db0c001ab0d6e6a30a3622b558a31b29b5e4159496c
-  md5: 52752a8b52f38b3c159f1a73fdef26fa
+- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-rosbag2-0.15.14-np126py311hd5de103_13.conda
+  sha256: 439987313096d4a162ad5a260987cc354e7794dee086f8f916758c9a83cd0b8b
+  md5: 408d54534da4e6f59e73d86167d4e6b1
   depends:
   - python
   - ros-humble-ros-workspace
@@ -61839,19 +61576,19 @@ packages:
   - ros-humble-rosbag2-transport
   - ros-humble-shared-queues-vendor
   - ros-humble-sqlite3-vendor
-  - ros2-distro-mutex 0.6.* humble_*
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - ros2-distro-mutex 0.7.* humble_*
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - python_abi 3.11.* *_cp311
-  - ros2-distro-mutex >=0.6.0,<0.7.0a0
   - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
+  - python_abi 3.11.* *_cp311
   license: BSD-3-Clause
-  size: 26583
-  timestamp: 1736243065852
+  size: 28120
+  timestamp: 1753352750042
 - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-rosbag2-compression-0.15.13-np126py311h2c3b307_7.conda
   sha256: 1e4c792af5fa807724096eb1ebb65050c71e82570f4ac405fece3a6a6660a35f
   md5: 0c06ec134116c3729eae744a8ba4b268
@@ -61930,9 +61667,9 @@ packages:
   license: BSD-3-Clause
   size: 154724
   timestamp: 1736211200206
-- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-rosbag2-compression-0.15.13-np126py311h7d8ee0e_8.conda
-  sha256: 59840ce41736fdb3dd58257e01389089290a788479fa7f242ea0d2f12aa88945
-  md5: 398a66ddb5476fa24ffc6d607d369121
+- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-rosbag2-compression-0.15.14-np126py311hd5de103_13.conda
+  sha256: b9046fae6922797fe05a4feaaa9ba76bfc4f2c123e1e329fe74313b484c2a823
+  md5: f6b91ed0ce6f9c36d0eca434fbffe40e
   depends:
   - python
   - ros-humble-rcpputils
@@ -61940,19 +61677,19 @@ packages:
   - ros-humble-ros-workspace
   - ros-humble-rosbag2-cpp
   - ros-humble-rosbag2-storage
-  - ros2-distro-mutex 0.6.* humble_*
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - ros2-distro-mutex 0.7.* humble_*
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - ros2-distro-mutex >=0.6.0,<0.7.0a0
-  - numpy >=1.26.4,<2.0a0
   - python_abi 3.11.* *_cp311
+  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
   license: BSD-3-Clause
-  size: 142800
-  timestamp: 1736236620791
+  size: 146158
+  timestamp: 1753337932899
 - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-rosbag2-compression-zstd-0.15.13-np126py311h2c3b307_7.conda
   sha256: a65af90d5887271ec4f57465ad4c7ad0fbcff750ecdbf70f4e0a73a27472ade2
   md5: f244f956d74099851038810fda900a7c
@@ -62036,9 +61773,9 @@ packages:
   license: BSD-3-Clause
   size: 60963
   timestamp: 1736211583344
-- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-rosbag2-compression-zstd-0.15.13-np126py311h7d8ee0e_8.conda
-  sha256: 7b82bf31a0c22f1a71e5ca8e3aefc82a6b1bd1c43a9139f41b8cedf3ada77ac3
-  md5: f308efb072f9a731c043c913ada67f15
+- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-rosbag2-compression-zstd-0.15.14-np126py311hd5de103_13.conda
+  sha256: 8daef4f957d5156d59d808f19b65f0a982e658bab6dfc1d1204ae9e55860d558
+  md5: de3f9fbf5094e1df06e92acb9033b8d7
   depends:
   - python
   - ros-humble-pluginlib
@@ -62047,19 +61784,19 @@ packages:
   - ros-humble-ros-workspace
   - ros-humble-rosbag2-compression
   - ros-humble-zstd-vendor
-  - ros2-distro-mutex 0.6.* humble_*
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - ros2-distro-mutex 0.7.* humble_*
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - ros2-distro-mutex >=0.6.0,<0.7.0a0
-  - python_abi 3.11.* *_cp311
   - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
   license: BSD-3-Clause
-  size: 61980
-  timestamp: 1736237665716
+  size: 63391
+  timestamp: 1753339330453
 - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-rosbag2-cpp-0.15.13-np126py311h2c3b307_7.conda
   sha256: 171f00616db086a530a2ba21820b8a315e90071e91fcd5f079dfbfdae3883bb3
   md5: 302ddf1519dcc0362a221b7d63437dc2
@@ -62176,9 +61913,9 @@ packages:
   license: BSD-3-Clause
   size: 230474
   timestamp: 1736210889259
-- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-rosbag2-cpp-0.15.13-np126py311h7d8ee0e_8.conda
-  sha256: 5384f36f7df02880273b6da8bd18dbd7abca0da680b7eb6732451147b22726e2
-  md5: e297ef004420f13f7a9f7753b0a15184
+- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-rosbag2-cpp-0.15.14-np126py311hd5de103_13.conda
+  sha256: 34eb45c13c4691a28d5e1131c1f67d0df4edb1992bb240ac5d4b568b260bb6f4
+  md5: 0d1a498a0a7374aeb4f047b47bf5de0f
   depends:
   - python
   - ros-humble-ament-index-cpp
@@ -62195,19 +61932,19 @@ packages:
   - ros-humble-rosidl-typesupport-cpp
   - ros-humble-rosidl-typesupport-introspection-cpp
   - ros-humble-shared-queues-vendor
-  - ros2-distro-mutex 0.6.* humble_*
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - ros2-distro-mutex 0.7.* humble_*
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - numpy >=1.26.4,<2.0a0
-  - ros2-distro-mutex >=0.6.0,<0.7.0a0
   - python_abi 3.11.* *_cp311
+  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
   license: BSD-3-Clause
-  size: 219434
-  timestamp: 1736235996515
+  size: 223190
+  timestamp: 1753335782847
 - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-rosbag2-interfaces-0.15.13-np126py311h2c3b307_7.conda
   sha256: 11db7368859bd992f1d2848389f48977194fc6bf769074729e9bc0ad568315af
   md5: 9a9ca9b20e969908e05470b95c634bb2
@@ -62279,27 +62016,27 @@ packages:
   license: BSD-3-Clause
   size: 175157
   timestamp: 1736208584162
-- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-rosbag2-interfaces-0.15.13-np126py311h7d8ee0e_8.conda
-  sha256: cffacb4a77db7906b977810ee8c6364d13705bae0c7de1b3cc0588a29d10bb13
-  md5: 420fa64c601726810a5fa19b7a14fb15
+- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-rosbag2-interfaces-0.15.14-np126py311hd5de103_13.conda
+  sha256: feb50d381426bd5cd42329e951ee13c2aa7cea2584abcd6945030af5cfef0a03
+  md5: cd4844c653c71054187dc379ec27ec2d
   depends:
   - python
   - ros-humble-builtin-interfaces
   - ros-humble-ros-workspace
   - ros-humble-rosidl-default-runtime
-  - ros2-distro-mutex 0.6.* humble_*
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - ros2-distro-mutex 0.7.* humble_*
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - ros2-distro-mutex >=0.6.0,<0.7.0a0
-  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
   - python_abi 3.11.* *_cp311
+  - numpy >=1.26.4,<2.0a0
   license: BSD-3-Clause
-  size: 185881
-  timestamp: 1736230555168
+  size: 188689
+  timestamp: 1753324649642
 - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-rosbag2-py-0.15.13-np126py311h2c3b307_7.conda
   sha256: 8604a7c44f80cfceb30a3cbe120fe2c4c2fe43c8551a3660b19f87b9afb9b198
   md5: 64f08939c2c2f6dbf53e94ee1953aa8a
@@ -62387,9 +62124,9 @@ packages:
   license: BSD-3-Clause
   size: 412813
   timestamp: 1736212976856
-- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-rosbag2-py-0.15.13-np126py311h7d8ee0e_8.conda
-  sha256: 6e7da678c66f19c645484e9aba7f7a31a34aff95ed7b05e772aac63c835caba6
-  md5: b697fa32d6f1854c25b321704e89b5d1
+- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-rosbag2-py-0.15.14-np126py311hd5de103_13.conda
+  sha256: 3fbfc6c6c9f65f5060fb273e83464add268143796f3e44519b0eaa877ed63a14
+  md5: b650fd4a297f8ee2adcb428cbfec76ce
   depends:
   - python
   - ros-humble-pybind11-vendor
@@ -62399,19 +62136,19 @@ packages:
   - ros-humble-rosbag2-storage
   - ros-humble-rosbag2-transport
   - ros-humble-rpyutils
-  - ros2-distro-mutex 0.6.* humble_*
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - ros2-distro-mutex 0.7.* humble_*
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
   - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
   - python_abi 3.11.* *_cp311
-  - ros2-distro-mutex >=0.6.0,<0.7.0a0
   license: BSD-3-Clause
-  size: 367393
-  timestamp: 1736239992008
+  size: 386656
+  timestamp: 1753346796046
 - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-rosbag2-storage-0.15.13-np126py311h2c3b307_7.conda
   sha256: 32c8da4b9af76db6025c0c2bae3f905a674bcc15b46f50ee9506d493e54e4df0
   md5: 5b2ff709a4b8c16f6187616972e2f2ad
@@ -62492,9 +62229,9 @@ packages:
   license: BSD-3-Clause
   size: 178657
   timestamp: 1736210256911
-- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-rosbag2-storage-0.15.13-np126py311h7d8ee0e_8.conda
-  sha256: 68921090768e9ef7776d9681b695258b5f7af458594a2c284d8644eb132222e2
-  md5: fb127a1e10dfdd6cfdd1a78d7d078c22
+- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-rosbag2-storage-0.15.14-np126py311hd5de103_13.conda
+  sha256: 08597c7d0164fa15d1c128f7ae395fe301c0ded5d9f2a694776d734504eaaea7
+  md5: 2dae1553d4f7067e4e37b0d1f97e7f60
   depends:
   - python
   - ros-humble-pluginlib
@@ -62502,19 +62239,19 @@ packages:
   - ros-humble-rcutils
   - ros-humble-ros-workspace
   - ros-humble-yaml-cpp-vendor
-  - ros2-distro-mutex 0.6.* humble_*
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - ros2-distro-mutex 0.7.* humble_*
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - python_abi 3.11.* *_cp311
-  - ros2-distro-mutex >=0.6.0,<0.7.0a0
   - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
+  - python_abi 3.11.* *_cp311
   license: BSD-3-Clause
-  size: 152037
-  timestamp: 1736234608388
+  size: 154345
+  timestamp: 1753333293656
 - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-rosbag2-storage-default-plugins-0.15.13-np126py311h2c3b307_7.conda
   sha256: 3f8df70a407dcb4dc40bce2f8a243f5a183794cbe909f0899cd5823772062f36
   md5: d08821189af864f789a4e4c69777681a
@@ -62602,9 +62339,9 @@ packages:
   license: BSD-3-Clause
   size: 108208
   timestamp: 1736210658585
-- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-rosbag2-storage-default-plugins-0.15.13-np126py311h7d8ee0e_8.conda
-  sha256: 86f3f8427ea67975ef4c5665e72d530f85b0723987636ab34192a045f4fa9bf2
-  md5: a903b14bb4b7bd0b536a39666ca1617a
+- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-rosbag2-storage-default-plugins-0.15.14-np126py311hd5de103_13.conda
+  sha256: 71a59afaf517e1d1fd0c634430c5d187f9b91ad362e23525dce89b457a7d8295
+  md5: 72f6f5c31690b1f7dbfa8819aeb70d1d
   depends:
   - python
   - ros-humble-pluginlib
@@ -62614,19 +62351,19 @@ packages:
   - ros-humble-rosbag2-storage
   - ros-humble-sqlite3-vendor
   - ros-humble-yaml-cpp-vendor
-  - ros2-distro-mutex 0.6.* humble_*
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - ros2-distro-mutex 0.7.* humble_*
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
   - python_abi 3.11.* *_cp311
-  - ros2-distro-mutex >=0.6.0,<0.7.0a0
   - numpy >=1.26.4,<2.0a0
   license: BSD-3-Clause
-  size: 111741
-  timestamp: 1736235499728
+  size: 114590
+  timestamp: 1753335086981
 - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-rosbag2-transport-0.15.13-np126py311h2c3b307_7.conda
   sha256: dba49cad737e6d721fa47a4e9fd59d77f2b7c58ee7d0060f9555c04ffbf304b7
   md5: 67c0aad8a7c42912037119c4cf253999
@@ -62727,9 +62464,9 @@ packages:
   license: BSD-3-Clause
   size: 294164
   timestamp: 1736212716186
-- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-rosbag2-transport-0.15.13-np126py311h7d8ee0e_8.conda
-  sha256: 2685e93fca2ad033133211db29887fdea5b626bbf509857793137cb825e61166
-  md5: f5372b239a37190e36c67f616e4a8ef8
+- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-rosbag2-transport-0.15.14-np126py311hd5de103_13.conda
+  sha256: c289ab6853f2a3bb5a2bb45738626a54866fd3ee2ee85473dcdf96c921e6a5b7
+  md5: 05d4f0b823e9dc84a62b118e5629749b
   depends:
   - python
   - ros-humble-keyboard-handler
@@ -62742,19 +62479,19 @@ packages:
   - ros-humble-rosbag2-storage
   - ros-humble-shared-queues-vendor
   - ros-humble-yaml-cpp-vendor
-  - ros2-distro-mutex 0.6.* humble_*
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - ros2-distro-mutex 0.7.* humble_*
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - ros2-distro-mutex >=0.6.0,<0.7.0a0
   - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
   - numpy >=1.26.4,<2.0a0
   license: BSD-3-Clause
-  size: 248768
-  timestamp: 1736239703446
+  size: 245442
+  timestamp: 1753343637684
 - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-rosgraph-msgs-1.2.1-np126py311h2c3b307_7.conda
   sha256: 189117c66097f6319d3b5c4dc6b45b8e0c0275e7ef487b50b587ff4a7ff4cf13
   md5: 756b632f703ce403a53a11b90c5225d9
@@ -62825,27 +62562,27 @@ packages:
   license: BSD-3-Clause
   size: 63865
   timestamp: 1736208550339
-- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-rosgraph-msgs-1.2.1-np126py311h7d8ee0e_8.conda
-  sha256: 0ff0c29cf457a513d0954d927fe222ccf146586fc3146b73801d04eb536a299f
-  md5: a3a7fc06b0386133a084bb51f2449839
+- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-rosgraph-msgs-1.2.1-np126py311hd5de103_13.conda
+  sha256: 723ba98528cd6eeccfc9a5c767048db18c2d8350603eeb9fe32d31dbda6a3c35
+  md5: f7f3ea46b45cc00eefad24705fa0ca16
   depends:
   - python
   - ros-humble-builtin-interfaces
   - ros-humble-ros-workspace
   - ros-humble-rosidl-default-runtime
-  - ros2-distro-mutex 0.6.* humble_*
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - ros2-distro-mutex 0.7.* humble_*
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - ros2-distro-mutex >=0.6.0,<0.7.0a0
   - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
   - numpy >=1.26.4,<2.0a0
   license: BSD-3-Clause
-  size: 72733
-  timestamp: 1736230448164
+  size: 74478
+  timestamp: 1753324461126
 - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-rosidl-adapter-3.1.6-np126py311h2c3b307_7.conda
   sha256: b99905f74700d086636bd3e8f84cf06b76194f7a45e34d6168d4f0285396f83a
   md5: b6f979e1aa1f4f4a9d7ebf804df79bbb
@@ -62922,28 +62659,28 @@ packages:
   license: BSD-3-Clause
   size: 62316
   timestamp: 1736207451416
-- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-rosidl-adapter-3.1.6-np126py311h7d8ee0e_8.conda
-  sha256: 5d0af3ab30b3122ae1cddf925994d921fc6ddc17b810bbca2959f85ed76f21be
-  md5: 8a5c8484e9fb91e1274fffe5df4635bd
+- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-rosidl-adapter-3.1.6-np126py311hd5de103_13.conda
+  sha256: 3a118078a294a7add43fa3b233c5fb6d5282b4e8d47233665d8ebfd6e82f2281
+  md5: b139288ac7e3453b1d61165e5eedcfa6
   depends:
   - empy
   - python
   - ros-humble-ament-cmake-core
   - ros-humble-ros-workspace
   - ros-humble-rosidl-cli
-  - ros2-distro-mutex 0.6.* humble_*
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - ros2-distro-mutex 0.7.* humble_*
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - numpy >=1.26.4,<2.0a0
   - python_abi 3.11.* *_cp311
-  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
+  - numpy >=1.26.4,<2.0a0
   license: BSD-3-Clause
-  size: 59091
-  timestamp: 1736210624724
+  size: 60488
+  timestamp: 1753317698348
 - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-rosidl-cli-3.1.6-np126py311hdfa6bdf_9.conda
   sha256: 9cb4c78c0ae6f4ee6b34382a53e896c6bdfe2ba1f67b56a91d1283902fd56242
   md5: 57e3161ca033613c0754a73818974f04
@@ -63015,27 +62752,27 @@ packages:
   license: BSD-3-Clause
   size: 38430
   timestamp: 1744204041998
-- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-rosidl-cli-3.1.6-np126py311h7d8ee0e_9.conda
-  sha256: 2fff7187fd4d67353b64b049595cbbef1a337545405426606da8bd138fa51bf1
-  md5: aecf1d0a06ade23a591a65738354d7b0
+- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-rosidl-cli-3.1.6-np126py311hd5de103_13.conda
+  sha256: 3febfb5cffb8285ebaa7ddbcf84d9fa1422d5e974d2d374ffa83c68eb6e2dc3f
+  md5: 4605e9866242d31914501c2bc76ff21a
   depends:
   - argcomplete
   - importlib-metadata
   - python
   - ros-humble-ros-workspace
-  - ros2-distro-mutex 0.6.* humble_*
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - ros2-distro-mutex 0.7.* humble_*
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - numpy >=1.26.4,<2.0a0
   - python_abi 3.11.* *_cp311
-  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
+  - numpy >=1.26.4,<2.0a0
   license: BSD-3-Clause
-  size: 42915
-  timestamp: 1744244100425
+  size: 43377
+  timestamp: 1753312866073
 - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-rosidl-cmake-3.1.6-np126py311h2c3b307_7.conda
   sha256: c81c44d584ad1495676305fb795da4265e9b3601bbdfdb1ecf1551db8eb538f5
   md5: 22d349936b0184cb8fe0897675354a10
@@ -63114,9 +62851,9 @@ packages:
   license: BSD-3-Clause
   size: 38733
   timestamp: 1736207588534
-- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-rosidl-cmake-3.1.6-np126py311h7d8ee0e_8.conda
-  sha256: 659e84f54689135cf6099c11292a4a0e77058c2ef0e91b9a7f79860eebcaa878
-  md5: d260f3d6dd28407e9e71b623bec2185f
+- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-rosidl-cmake-3.1.6-np126py311hd5de103_13.conda
+  sha256: a4d1cfcb0a260e215363f3c6c5f77071a23275dc84a45be8f8a9232c666d7ec9
+  md5: 9bdaa4dadac4d3d491423aa59f053b09
   depends:
   - empy
   - python
@@ -63124,19 +62861,19 @@ packages:
   - ros-humble-ros-workspace
   - ros-humble-rosidl-adapter
   - ros-humble-rosidl-parser
-  - ros2-distro-mutex 0.6.* humble_*
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - ros2-distro-mutex 0.7.* humble_*
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - ros2-distro-mutex >=0.6.0,<0.7.0a0
   - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
   - numpy >=1.26.4,<2.0a0
   license: BSD-3-Clause
-  size: 35491
-  timestamp: 1736227229474
+  size: 36739
+  timestamp: 1753319537718
 - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-rosidl-default-generators-1.2.0-np126py311h2c3b307_7.conda
   sha256: 757a79d84073db54804062e2ee83cb16e41e244c4281b579dcf1a2b3532bb0e7
   md5: a310fe4b1d97dd61b2eb16b91c028bb3
@@ -63245,9 +62982,9 @@ packages:
   license: BSD-3-Clause
   size: 29847
   timestamp: 1736208363863
-- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-rosidl-default-generators-1.2.0-np126py311h7d8ee0e_8.conda
-  sha256: df61526a5502d2ee1a48a274e0b6eca51ff4b907cf227002cf3046189f8641de
-  md5: ec8cbcbf336288c192e9443282ea8835
+- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-rosidl-default-generators-1.2.0-np126py311hd5de103_13.conda
+  sha256: c9332dc1ce278809e583e23d92ec497c8d6a48ae6925135fa150e6fa87905423
+  md5: c208d3aa1f20fe03b84eec9177f23bfc
   depends:
   - python
   - ros-humble-ament-cmake-core
@@ -63262,19 +62999,19 @@ packages:
   - ros-humble-rosidl-typesupport-fastrtps-cpp
   - ros-humble-rosidl-typesupport-introspection-c
   - ros-humble-rosidl-typesupport-introspection-cpp
-  - ros2-distro-mutex 0.6.* humble_*
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - ros2-distro-mutex 0.7.* humble_*
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - ros2-distro-mutex >=0.6.0,<0.7.0a0
   - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
   - numpy >=1.26.4,<2.0a0
   license: BSD-3-Clause
-  size: 26677
-  timestamp: 1736229588546
+  size: 28134
+  timestamp: 1753322719893
 - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-rosidl-default-runtime-1.2.0-np126py311h2c3b307_7.conda
   sha256: ea2640211e377c0b880524d4c0bbb2fe6b8f31c1b5c28dba0cc8559ce7e9b6bb
   md5: 58aabc3c1eb5ff44e274b5c0cff98b23
@@ -63373,9 +63110,9 @@ packages:
   license: BSD-3-Clause
   size: 28901
   timestamp: 1736208348172
-- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-rosidl-default-runtime-1.2.0-np126py311h7d8ee0e_8.conda
-  sha256: 69d791f93537f2a8d5ad84621e511897927417b215983b495c25ea0b3168c22b
-  md5: a77acdb589c5022dfa20a7346c42792c
+- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-rosidl-default-runtime-1.2.0-np126py311hd5de103_13.conda
+  sha256: 7fc9704343c3fde4f40bc5f1398d6d420eca2d7b74453f02e895422a05edd0e9
+  md5: eed2cfa610eb7178e52280d64ebf7d08
   depends:
   - python
   - ros-humble-ros-workspace
@@ -63388,19 +63125,19 @@ packages:
   - ros-humble-rosidl-typesupport-fastrtps-cpp
   - ros-humble-rosidl-typesupport-introspection-c
   - ros-humble-rosidl-typesupport-introspection-cpp
-  - ros2-distro-mutex 0.6.* humble_*
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - ros2-distro-mutex 0.7.* humble_*
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
   - python_abi 3.11.* *_cp311
-  - ros2-distro-mutex >=0.6.0,<0.7.0a0
   - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
   license: BSD-3-Clause
-  size: 25661
-  timestamp: 1736229481594
+  size: 27144
+  timestamp: 1753322645131
 - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-rosidl-generator-c-3.1.6-np126py311h2c3b307_7.conda
   sha256: 09b6a087a006b4c7e9c88f15423f42608ffa1162dac246b0038ae33fe7aba7bd
   md5: 16e7a9beed934789dbf03a87b737863e
@@ -63492,9 +63229,9 @@ packages:
   license: BSD-3-Clause
   size: 45459
   timestamp: 1736207901728
-- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-rosidl-generator-c-3.1.6-np126py311h7d8ee0e_8.conda
-  sha256: 438ac6841d5ac738dff1c4e196f0370a1d041fcedefb4e88d1e0e7d06fa7663b
-  md5: e4293452579695b77061195aa0e8b531
+- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-rosidl-generator-c-3.1.6-np126py311hd5de103_13.conda
+  sha256: 4c132e0d1ec39637bcdc0290ed33e58bad3e2bf89de2e54c0c0466bb2b4835e9
+  md5: 4f188eb119bc168eea1cbd404158cefc
   depends:
   - python
   - ros-humble-ament-cmake-core
@@ -63505,19 +63242,19 @@ packages:
   - ros-humble-rosidl-cmake
   - ros-humble-rosidl-parser
   - ros-humble-rosidl-typesupport-interface
-  - ros2-distro-mutex 0.6.* humble_*
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - ros2-distro-mutex 0.7.* humble_*
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - ros2-distro-mutex >=0.6.0,<0.7.0a0
-  - numpy >=1.26.4,<2.0a0
   - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
+  - numpy >=1.26.4,<2.0a0
   license: BSD-3-Clause
-  size: 42268
-  timestamp: 1736227971484
+  size: 43675
+  timestamp: 1753320563542
 - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-rosidl-generator-cpp-3.1.6-np126py311h2c3b307_7.conda
   sha256: 804a896dba771d8afee698816d4fccbd7c99893a3065eeaa4dc2bc9ae36a48dc
   md5: f6bd1fb10d7e5f4ca7ad0ee095687fae
@@ -63610,9 +63347,9 @@ packages:
   license: BSD-3-Clause
   size: 48293
   timestamp: 1736207979642
-- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-rosidl-generator-cpp-3.1.6-np126py311h7d8ee0e_8.conda
-  sha256: 80778b1fe45ed9e1cb6fa714ddc8d2f15d2a88f21db61ab44c59e10e1c17acd4
-  md5: 61e50c8f4c1568906c8ab716464c3b3c
+- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-rosidl-generator-cpp-3.1.6-np126py311hd5de103_14.conda
+  sha256: b392c9201941a0a2cce8ebcaebcb7c296e7bdcf497a57565fec647eb3dcbd1b7
+  md5: a971c714123845bedaf5f7c353e261a4
   depends:
   - python
   - ros-humble-ament-cmake-core
@@ -63623,19 +63360,19 @@ packages:
   - ros-humble-rosidl-generator-c
   - ros-humble-rosidl-parser
   - ros-humble-rosidl-runtime-cpp
-  - ros2-distro-mutex 0.6.* humble_*
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - ros2-distro-mutex 0.7.* humble_*
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
   - python_abi 3.11.* *_cp311
   - numpy >=1.26.4,<2.0a0
   license: BSD-3-Clause
-  size: 45214
-  timestamp: 1736228216231
+  size: 47295
+  timestamp: 1758227460906
 - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-rosidl-generator-py-0.14.4-np126py311h2c3b307_7.conda
   sha256: 176b09cbdbcad422eed3a64f54160997f09bc09218f3e426a9b28d7e1fea5d6c
   md5: d527fad6a5260f831a8b2ccc9ee4ce3b
@@ -63750,9 +63487,9 @@ packages:
   license: BSD-3-Clause
   size: 58856
   timestamp: 1736208313318
-- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-rosidl-generator-py-0.14.4-np126py311h7d8ee0e_8.conda
-  sha256: 52733adac7c80faa7a0656790f5558fc54fb6f4754a24207db069dcf5d370030
-  md5: 2ae30e66e4619fc56f704941a165986e
+- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-rosidl-generator-py-0.14.4-np126py311hd5de103_13.conda
+  sha256: 5b5a027990788a272d186ed4050b23f2bc1831ddfdd8da550c387822148288a5
+  md5: ec197246c8f9bb57b8b544e802064863
   depends:
   - numpy
   - python
@@ -63769,19 +63506,19 @@ packages:
   - ros-humble-rosidl-typesupport-c
   - ros-humble-rosidl-typesupport-interface
   - ros-humble-rpyutils
-  - ros2-distro-mutex 0.6.* humble_*
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - ros2-distro-mutex 0.7.* humble_*
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - numpy >=1.26.4,<2.0a0
-  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
   - python_abi 3.11.* *_cp311
+  - numpy >=1.26.4,<2.0a0
   license: BSD-3-Clause
-  size: 55883
-  timestamp: 1736229262010
+  size: 57403
+  timestamp: 1753322557737
 - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-rosidl-parser-3.1.6-np126py311h2c3b307_7.conda
   sha256: f2045ded7e348395ad0a6b98768356836f5c9fdeea38fb66cfdd0b08ae3c9d60
   md5: ff082e99304c62a808b916b7d1812175
@@ -63854,27 +63591,27 @@ packages:
   license: BSD-3-Clause
   size: 58656
   timestamp: 1736207502121
-- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-rosidl-parser-3.1.6-np126py311h7d8ee0e_8.conda
-  sha256: a0d34589ccbaa64541b670d044222eac4a7a808bd57b6446f188d75fab4a2613
-  md5: 91d228661ca7cbf490f657c719f447e6
+- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-rosidl-parser-3.1.6-np126py311hd5de103_13.conda
+  sha256: e11a5aafd5ebfb5e92b1d7ae063ae5a59525b71cad6c31cc3f878468c8d5425b
+  md5: ac2955a245a0564fa7f7ae949209cf03
   depends:
   - lark-parser
   - python
   - ros-humble-ros-workspace
   - ros-humble-rosidl-adapter
-  - ros2-distro-mutex 0.6.* humble_*
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - ros2-distro-mutex 0.7.* humble_*
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
   - python_abi 3.11.* *_cp311
-  - ros2-distro-mutex >=0.6.0,<0.7.0a0
   - numpy >=1.26.4,<2.0a0
   license: BSD-3-Clause
-  size: 55725
-  timestamp: 1736226491881
+  size: 57073
+  timestamp: 1753318767246
 - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-rosidl-runtime-c-3.1.6-np126py311h2c3b307_7.conda
   sha256: 4f21b666450762121f032c0f8c3269d95c7aaea86173e9e9cd686588be9270d2
   md5: 9a5f67756089c9355dfd72c9a3d11cea
@@ -63949,28 +63686,28 @@ packages:
   license: BSD-3-Clause
   size: 43610
   timestamp: 1736207673681
-- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-rosidl-runtime-c-3.1.6-np126py311h7d8ee0e_8.conda
-  sha256: 188381d05a40611f0fd2737a582906c324df0f52aabf4ee9cbb5d07ce71664a6
-  md5: 50f651ba051410cbf0d06f0cd49d04bd
+- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-rosidl-runtime-c-3.1.6-np126py311hd5de103_13.conda
+  sha256: b03baf66499c4c8029157e90e085b83df5392c01d4c5139a2ca1931855e80b4d
+  md5: 2ee2815435f46d771ede458f5b531bdd
   depends:
   - python
   - ros-humble-ament-cmake
   - ros-humble-rcutils
   - ros-humble-ros-workspace
   - ros-humble-rosidl-typesupport-interface
-  - ros2-distro-mutex 0.6.* humble_*
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - ros2-distro-mutex 0.7.* humble_*
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
   - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
   - numpy >=1.26.4,<2.0a0
-  - ros2-distro-mutex >=0.6.0,<0.7.0a0
   license: BSD-3-Clause
-  size: 45571
-  timestamp: 1736227563147
+  size: 47252
+  timestamp: 1753319833199
 - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-rosidl-runtime-cpp-3.1.6-np126py311h2c3b307_7.conda
   sha256: 3d4e2b3cb3f8653038071a9d2c865b5a5d865d457fbb8308cd94f84815e73731
   md5: b0aaa0da0aae6a06c34b4803b50209c8
@@ -64042,27 +63779,27 @@ packages:
   license: BSD-3-Clause
   size: 34142
   timestamp: 1736207885606
-- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-rosidl-runtime-cpp-3.1.6-np126py311h7d8ee0e_8.conda
-  sha256: b7bff4f61a76ac713e1f42fb54a08d46be7c2dc8a4eefc619ac6002dfea557f9
-  md5: f4db0ae4ee0d9eec8c4041d5b3958752
+- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-rosidl-runtime-cpp-3.1.6-np126py311hd5de103_14.conda
+  sha256: 151085a26eb0616fabda59581af1e9c3ca1fecc88f742ee76b4a9f03145c7671
+  md5: 1acb503c7d9ea7ae978f97c5af1ee96f
   depends:
   - python
   - ros-humble-ament-cmake
   - ros-humble-ros-workspace
   - ros-humble-rosidl-runtime-c
-  - ros2-distro-mutex 0.6.* humble_*
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - ros2-distro-mutex 0.7.* humble_*
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
   - python_abi 3.11.* *_cp311
   - numpy >=1.26.4,<2.0a0
-  - ros2-distro-mutex >=0.6.0,<0.7.0a0
   license: BSD-3-Clause
-  size: 30829
-  timestamp: 1736227878465
+  size: 32896
+  timestamp: 1758227342999
 - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-rosidl-runtime-py-0.9.3-np126py311h2c3b307_7.conda
   sha256: fb296c4c66594ccf8f52fc77a38c5182490c4876f30e9ba178b58acbf8bc1d10
   md5: 457876038b4f981e1a717e5ea95ffa8c
@@ -64139,28 +63876,28 @@ packages:
   license: BSD-3-Clause
   size: 45060
   timestamp: 1736208916937
-- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-rosidl-runtime-py-0.9.3-np126py311h7d8ee0e_8.conda
-  sha256: 42a861b6eee904c5b7e6d1525c322bdf605c4527bdbf2efc6709ffbdb004fdd4
-  md5: 204525c6e3a4e8628b235f52bfeb8fb6
+- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-rosidl-runtime-py-0.9.3-np126py311hd5de103_13.conda
+  sha256: a36c9405b36cdf7cd5cefb90e2a772907f46a66c552d8c2663fb2062b32eefbe
+  md5: 9d793a675faddfb7c84901fc3f743596
   depends:
   - numpy
   - python
   - pyyaml
   - ros-humble-ros-workspace
   - ros-humble-rosidl-parser
-  - ros2-distro-mutex 0.6.* humble_*
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - ros2-distro-mutex 0.7.* humble_*
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
   - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
   - python_abi 3.11.* *_cp311
-  - ros2-distro-mutex >=0.6.0,<0.7.0a0
   license: BSD-3-Clause
-  size: 38433
-  timestamp: 1736231630528
+  size: 38982
+  timestamp: 1753326616346
 - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-rosidl-typesupport-c-2.0.2-np126py311h2c3b307_7.conda
   sha256: 91a1352d45770245fe94ed58c15fbd5ed4f20a81c52cdad4873d6d48345d79c7
   md5: ac116dc81cf89886d20add8207fa4c14
@@ -64260,9 +63997,9 @@ packages:
   license: BSD-3-Clause
   size: 46748
   timestamp: 1736208292850
-- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-rosidl-typesupport-c-2.0.2-np126py311h7d8ee0e_8.conda
-  sha256: da5514616e809f48f734b3e3c368305736e96317d86f1b8a1ff5de7de9e49522
-  md5: 343f5e54d4b73eb2ec1a4278ad6ee57c
+- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-rosidl-typesupport-c-2.0.2-np126py311hd5de103_13.conda
+  sha256: 089ea8a2ba73ed143f9306c168f25b9bcc309a21b4fa3e37779203f226f56201
+  md5: ebdf39f3099c9c816c7a022df88fdda7
   depends:
   - python
   - ros-humble-ament-cmake-core
@@ -64275,19 +64012,19 @@ packages:
   - ros-humble-rosidl-typesupport-fastrtps-c
   - ros-humble-rosidl-typesupport-interface
   - ros-humble-rosidl-typesupport-introspection-c
-  - ros2-distro-mutex 0.6.* humble_*
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - ros2-distro-mutex 0.7.* humble_*
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - numpy >=1.26.4,<2.0a0
-  - ros2-distro-mutex >=0.6.0,<0.7.0a0
   - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
+  - numpy >=1.26.4,<2.0a0
   license: BSD-3-Clause
-  size: 47757
-  timestamp: 1736229109742
+  size: 49314
+  timestamp: 1753322274140
 - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-rosidl-typesupport-cpp-2.0.2-np126py311h2c3b307_7.conda
   sha256: 7d525dbd7e3e54d0c19a787f80a1f90eb46fe8bef61c3cff240b2d073fb62623
   md5: bf18b6b068d1734fb700ecc9153c737a
@@ -64395,9 +64132,9 @@ packages:
   license: BSD-3-Clause
   size: 46024
   timestamp: 1736208306679
-- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-rosidl-typesupport-cpp-2.0.2-np126py311h7d8ee0e_8.conda
-  sha256: 62f4ae407fe96f210bca8e29ff3e5f7899a01073a4517961c174a957595adbb6
-  md5: e309595b046589910a425c6e136087b4
+- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-rosidl-typesupport-cpp-2.0.2-np126py311hd5de103_13.conda
+  sha256: daf0fb3e9c89222c60579015d6c3d76def472a5ed7ea17ed97835a16bf42627d
+  md5: 72e01312597bda742aaacce2b19a58ee
   depends:
   - python
   - ros-humble-ament-cmake-core
@@ -64412,19 +64149,19 @@ packages:
   - ros-humble-rosidl-typesupport-fastrtps-cpp
   - ros-humble-rosidl-typesupport-interface
   - ros-humble-rosidl-typesupport-introspection-cpp
-  - ros2-distro-mutex 0.6.* humble_*
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - ros2-distro-mutex 0.7.* humble_*
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - ros2-distro-mutex >=0.6.0,<0.7.0a0
   - python_abi 3.11.* *_cp311
   - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
   license: BSD-3-Clause
-  size: 47156
-  timestamp: 1736229231015
+  size: 48599
+  timestamp: 1753322473989
 - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-rosidl-typesupport-fastrtps-c-2.2.2-np126py311h2c3b307_7.conda
   sha256: 0ba946b80619bb404b2ebb8fb3f421a434b1bfeb9d5d88fc71bcb6c567a1a7ab
   md5: 096294f7cfcc2e22fc0e4c77612121a5
@@ -64536,9 +64273,9 @@ packages:
   license: BSD-3-Clause
   size: 46353
   timestamp: 1736208192294
-- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-rosidl-typesupport-fastrtps-c-2.2.2-np126py311h7d8ee0e_8.conda
-  sha256: 4502e5f45bf08a01dbeda6e15e3b50473d3a8e335e6f5a0017a4b40a365e3593
-  md5: 40fce540cdd09e658e75128d7242c347
+- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-rosidl-typesupport-fastrtps-c-2.2.2-np126py311hd5de103_13.conda
+  sha256: 5ca478a5e3321f9c0f2cd2e375c1d6bd2c2e1fdbd01891c0eae857f7bcda7822
+  md5: 21813552c1831acbb4a15c72a28a75bd
   depends:
   - python
   - ros-humble-ament-cmake-ros
@@ -64554,19 +64291,19 @@ packages:
   - ros-humble-rosidl-runtime-cpp
   - ros-humble-rosidl-typesupport-fastrtps-cpp
   - ros-humble-rosidl-typesupport-interface
-  - ros2-distro-mutex 0.6.* humble_*
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - ros2-distro-mutex 0.7.* humble_*
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - ros2-distro-mutex >=0.6.0,<0.7.0a0
-  - numpy >=1.26.4,<2.0a0
   - python_abi 3.11.* *_cp311
+  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
   license: BSD-3-Clause
-  size: 47891
-  timestamp: 1736228695990
+  size: 49554
+  timestamp: 1753322012544
 - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-rosidl-typesupport-fastrtps-cpp-2.2.2-np126py311h2c3b307_7.conda
   sha256: 4e506897b48cf907ae437420e71e8b80d764c78f0f49ab4574f75f7c12cbd5fd
   md5: ad63d1859f877850a6c0f2a45058ea7d
@@ -64674,9 +64411,9 @@ packages:
   license: BSD-3-Clause
   size: 48266
   timestamp: 1736208061600
-- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-rosidl-typesupport-fastrtps-cpp-2.2.2-np126py311h7d8ee0e_8.conda
-  sha256: 1b3a0ae3f2237366f0495ceb55b1322066ce8ead3d8d14785d60866ece8f3bb3
-  md5: eaaab0bee19915dbd200cfe934949f9d
+- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-rosidl-typesupport-fastrtps-cpp-2.2.2-np126py311hd5de103_13.conda
+  sha256: 7c12457ad4480d97527493a3497bf7a04b79cc46534ef35b6db48f85de2abdcf
+  md5: 6a0ebeb36ee8cc4a3ab8b75b7e06787c
   depends:
   - python
   - ros-humble-ament-cmake-ros
@@ -64691,19 +64428,19 @@ packages:
   - ros-humble-rosidl-runtime-c
   - ros-humble-rosidl-runtime-cpp
   - ros-humble-rosidl-typesupport-interface
-  - ros2-distro-mutex 0.6.* humble_*
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - ros2-distro-mutex 0.7.* humble_*
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
   - numpy >=1.26.4,<2.0a0
-  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - python_abi 3.11.* *_cp311
   license: BSD-3-Clause
-  size: 48728
-  timestamp: 1736228517506
+  size: 50796
+  timestamp: 1753321596363
 - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-rosidl-typesupport-interface-3.1.6-np126py311h2c3b307_7.conda
   sha256: 61403c3f0bad550b6373e659d35e386b67250a363b4499afe8e56ca8742a763f
   md5: c766ae1960e035927df3ebafab95e83c
@@ -64766,25 +64503,25 @@ packages:
   license: BSD-3-Clause
   size: 27144
   timestamp: 1736207224656
-- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-rosidl-typesupport-interface-3.1.6-np126py311h7d8ee0e_8.conda
-  sha256: 91bd933a629c6cd5aff3d6c8974168c07ae894cf4d46090e852522c2a39d1803
-  md5: 96ac377dd92c7d934ec48821aa929ab9
+- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-rosidl-typesupport-interface-3.1.6-np126py311hd5de103_13.conda
+  sha256: fa64da4245cabfcd35e16271e91a49a54cd374f5a00e82135e09865d6d522cbe
+  md5: 664530b0f16157cae712a20b80a9fe42
   depends:
   - python
   - ros-humble-ros-workspace
-  - ros2-distro-mutex 0.6.* humble_*
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - ros2-distro-mutex 0.7.* humble_*
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
   - numpy >=1.26.4,<2.0a0
-  - ros2-distro-mutex >=0.6.0,<0.7.0a0
   - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
   license: BSD-3-Clause
-  size: 23805
-  timestamp: 1736226457593
+  size: 25142
+  timestamp: 1753317762721
 - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-rosidl-typesupport-introspection-c-3.1.6-np126py311h2c3b307_7.conda
   sha256: 54cf06f2d15fd71d8760c7ccb00ddab4141aee2b9e05642c6ff33f9f109fb913
   md5: e62862c3d3c3d2e7a79da43c814aa583
@@ -64873,9 +64610,9 @@ packages:
   license: BSD-3-Clause
   size: 44169
   timestamp: 1736207916343
-- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-rosidl-typesupport-introspection-c-3.1.6-np126py311h7d8ee0e_8.conda
-  sha256: fc5929d375024cc7144f1abeefd44cd1ddd46a7fb21eab2156c2ad7302c6dfe3
-  md5: a380ba5bdbcca3d63ded4c3864dc5267
+- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-rosidl-typesupport-introspection-c-3.1.6-np126py311hd5de103_13.conda
+  sha256: 7a356de281bab50815b4dbcb64976f7dbc3e02581d5b51c412d1b521f6b5fcf0
+  md5: c3526524aa83bcbb0f6c8afb7ef4aa7e
   depends:
   - python
   - ros-humble-ament-cmake
@@ -64885,19 +64622,19 @@ packages:
   - ros-humble-rosidl-cmake
   - ros-humble-rosidl-parser
   - ros-humble-rosidl-runtime-c
-  - ros2-distro-mutex 0.6.* humble_*
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - ros2-distro-mutex 0.7.* humble_*
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
   - python_abi 3.11.* *_cp311
   - numpy >=1.26.4,<2.0a0
-  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
   license: BSD-3-Clause
-  size: 44906
-  timestamp: 1736228032532
+  size: 46484
+  timestamp: 1753320719839
 - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-rosidl-typesupport-introspection-cpp-3.1.6-np126py311h2c3b307_7.conda
   sha256: e911a28f29af4782227a03c1f2f8c0db3f68cb90604dfb4541faec50a19b5504
   md5: 6c808a6da6995bc725e3f6bee31267e0
@@ -64998,9 +64735,9 @@ packages:
   license: BSD-3-Clause
   size: 44405
   timestamp: 1736207995658
-- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-rosidl-typesupport-introspection-cpp-3.1.6-np126py311h7d8ee0e_8.conda
-  sha256: 7d68210a303adc73e30e428a5455e0452c3c1eef12d384edb2b3610bf6fc487d
-  md5: 0ea911d72296fde8f164dcddbef72278
+- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-rosidl-typesupport-introspection-cpp-3.1.6-np126py311hd5de103_13.conda
+  sha256: 6c7b681f62c74fe72e408374df5fcfa5169b8676eae491da0f45bd7219451d3b
+  md5: 95f58ba92ba65a07dfbcc13251d01b1d
   depends:
   - python
   - ros-humble-ament-cmake
@@ -65013,19 +64750,19 @@ packages:
   - ros-humble-rosidl-runtime-cpp
   - ros-humble-rosidl-typesupport-interface
   - ros-humble-rosidl-typesupport-introspection-c
-  - ros2-distro-mutex 0.6.* humble_*
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - ros2-distro-mutex 0.7.* humble_*
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - ros2-distro-mutex >=0.6.0,<0.7.0a0
   - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
   - python_abi 3.11.* *_cp311
   license: BSD-3-Clause
-  size: 45235
-  timestamp: 1736228320751
+  size: 46827
+  timestamp: 1753321302009
 - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-rpyutils-0.2.1-np126py311h2c3b307_7.conda
   sha256: 577e7562016cf46d8a7f879db09778ee1b132bb9b6c327f8ec01d373dcef1551
   md5: 5b2f319c93475b695c86db4d43262b5e
@@ -65089,25 +64826,25 @@ packages:
   license: BSD-3-Clause
   size: 25110
   timestamp: 1736206663996
-- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-rpyutils-0.2.1-np126py311h7d8ee0e_8.conda
-  sha256: e48e37ce54d5e41c5c90457d6c8052ccb3fd1f93f4869e935378de02da7351a3
-  md5: b8343ab7d4690d7889c32fd46e2b54d2
+- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-rpyutils-0.2.1-np126py311hd5de103_13.conda
+  sha256: 15b8976166441b99baf94088842026a19cfd21c82a28bbc645df5373b37d1005
+  md5: ddb9382b8194d9c5da245ed933ba30a9
   depends:
   - python
   - ros-humble-ros-workspace
-  - ros2-distro-mutex 0.6.* humble_*
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - ros2-distro-mutex 0.7.* humble_*
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - ros2-distro-mutex >=0.6.0,<0.7.0a0
   - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
   - numpy >=1.26.4,<2.0a0
   license: BSD-3-Clause
-  size: 18336
-  timestamp: 1736208030311
+  size: 18682
+  timestamp: 1753312899510
 - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-rsl-1.1.0-np126py311h2c3b307_7.conda
   sha256: ce0edd2d93f384c144cb52a1db030547a99bd483f94f809aba47fa25d15b9349
   md5: accdaa8093a107f57bdb635c55039a88
@@ -65200,9 +64937,9 @@ packages:
   license: BSD-3-Clause
   size: 46083
   timestamp: 1736209638031
-- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-rsl-1.1.0-np126py311h7d8ee0e_8.conda
-  sha256: f343f7c5cca7de59a08f94632b467262ded4f895988aa461b11493fff2562465
-  md5: 617c633a2fa5cc34301837a8c763e50b
+- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-rsl-1.2.0-np126py311h4715f36_13.conda
+  sha256: 5046332c0b598be6b0b01ff2373c6db0abe1592a294aeadc29d7d3a135450c82
+  md5: fae6ed2ae0fc19fea23b5ab7e7735c27
   depends:
   - eigen
   - fmt
@@ -65211,21 +64948,21 @@ packages:
   - ros-humble-ros-workspace
   - ros-humble-tcb-span
   - ros-humble-tl-expected
-  - ros2-distro-mutex 0.6.* humble_*
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - ros2-distro-mutex 0.7.* humble_*
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
   - python_abi 3.11.* *_cp311
-  - fmt >=11.0.2,<12.0a0
+  - graphviz >=12.2.1,<13.0a0
   - numpy >=1.26.4,<2.0a0
-  - graphviz >=12.0.0,<13.0a0
-  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - fmt >=11.2.0,<11.3.0a0
   license: BSD-3-Clause
-  size: 77902
-  timestamp: 1736234109536
+  size: 49964
+  timestamp: 1753331812749
 - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-rti-connext-dds-cmake-module-0.11.3-np126py311h2c3b307_7.conda
   sha256: d98d4220e5269773db84c25746af5e38095058e85cdcb9d611957402f45f3847
   md5: ee7773cf356c772693e144aaa1d5c93d
@@ -65293,26 +65030,26 @@ packages:
   license: BSD-3-Clause
   size: 29447
   timestamp: 1736207409374
-- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-rti-connext-dds-cmake-module-0.11.3-np126py311h7d8ee0e_8.conda
-  sha256: c8531e0e64c5526a3de82320e92256174c7a684f938daa5c731472a819332d5e
-  md5: 7702443df182ba5ebabf13df6a269289
+- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-rti-connext-dds-cmake-module-0.11.3-np126py311hd5de103_13.conda
+  sha256: 87bedcf9b81b888a4ac58781d96797b11afe8a0502e6eb185911d9e5904a3a7b
+  md5: 5ffaed20398c8d3fecb7444bd430768f
   depends:
   - python
   - ros-humble-ament-cmake
   - ros-humble-ros-workspace
-  - ros2-distro-mutex 0.6.* humble_*
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - ros2-distro-mutex 0.7.* humble_*
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
   - numpy >=1.26.4,<2.0a0
   - python_abi 3.11.* *_cp311
   license: BSD-3-Clause
-  size: 26214
-  timestamp: 1736226806127
+  size: 27515
+  timestamp: 1753318381252
 - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-ruckig-0.9.2-np126py311h2c3b307_7.conda
   sha256: cc8cc05104cc804dc8dbe7a631f3e7cc7d6a553f3cf950408597ae4d627ae5cb
   md5: 60899f78db1a14cc47d57b102b6aaf49
@@ -65376,25 +65113,25 @@ packages:
   license: BSD-3-Clause
   size: 71638
   timestamp: 1736205469861
-- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-ruckig-0.9.2-np126py311h7d8ee0e_8.conda
-  sha256: f5df08430e73c0768037b207f2d52a8b21293511af4486d6dbe42574bf86ba31
-  md5: 53ae4d2bc9dee781a08dc83938241908
+- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-ruckig-0.9.2-np126py311hd5de103_13.conda
+  sha256: 63f317d770be47bd8b6fce803113865b3b06f5480c6eec6370f2c7508e5c20e0
+  md5: b307a37aa52d2944bc730266defea370
   depends:
   - python
   - ros-humble-ros-workspace
-  - ros2-distro-mutex 0.6.* humble_*
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - ros2-distro-mutex 0.7.* humble_*
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - python_abi 3.11.* *_cp311
-  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
   - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
   license: BSD-3-Clause
-  size: 102176
-  timestamp: 1736205774909
+  size: 103665
+  timestamp: 1753308595526
 - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-rviz-assimp-vendor-11.2.15-np126py311h2c3b307_7.conda
   sha256: d958338f5a692eabeacde67daef46aa44c81bec782c55922ad0223c3998e8491
   md5: 6ab6264160dc97efaaf936f0c5086b01
@@ -65466,27 +65203,27 @@ packages:
   license: BSD-3-Clause
   size: 22804
   timestamp: 1736207187165
-- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-rviz-assimp-vendor-11.2.15-np126py311h7d8ee0e_8.conda
-  sha256: 37520bc2b04a9ab0d9ead7fed27f2a846e6b076fe6eb4ac93ee03c14b46da602
-  md5: 6bd06ab01bf794c787e04f525c066870
+- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-rviz-assimp-vendor-11.2.18-np126py311hd5de103_13.conda
+  sha256: 1125d1180cdea036dfaa362d5d97495781664cde0966811453602c6fe82a5dbd
+  md5: 12d57b49d699bb0284fbea0d4ba44097
   depends:
   - assimp
   - python
   - ros-humble-ros-workspace
-  - ros2-distro-mutex 0.6.* humble_*
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - ros2-distro-mutex 0.7.* humble_*
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - assimp >=5.4.3,<5.4.4.0a0
-  - python_abi 3.11.* *_cp311
-  - ros2-distro-mutex >=0.6.0,<0.7.0a0
   - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
+  - python_abi 3.11.* *_cp311
+  - assimp >=5.4.3,<5.4.4.0a0
   license: BSD-3-Clause
-  size: 19571
-  timestamp: 1736210232478
+  size: 20698
+  timestamp: 1753317160349
 - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-rviz-common-11.2.15-np126py311h2c3b307_7.conda
   sha256: 6aa1c7a40c085cb560e3c691c9a1d9e20c172732043805de98606eef85aa7d3f
   md5: fa85c669637c948873b6c620f26ef490
@@ -65642,9 +65379,9 @@ packages:
   license: BSD-3-Clause
   size: 638003
   timestamp: 1736211168410
-- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-rviz-common-11.2.15-np126py311h7d8ee0e_8.conda
-  sha256: f0db4b1afd172fa343b9890997bf7c59dc66433afe55cc147f42367a4b58bfc2
-  md5: 2bad2b32dee94a7a8fd226ced2d8bd44
+- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-rviz-common-11.2.18-np126py311hd5de103_13.conda
+  sha256: b90c1c0c6e2f073eeabbf18839918dcec08d507bf638903ae582ba3d5a3cae04
+  md5: 50c37c16c28b7519f6c1a7070568f2b8
   depends:
   - python
   - qt-main
@@ -65665,20 +65402,20 @@ packages:
   - ros-humble-tinyxml2-vendor
   - ros-humble-urdf
   - ros-humble-yaml-cpp-vendor
-  - ros2-distro-mutex 0.6.* humble_*
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - ros2-distro-mutex 0.7.* humble_*
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - ros2-distro-mutex >=0.6.0,<0.7.0a0
-  - numpy >=1.26.4,<2.0a0
   - qt-main >=5.15.15,<5.16.0a0
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
+  - numpy >=1.26.4,<2.0a0
   - python_abi 3.11.* *_cp311
   license: BSD-3-Clause
-  size: 639814
-  timestamp: 1736236493567
+  size: 631406
+  timestamp: 1753336805533
 - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-rviz-default-plugins-11.2.15-np126py311h2c3b307_7.conda
   sha256: cbf35da017a8511903729f06c380292d92617d3de7dc8a24fdcc36abd9aa04e0
   md5: b2fc7d1767d728e5c4f130ab1d5a9c28
@@ -65841,9 +65578,9 @@ packages:
   license: BSD-3-Clause
   size: 1535084
   timestamp: 1736212307341
-- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-rviz-default-plugins-11.2.15-np126py311h7d8ee0e_8.conda
-  sha256: 97bf2a1aa9758d432437cf9a6d88853bcc587b17726a84fc9393526dc124aa56
-  md5: e61e0e60edba9081cd12533759590e92
+- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-rviz-default-plugins-11.2.18-np126py311hd5de103_13.conda
+  sha256: dfed895a2c7328df6cf55697e1c2905ee3166ce82201e634613d0179cdc075b7
+  md5: de523092deaf7d754fa8e681c8975b34
   depends:
   - python
   - qt-main
@@ -65866,20 +65603,20 @@ packages:
   - ros-humble-tf2-ros
   - ros-humble-urdf
   - ros-humble-visualization-msgs
-  - ros2-distro-mutex 0.6.* humble_*
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - ros2-distro-mutex 0.7.* humble_*
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - qt-main >=5.15.15,<5.16.0a0
-  - ros2-distro-mutex >=0.6.0,<0.7.0a0
-  - numpy >=1.26.4,<2.0a0
   - python_abi 3.11.* *_cp311
+  - numpy >=1.26.4,<2.0a0
+  - qt-main >=5.15.15,<5.16.0a0
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
   license: BSD-3-Clause
-  size: 1071395
-  timestamp: 1736238549917
+  size: 1069171
+  timestamp: 1753342164709
 - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-rviz-ogre-vendor-11.2.15-np126py311h2c3b307_7.conda
   sha256: f9786740ee8717af8e9ad1db0d918316dbb6738ce7b383b280124e71ae869700
   md5: 3486cdfd5dda6d43bfacd203f9cf173b
@@ -66016,36 +65753,39 @@ packages:
   license: BSD-3-Clause
   size: 4126167
   timestamp: 1736206936011
-- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-rviz-ogre-vendor-11.2.15-np126py311h7d8ee0e_8.conda
-  sha256: 410d2061e3bcc0e52eb404ffd8756fbb8438ef211c53d2b1d780509600bfa0a9
-  md5: 70d88e7d55f27170082f0022e9db97fc
+- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-rviz-ogre-vendor-11.2.18-np126py311hcdf5458_13.conda
+  sha256: 255686448aec45ed74a45bfc6d73ec52b2586a1a79b31295fc6790bfee17e072
+  md5: e78a913edfd9dd566970dcd94311e11f
   depends:
   - assimp
   - freetype
+  - glew
   - python
   - ros-humble-ros-workspace
-  - ros2-distro-mutex 0.6.* humble_*
+  - ros2-distro-mutex 0.7.* humble_*
   - xorg-libx11
   - xorg-xorgproto
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - pugixml >=1.14,<1.15.0a0
-  - libzlib >=1.3.1,<2.0a0
   - freeimage >=3.18.0,<3.19.0a0
+  - glew >=2.1.0,<2.2.0a0
+  - xorg-libx11 >=1.8.12,<2.0a0
+  - libfreetype >=2.13.3
+  - libfreetype6 >=2.13.3
+  - libzlib >=1.3.1,<2.0a0
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
   - zziplib >=0.13.69,<0.14.0a0
-  - ros2-distro-mutex >=0.6.0,<0.7.0a0
   - numpy >=1.26.4,<2.0a0
-  - freetype >=2.12.1,<3.0a0
   - assimp >=5.4.3,<5.4.4.0a0
-  - xorg-libx11 >=1.8.10,<2.0a0
+  - pugixml >=1.15,<1.16.0a0
   - python_abi 3.11.* *_cp311
   license: BSD-3-Clause
-  size: 4661981
-  timestamp: 1736209110750
+  size: 4628486
+  timestamp: 1753315767546
 - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-rviz-rendering-11.2.15-np126py311h2c3b307_7.conda
   sha256: ebcad1222c48f33792266b6c758e72bc3b32c6bd4a4eb534e7a96b04a1978392
   md5: d53d357fdbbd762a69f72b614790d72e
@@ -66166,9 +65906,9 @@ packages:
   license: BSD-3-Clause
   size: 859957
   timestamp: 1736207613324
-- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-rviz-rendering-11.2.15-np126py311h7d8ee0e_8.conda
-  sha256: 77aa0f7d3b9936940dede2011875277ba067b8fd846cf7d5eb675a09224a8392
-  md5: 76fd9ce482014646657095d607f368b1
+- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-rviz-rendering-11.2.18-np126py311hd5de103_13.conda
+  sha256: d57551bfbd9a0e1f417e7447189fdbbb042341f6de128b328185f67d87eddbfe
+  md5: 7dff5eb745bff8a9102a5bb8ae942e0a
   depends:
   - eigen
   - python
@@ -66179,21 +65919,21 @@ packages:
   - ros-humble-ros-workspace
   - ros-humble-rviz-assimp-vendor
   - ros-humble-rviz-ogre-vendor
-  - ros2-distro-mutex 0.6.* humble_*
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - ros2-distro-mutex 0.7.* humble_*
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
+  - python_abi 3.11.* *_cp311
+  - qt-main >=5.15.15,<5.16.0a0
   - numpy >=1.26.4,<2.0a0
   - glew >=2.1.0,<2.2.0a0
-  - qt-main >=5.15.15,<5.16.0a0
-  - python_abi 3.11.* *_cp311
-  - ros2-distro-mutex >=0.6.0,<0.7.0a0
   license: BSD-3-Clause
-  size: 858975
-  timestamp: 1736227296983
+  size: 858382
+  timestamp: 1753319633942
 - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-rviz-visual-tools-4.1.4-np126py311h2c3b307_7.conda
   sha256: 7082f6e4abd6bf3578fb6259044e36db58153b3a3c85fc6f9384aecadaa95101
   md5: 4e30a2b75213ca689f2c6ff77f337861
@@ -66381,9 +66121,9 @@ packages:
   license: BSD-3-Clause
   size: 370898
   timestamp: 1736213297984
-- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-rviz-visual-tools-4.1.4-np126py311h7d8ee0e_8.conda
-  sha256: 4ffae9a6c4f15b7414a996349382b1ff20db943626ed6858dce53fab63bae31e
-  md5: 312c5598cfbf2530cfc6e3af8d038a3d
+- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-rviz-visual-tools-4.1.4-np126py311hd5de103_13.conda
+  sha256: 1620c4a486f311b668de4972af7392926bfbd70a834ed33e7f14afcdf52df55a
+  md5: 708646c16efdaacb3f7c125a27831108
   depends:
   - eigen
   - python
@@ -66412,20 +66152,20 @@ packages:
   - ros-humble-tf2-geometry-msgs
   - ros-humble-trajectory-msgs
   - ros-humble-visualization-msgs
-  - ros2-distro-mutex 0.6.* humble_*
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - ros2-distro-mutex 0.7.* humble_*
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - numpy >=1.26.4,<2.0a0
   - qt-main >=5.15.15,<5.16.0a0
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
+  - numpy >=1.26.4,<2.0a0
   - python_abi 3.11.* *_cp311
-  - ros2-distro-mutex >=0.6.0,<0.7.0a0
   license: BSD-3-Clause
-  size: 483453
-  timestamp: 1736241054984
+  size: 482840
+  timestamp: 1753347342613
 - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-rviz2-11.2.15-np126py311h2c3b307_7.conda
   sha256: ee3283a41cf43a844dcf6c6fe326e5df23adbf0b5f7321b74d708e5179e02071
   md5: 24a647930dd99ac9a395b8c8490f92f1
@@ -66525,29 +66265,29 @@ packages:
   license: BSD-3-Clause
   size: 52707
   timestamp: 1736213109978
-- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-rviz2-11.2.15-np126py311h7d8ee0e_8.conda
-  sha256: 9786b98a1d348af1402489b7f5cc639c5143f9f141ac3033a42446bbad730084
-  md5: 2e5ad61bd398f91ecfe04d365a21bfd1
+- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-rviz2-11.2.18-np126py311hd5de103_13.conda
+  sha256: 09d322329498585af164584e418dae793685124b3bcec75191f5118ffba3f6fc
+  md5: ef69f66a3efaa233773220d6a4bad610
   depends:
   - python
   - ros-humble-ros-workspace
   - ros-humble-rviz-common
   - ros-humble-rviz-default-plugins
   - ros-humble-rviz-ogre-vendor
-  - ros2-distro-mutex 0.6.* humble_*
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - ros2-distro-mutex 0.7.* humble_*
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - numpy >=1.26.4,<2.0a0
   - qt-main >=5.15.15,<5.16.0a0
-  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - numpy >=1.26.4,<2.0a0
   - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
   license: BSD-3-Clause
-  size: 49793
-  timestamp: 1736240118605
+  size: 52137
+  timestamp: 1753345601453
 - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-sensor-msgs-4.2.4-np126py311h2c3b307_7.conda
   sha256: d5ee5588dc8f4ecfa831a31c70e0be13728ae19b3c30d8dcc6d5514e781bf317
   md5: 723fbaf94adae9ec48c6eb6f75b554af
@@ -66627,9 +66367,9 @@ packages:
   license: BSD-3-Clause
   size: 386233
   timestamp: 1736208877713
-- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-sensor-msgs-4.2.4-np126py311h7d8ee0e_8.conda
-  sha256: c187b52c3a7c1112e10f7b70c05e0c466c3626b8922d7743359841e3fb44b51d
-  md5: 0d28220b01f17d9ddc0e2979e581dccd
+- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-sensor-msgs-4.9.0-np126py311hd5de103_13.conda
+  sha256: 3e1c369e3d8fbeb4f87279fa6d6838ac54a8da75c75b4880b9e4ad4bce2eb076
+  md5: 54f9ab45ce93ac807115b9e960751d1b
   depends:
   - python
   - ros-humble-builtin-interfaces
@@ -66637,19 +66377,19 @@ packages:
   - ros-humble-ros-workspace
   - ros-humble-rosidl-default-runtime
   - ros-humble-std-msgs
-  - ros2-distro-mutex 0.6.* humble_*
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - ros2-distro-mutex 0.7.* humble_*
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
   - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
   - numpy >=1.26.4,<2.0a0
-  - ros2-distro-mutex >=0.6.0,<0.7.0a0
   license: BSD-3-Clause
-  size: 394287
-  timestamp: 1736231534008
+  size: 395091
+  timestamp: 1753326491022
 - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-sensor-msgs-py-4.2.4-np126py311h2c3b307_7.conda
   sha256: 4c91002093d9cf7c47f4c399f703bdb4418d104e9936cb7d09937b6c675582cb
   md5: e6b54b523a0d6ce5a8c013b10e41258d
@@ -66721,27 +66461,27 @@ packages:
   license: BSD-3-Clause
   size: 30043
   timestamp: 1736209058568
-- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-sensor-msgs-py-4.2.4-np126py311h7d8ee0e_8.conda
-  sha256: deb59f71af634d979c710b67ad6bc77af9456371765a95d0c5c1421b818000ac
-  md5: bc3da2b5d950657cbf6ec6d5476a295f
+- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-sensor-msgs-py-4.9.0-np126py311hd5de103_13.conda
+  sha256: 0ef6d8d87cfdcf20ca583d902381dd1154a86e7f2f83717dd066d9fa9be77794
+  md5: 126dedd42ee553c10f5767aa54dd603f
   depends:
   - numpy
   - python
   - ros-humble-ros-workspace
   - ros-humble-sensor-msgs
-  - ros2-distro-mutex 0.6.* humble_*
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - ros2-distro-mutex 0.7.* humble_*
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - ros2-distro-mutex >=0.6.0,<0.7.0a0
-  - numpy >=1.26.4,<2.0a0
   - python_abi 3.11.* *_cp311
+  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
   license: BSD-3-Clause
-  size: 27910
-  timestamp: 1736232121658
+  size: 28292
+  timestamp: 1753327971483
 - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-shape-msgs-4.2.4-np126py311h2c3b307_7.conda
   sha256: 1625a9f576b641cdd30964a7794735ceb7e3331e3a97564a1d6f138ba501268b
   md5: cd985400965b9ca9a31d2bae1a06a4ae
@@ -66812,27 +66552,27 @@ packages:
   license: BSD-3-Clause
   size: 105364
   timestamp: 1736208845288
-- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-shape-msgs-4.2.4-np126py311h7d8ee0e_8.conda
-  sha256: b4d34241c37ae22033676adae3de9ae0a2e31b87dcdb19528b2759e4184c3d85
-  md5: 9893c50120912b7d3fabb81272d66b55
+- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-shape-msgs-4.9.0-np126py311hd5de103_13.conda
+  sha256: e769de3c6ab5cdeaca14c94d09ee0e4219a6c7806a672ec65def80efe9bb6a00
+  md5: d8559d55affa3ccf259ad165b4c882b4
   depends:
   - python
   - ros-humble-geometry-msgs
   - ros-humble-ros-workspace
   - ros-humble-rosidl-default-runtime
-  - ros2-distro-mutex 0.6.* humble_*
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - ros2-distro-mutex 0.7.* humble_*
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
   - numpy >=1.26.4,<2.0a0
-  - ros2-distro-mutex >=0.6.0,<0.7.0a0
   - python_abi 3.11.* *_cp311
   license: BSD-3-Clause
-  size: 115140
-  timestamp: 1736231424027
+  size: 116924
+  timestamp: 1753326778074
 - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-shared-queues-vendor-0.15.13-np126py311h2c3b307_7.conda
   sha256: f7ebfd5d1b808d07bee8b731613fad977a9a9f3f5faf4a804e48dfbcb827b63b
   md5: f5e850892627cc24a26ca14e81430423
@@ -66894,25 +66634,25 @@ packages:
   license: BSD-3-Clause
   size: 65116
   timestamp: 1736206638370
-- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-shared-queues-vendor-0.15.13-np126py311h7d8ee0e_8.conda
-  sha256: 48f81d00d56b8b82829898f40aa738bbb1a4255dbfba85ea6df64e780ddfda2e
-  md5: 35bf52fef62304e0ccaf77054651628f
+- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-shared-queues-vendor-0.15.14-np126py311hd5de103_13.conda
+  sha256: 51dafe446124b0007f1551680ff128111b606954a11a40fcd4e5693ce255edd2
+  md5: dc3d2dbf1db7b37b9a8e228eb8ff2529
   depends:
   - python
   - ros-humble-ros-workspace
-  - ros2-distro-mutex 0.6.* humble_*
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - ros2-distro-mutex 0.7.* humble_*
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - ros2-distro-mutex >=0.6.0,<0.7.0a0
-  - numpy >=1.26.4,<2.0a0
   - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
+  - numpy >=1.26.4,<2.0a0
   license: BSD-3-Clause
-  size: 60056
-  timestamp: 1736207912225
+  size: 61222
+  timestamp: 1753312750183
 - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-spdlog-vendor-1.3.1-np126py311h6a008e1_7.conda
   sha256: c2f08f93c2d6f61109524eed6077e4c2a0d535e0a887de3b05bca2145014c29d
   md5: 511f6231235fcfbc355a5a6590766599
@@ -66983,27 +66723,27 @@ packages:
   license: BSD-3-Clause
   size: 24474
   timestamp: 1736207243786
-- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-spdlog-vendor-1.3.1-np126py311h1c95eb5_8.conda
-  sha256: 8acf9c0ba96092e50461502cc4e0b7bd30a6b6fddb503c781d756859acfc1b62
-  md5: dc83e33849b143047248dc5923adb67c
+- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-spdlog-vendor-1.3.1-np126py311hc120487_13.conda
+  sha256: d1eff449ea44fc07cc0932ded798784a0b0961c0446105830f254b5f7ee4a05d
+  md5: 0228bab0f455ef4cc582c134423ab1ba
   depends:
   - python
   - ros-humble-ros-workspace
-  - ros2-distro-mutex 0.6.* humble_*
+  - ros2-distro-mutex 0.7.* humble_*
   - spdlog
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - spdlog >=1.14.1,<1.15.0a0
   - python_abi 3.11.* *_cp311
-  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
+  - spdlog >=1.15.3,<1.16.0a0
   - numpy >=1.26.4,<2.0a0
   license: BSD-3-Clause
-  size: 21161
-  timestamp: 1736210500482
+  size: 23564
+  timestamp: 1753317468674
 - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-sqlite3-vendor-0.15.13-np126py311h2c3b307_7.conda
   sha256: a0c9ac4dc3129e534a1db2d672987920fdf4458961036fdfc192b308f9ff371a
   md5: 7d6edea29c8d9b572a6717b2bd0e0881
@@ -67074,27 +66814,27 @@ packages:
   license: BSD-3-Clause
   size: 22723
   timestamp: 1736206617268
-- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-sqlite3-vendor-0.15.13-np126py311h7d8ee0e_8.conda
-  sha256: e561bd6e34e129876134196ecb07de6cde0fe0e82340aa1bf6fb136c67ee8041
-  md5: 97c1b87c47f63e1b2f3de8eaf6a05d2d
+- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-sqlite3-vendor-0.15.14-np126py311hd5de103_13.conda
+  sha256: 4859c78f4b3e91a89f461a9cbd1314a1736c9cd706a4f2af1ef3eb79edd80aac
+  md5: 0560148cd76bc472a5255ce6fab77b82
   depends:
   - python
   - ros-humble-ros-workspace
-  - ros2-distro-mutex 0.6.* humble_*
+  - ros2-distro-mutex 0.7.* humble_*
   - sqlite
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - libsqlite >=3.47.2,<4.0a0
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
   - python_abi 3.11.* *_cp311
+  - libsqlite >=3.50.3,<4.0a0
   - numpy >=1.26.4,<2.0a0
-  - ros2-distro-mutex >=0.6.0,<0.7.0a0
   license: BSD-3-Clause
-  size: 19481
-  timestamp: 1736207835833
+  size: 20722
+  timestamp: 1753312663904
 - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-srdfdom-2.0.5-np126py311h2c3b307_7.conda
   sha256: bc9bcd75948575c0e8c3d88108e79acd84ae2015749b08bc98bd86a50fd654d2
   md5: 487331715410cf41cbc58c0e11c294fe
@@ -67186,9 +66926,9 @@ packages:
   license: BSD-3-Clause
   size: 95293
   timestamp: 1736210276636
-- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-srdfdom-2.0.5-np126py311h7d8ee0e_8.conda
-  sha256: 829ad7ffa05716be67b9a7ba8bfe6936ee4b04597ae4e02cb5bc93eb82ab1661
-  md5: 198cc4666a0fb597cf5fd81a222ae62c
+- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-srdfdom-2.0.7-np126py311hd5de103_13.conda
+  sha256: 6c43dc922a0106e7c5c0fcad07cb630f35c97a1f773723bc79bb5ad846a96f84
+  md5: f2f4f53a3004b3c30f965d84c7b492f4
   depends:
   - console_bridge
   - python
@@ -67197,21 +66937,21 @@ packages:
   - ros-humble-tinyxml2-vendor
   - ros-humble-urdf
   - ros-humble-urdfdom-py
-  - ros2-distro-mutex 0.6.* humble_*
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - ros2-distro-mutex 0.7.* humble_*
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
   - numpy >=1.26.4,<2.0a0
-  - python_abi 3.11.* *_cp311
   - libboost >=1.86.0,<1.87.0a0
   - console_bridge >=1.0.2,<1.1.0a0
+  - python_abi 3.11.* *_cp311
   license: BSD-3-Clause
-  size: 113293
-  timestamp: 1736234737666
+  size: 112042
+  timestamp: 1753333134821
 - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-sros2-0.10.5-np126py311h2c3b307_7.conda
   sha256: 06b3684c099d47646135d349aa525f3ed5b997d27e1d84d0d6778d36bf278e45
   md5: e85e7bbe01806ea370a094954343b9b9
@@ -67299,9 +67039,9 @@ packages:
   license: BSD-3-Clause
   size: 71820
   timestamp: 1736211155345
-- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-sros2-0.10.5-np126py311h7d8ee0e_8.conda
-  sha256: c53588dcf8e450cedc167cbc6acf3301eb12aeae99b4475226c7d86149f1a56a
-  md5: 569f5b43ccf3c7610a57042805fa01dd
+- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-sros2-0.10.6-np126py311hd5de103_13.conda
+  sha256: c9fc71dc46abe41ee763555b7b957e6efa46b159b6bd16262e87caeeec5a07c6
+  md5: b74ba572dcd06558f5c8c735847ce5d4
   depends:
   - cryptography
   - importlib_resources
@@ -67311,19 +67051,19 @@ packages:
   - ros-humble-rclpy
   - ros-humble-ros-workspace
   - ros-humble-ros2cli
-  - ros2-distro-mutex 0.6.* humble_*
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - ros2-distro-mutex 0.7.* humble_*
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - ros2-distro-mutex >=0.6.0,<0.7.0a0
   - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
   - numpy >=1.26.4,<2.0a0
   license: BSD-3-Clause
-  size: 67430
-  timestamp: 1736236474645
+  size: 68212
+  timestamp: 1753336701371
 - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-sros2-cmake-0.10.5-np126py311h2c3b307_7.conda
   sha256: a82738d225ee8f67b6050e847d2d69808e3e648a90f7beb645c9eedb7677b9b2
   md5: a4c9d6f957540d75554ecf38bf1c9b6c
@@ -67394,27 +67134,27 @@ packages:
   license: BSD-3-Clause
   size: 34589
   timestamp: 1736211768337
-- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-sros2-cmake-0.10.5-np126py311h7d8ee0e_8.conda
-  sha256: ec1ca5ecd532d9f2528f51427283374382f0a2d5f96c083cdb4d8f3a523d67e3
-  md5: 103cadb275c808f71fc5307ae79a9e79
+- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-sros2-cmake-0.10.6-np126py311hd5de103_13.conda
+  sha256: c2129d94dff24e7fe07f8f938a635e18dc51a43a61f05ab595dbf4f7b7a2e082
+  md5: 351a43f79738bb8477d34ae0bf849aaf
   depends:
   - python
   - ros-humble-ros-workspace
   - ros-humble-ros2cli
   - ros-humble-sros2
-  - ros2-distro-mutex 0.6.* humble_*
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - ros2-distro-mutex 0.7.* humble_*
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
   - numpy >=1.26.4,<2.0a0
-  - ros2-distro-mutex >=0.6.0,<0.7.0a0
   - python_abi 3.11.* *_cp311
   license: BSD-3-Clause
-  size: 31390
-  timestamp: 1736237472309
+  size: 32839
+  timestamp: 1753339685548
 - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-statistics-msgs-1.2.1-np126py311h2c3b307_7.conda
   sha256: f3473634c3d0ff080603d470533dac5ca61d808dc0f226bd65efd81d2094288d
   md5: e46f0fc73a7da6bfe440457fe5e42b13
@@ -67486,27 +67226,27 @@ packages:
   license: BSD-3-Clause
   size: 91804
   timestamp: 1736208536613
-- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-statistics-msgs-1.2.1-np126py311h7d8ee0e_8.conda
-  sha256: 44c0eaf0839a711106e912003032c09dbb3fc4683699bc2071b1cbf1fec33824
-  md5: 11996744ae8f9827135fa14992cdecbb
+- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-statistics-msgs-1.2.1-np126py311hd5de103_13.conda
+  sha256: e302452e1f3aaeee84639d650fcb9abcd5be0c9d3baf3709f2603f97d172d455
+  md5: 52b6c2b4a65f311560f7e9a0621b1a01
   depends:
   - python
   - ros-humble-builtin-interfaces
   - ros-humble-ros-workspace
   - ros-humble-rosidl-default-runtime
-  - ros2-distro-mutex 0.6.* humble_*
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - ros2-distro-mutex 0.7.* humble_*
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - numpy >=1.26.4,<2.0a0
-  - ros2-distro-mutex >=0.6.0,<0.7.0a0
   - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
+  - numpy >=1.26.4,<2.0a0
   license: BSD-3-Clause
-  size: 101369
-  timestamp: 1736230404450
+  size: 103654
+  timestamp: 1753324381627
 - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-std-msgs-4.2.4-np126py311h2c3b307_7.conda
   sha256: a0ca6df6139c14b7b0d9495661ffa69b9aa6761848c6ff477c05fccd2a8d9b3b
   md5: 20cc53f864b7f5f1607bc2a63bcfa65d
@@ -67576,27 +67316,27 @@ packages:
   license: BSD-3-Clause
   size: 245036
   timestamp: 1736208489978
-- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-std-msgs-4.2.4-np126py311h7d8ee0e_8.conda
-  sha256: 06b58690ca9e8894820d0f415e5cf70668483b4cf9553cfc05bbaf966da5696b
-  md5: 218b9f6dacdfb3f352c3532d236455f9
+- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-std-msgs-4.9.0-np126py311hd5de103_13.conda
+  sha256: d0b2e97572ee4bd5e9aa6a4b67cd36cfab57cbd07b4dde39392bfb75f55c8f53
+  md5: dd17ae64465e2627c55443b4ca4b4018
   depends:
   - python
   - ros-humble-builtin-interfaces
   - ros-humble-ros-workspace
   - ros-humble-rosidl-default-runtime
-  - ros2-distro-mutex 0.6.* humble_*
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - ros2-distro-mutex 0.7.* humble_*
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
   - python_abi 3.11.* *_cp311
   - numpy >=1.26.4,<2.0a0
   license: BSD-3-Clause
-  size: 251403
-  timestamp: 1736230223892
+  size: 252366
+  timestamp: 1753324261347
 - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-std-srvs-4.2.4-np126py311h2c3b307_7.conda
   sha256: 825d91a607a17d01f682620fc9db3b58a9ce756bc74e2ac10b2742017af0e8b5
   md5: 46a2844ab9a70c17513b557bce3d2a80
@@ -67663,26 +67403,26 @@ packages:
   license: BSD-3-Clause
   size: 92650
   timestamp: 1736208456285
-- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-std-srvs-4.2.4-np126py311h7d8ee0e_8.conda
-  sha256: eae0dc1a8bc9591607839e3741bee916e1c2fe7e744f9fea787706ff9d891e31
-  md5: 44ab9b66e39e07a961f5d198821f993d
+- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-std-srvs-4.9.0-np126py311hd5de103_13.conda
+  sha256: 04e6e57c5abaf7c1a2037d9f59794e95a82a728a3a00fa19599afec317ed740d
+  md5: 0e2e7699cce24b623e6b3e909c687953
   depends:
   - python
   - ros-humble-ros-workspace
   - ros-humble-rosidl-default-runtime
-  - ros2-distro-mutex 0.6.* humble_*
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - ros2-distro-mutex 0.7.* humble_*
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - python_abi 3.11.* *_cp311
-  - ros2-distro-mutex >=0.6.0,<0.7.0a0
   - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
   license: BSD-3-Clause
-  size: 102334
-  timestamp: 1736230006610
+  size: 104184
+  timestamp: 1753323353116
 - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-stereo-msgs-4.2.4-np126py311h2c3b307_7.conda
   sha256: abd46f0ec286d815598d99c672511aa7d4c425589006ca743b72f7f6f6f75db2
   md5: 72f623956cdb15061572a89ee724f6e0
@@ -67756,28 +67496,28 @@ packages:
   license: BSD-3-Clause
   size: 71968
   timestamp: 1736209047923
-- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-stereo-msgs-4.2.4-np126py311h7d8ee0e_8.conda
-  sha256: 6de2c9e3ff252df5867382649c44acf7454f08ecbf3cfa4fd663560031cbe6b2
-  md5: bd8efb5e1e1104a544276c7169b73030
+- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-stereo-msgs-4.9.0-np126py311hd5de103_13.conda
+  sha256: 956947c52dc2a10b1629b8a1c22c381375773cdffab4c2c90c0ffdb1e8195059
+  md5: 64ddc1c8c624a1bcbd713c424ddc0505
   depends:
   - python
   - ros-humble-ros-workspace
   - ros-humble-rosidl-default-runtime
   - ros-humble-sensor-msgs
   - ros-humble-std-msgs
-  - ros2-distro-mutex 0.6.* humble_*
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - ros2-distro-mutex 0.7.* humble_*
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - ros2-distro-mutex >=0.6.0,<0.7.0a0
   - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
   - python_abi 3.11.* *_cp311
   license: BSD-3-Clause
-  size: 80996
-  timestamp: 1736232080898
+  size: 84423
+  timestamp: 1753327907251
 - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-tcb-span-1.0.2-np126py311h2c3b307_7.conda
   sha256: 6c4d652fa5cf2f7eaf2d612ba82f082974537c4341c54b9c241bf986d7001412
   md5: 54da39836c40fbfdd7f98a2ce8d5470e
@@ -67840,25 +67580,25 @@ packages:
   license: BSD-3-Clause
   size: 26364
   timestamp: 1736206654382
-- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-tcb-span-1.0.2-np126py311h7d8ee0e_8.conda
-  sha256: e0a2155b12e1fb51566bbbb011cab8e7e3e8edb41ef42a79cc68349610c5be98
-  md5: 25062f28822b1686417b16df05b965ab
+- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-tcb-span-1.0.2-np126py311hd5de103_13.conda
+  sha256: 70d5d1b21d74424e90847bf7726cbf85d0050bfba8231ebbc292a47cf182c826
+  md5: b60fbc94c57dd84a9289f0be2ecaa701
   depends:
   - python
   - ros-humble-ros-workspace
-  - ros2-distro-mutex 0.6.* humble_*
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - ros2-distro-mutex 0.7.* humble_*
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
   - numpy >=1.26.4,<2.0a0
   - python_abi 3.11.* *_cp311
   license: BSD-3-Clause
-  size: 23174
-  timestamp: 1736208016945
+  size: 24333
+  timestamp: 1753312718456
 - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-test-msgs-1.2.1-np126py311h2c3b307_7.conda
   sha256: b8537e49f7d48add765268ddeb8277274c32e08c8f76e4ae50529b98aba3cdc4
   md5: c9129b302c4c3c39ba394b50844cbd46
@@ -67933,28 +67673,28 @@ packages:
   license: BSD-3-Clause
   size: 556614
   timestamp: 1736208636455
-- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-test-msgs-1.2.1-np126py311h7d8ee0e_8.conda
-  sha256: d75cfd5ff0e7fddf217fff14b17814f3d1ba657cf1c193edb995348cd98e1ff2
-  md5: 758b09be6ea24baf862870ee36d931e4
+- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-test-msgs-1.2.1-np126py311hd5de103_13.conda
+  sha256: ad51653903ad210ca0bbc2ead09da4045cf1f634e56bb8bc086b3dfc7900190a
+  md5: e13a2bb96a42c547e2ee4388cbc15a82
   depends:
   - python
   - ros-humble-action-msgs
   - ros-humble-builtin-interfaces
   - ros-humble-ros-workspace
   - ros-humble-rosidl-default-runtime
-  - ros2-distro-mutex 0.6.* humble_*
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - ros2-distro-mutex 0.7.* humble_*
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - ros2-distro-mutex >=0.6.0,<0.7.0a0
-  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
   - python_abi 3.11.* *_cp311
+  - numpy >=1.26.4,<2.0a0
   license: BSD-3-Clause
-  size: 519723
-  timestamp: 1736230764251
+  size: 520456
+  timestamp: 1753324864574
 - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-tf2-0.25.10-np126py311h2c3b307_7.conda
   sha256: 6fe02d77e6da7f4a6b2731ae988de84494e11bd29c20cb91a05615687ef2ba52
   md5: e9b8816b76d59ee653a52a9efdaa2715
@@ -68045,9 +67785,9 @@ packages:
   license: BSD-3-Clause
   size: 114163
   timestamp: 1736208924463
-- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-tf2-0.25.10-np126py311h7d8ee0e_8.conda
-  sha256: 4533bd0a407d48617dab1b1d156a658b375b24c7cfc23649bf77641f145c2d86
-  md5: 11aa4df3a48a38aeaeb09994f1b9bb82
+- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-tf2-0.25.14-np126py311hd5de103_13.conda
+  sha256: 4a2c29db5a63fcae2f7acb272e4123ae4431e90416afa1ccc6af9bc10ea695d4
+  md5: e1d97baaabe5b3a1323b36e023c840b0
   depends:
   - console_bridge
   - python
@@ -68057,20 +67797,20 @@ packages:
   - ros-humble-rcutils
   - ros-humble-ros-workspace
   - ros-humble-rosidl-runtime-cpp
-  - ros2-distro-mutex 0.6.* humble_*
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - ros2-distro-mutex 0.7.* humble_*
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - numpy >=1.26.4,<2.0a0
-  - ros2-distro-mutex >=0.6.0,<0.7.0a0
   - console_bridge >=1.0.2,<1.1.0a0
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
   - python_abi 3.11.* *_cp311
+  - numpy >=1.26.4,<2.0a0
   license: BSD-3-Clause
-  size: 129216
-  timestamp: 1736231654412
+  size: 131567
+  timestamp: 1753326659771
 - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-tf2-bullet-0.25.10-np126py311h2c3b307_7.conda
   sha256: 4ae0a06da06cfaf288cfb7d9e400f3ca49a34efdb46a19111bc245361ac0f388
   md5: 45b2988c7f61043dbb881bdb956171a1
@@ -68149,9 +67889,9 @@ packages:
   license: BSD-3-Clause
   size: 39222
   timestamp: 1736210952296
-- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-tf2-bullet-0.25.10-np126py311h7d8ee0e_8.conda
-  sha256: aa9d1ad1e577a368d047c93e1de8ec96899b3ff9eda469aead7abd2040143a6f
-  md5: b33a98482325f43de7f65b19a9611d39
+- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-tf2-bullet-0.25.14-np126py311hd5de103_13.conda
+  sha256: ad1c39ab19a326dac0c2554c2953ed246f0cefdebfda54688e15920cdb081998
+  md5: bbbfe73eba39f74fca121f992dac60a7
   depends:
   - bullet
   - python
@@ -68159,19 +67899,19 @@ packages:
   - ros-humble-ros-workspace
   - ros-humble-tf2
   - ros-humble-tf2-ros
-  - ros2-distro-mutex 0.6.* humble_*
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - ros2-distro-mutex 0.7.* humble_*
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - ros2-distro-mutex >=0.6.0,<0.7.0a0
-  - python_abi 3.11.* *_cp311
   - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
   license: BSD-3-Clause
-  size: 35354
-  timestamp: 1736236077049
+  size: 36706
+  timestamp: 1753335631816
 - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-tf2-eigen-0.25.10-np126py311h2c3b307_7.conda
   sha256: 6505c33db221171103ba8184c74f491e5a8c61aa8f780a2ee5b4598feab8fd98
   md5: dba8e4e58ca850edcae33dd2a11eda5a
@@ -68250,9 +67990,9 @@ packages:
   license: BSD-3-Clause
   size: 41011
   timestamp: 1736211061406
-- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-tf2-eigen-0.25.10-np126py311h7d8ee0e_8.conda
-  sha256: 815abcf178dc774bd12f2885ff089edb6cebab202667b8e20efc03fd43171437
-  md5: c45277343b7e86230d6c2fd02f66aadc
+- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-tf2-eigen-0.25.14-np126py311hd5de103_13.conda
+  sha256: c0806536f41f2d45202a262c6b51427bb233e108c0d4c6c77be7604e0cfbde6e
+  md5: 7997b39541ab5e6b08195d135fc9a73b
   depends:
   - eigen
   - python
@@ -68260,19 +68000,19 @@ packages:
   - ros-humble-ros-workspace
   - ros-humble-tf2
   - ros-humble-tf2-ros
-  - ros2-distro-mutex 0.6.* humble_*
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - ros2-distro-mutex 0.7.* humble_*
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - numpy >=1.26.4,<2.0a0
   - python_abi 3.11.* *_cp311
-  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
   license: BSD-3-Clause
-  size: 39454
-  timestamp: 1736236128363
+  size: 39183
+  timestamp: 1753335682774
 - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-tf2-eigen-kdl-0.25.10-np126py311h2c3b307_7.conda
   sha256: db5a4c33c50100339e63ac618fbf3063a6a483c2912a86e92ca5951d22e85e7a
   md5: 7b695b98df9351330e188be11a8a71f1
@@ -68348,28 +68088,28 @@ packages:
   license: BSD-3-Clause
   size: 37742
   timestamp: 1736209155656
-- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-tf2-eigen-kdl-0.25.10-np126py311h7d8ee0e_8.conda
-  sha256: b46c5d7b70a5a524b53e22725b066f71234102efbca0170d0ccf8ab1c785cccf
-  md5: dba241f17847714c87760482fa49b864
+- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-tf2-eigen-kdl-0.25.14-np126py311hd5de103_13.conda
+  sha256: c9f587194f465107a1c5fd51d86589d512f7451c5d42ad39189a652d4b8710d1
+  md5: be0f5734b8211c0a3594d056dcbd7aee
   depends:
   - eigen
   - python
   - ros-humble-orocos-kdl-vendor
   - ros-humble-ros-workspace
   - ros-humble-tf2
-  - ros2-distro-mutex 0.6.* humble_*
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - ros2-distro-mutex 0.7.* humble_*
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - numpy >=1.26.4,<2.0a0
-  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
   - python_abi 3.11.* *_cp311
+  - numpy >=1.26.4,<2.0a0
   license: BSD-3-Clause
-  size: 39392
-  timestamp: 1736232130700
+  size: 40967
+  timestamp: 1753328390642
 - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-tf2-geometry-msgs-0.25.10-np126py311h2c3b307_7.conda
   sha256: 9b8144f0a34ae074c395f1b3569f081ede62b7ac1a18402b2ece829e219b9c9d
   md5: c478f0630e6a89a61308365eb6ad5372
@@ -68457,9 +68197,9 @@ packages:
   license: BSD-3-Clause
   size: 53170
   timestamp: 1736211045199
-- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-tf2-geometry-msgs-0.25.10-np126py311h7d8ee0e_8.conda
-  sha256: 0a674b8ac6c44efb7cfaf20a91e4db118b460910a0dadcb7dfbc1e24e5b13dff
-  md5: 15fdb16e6fa82991130683a53a0d6653
+- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-tf2-geometry-msgs-0.25.14-np126py311hd5de103_13.conda
+  sha256: 8d1d61a693621551de45fb62ae20ebf25d2c03e059b2e4aadab72b0cdc8cebed
+  md5: d34314fa85178d98fd4e7721711b96d8
   depends:
   - numpy
   - python
@@ -68469,19 +68209,19 @@ packages:
   - ros-humble-tf2
   - ros-humble-tf2-ros
   - ros-humble-tf2-ros-py
-  - ros2-distro-mutex 0.6.* humble_*
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - ros2-distro-mutex 0.7.* humble_*
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
   - python_abi 3.11.* *_cp311
-  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
   - numpy >=1.26.4,<2.0a0
   license: BSD-3-Clause
-  size: 49858
-  timestamp: 1736236092075
+  size: 51446
+  timestamp: 1753335626843
 - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-tf2-kdl-0.25.10-np126py311h2c3b307_7.conda
   sha256: 0ff26f8c3f00e78b68f1d5b1f2e261d056ec628d99ae35ab5c0206ae6fd69429
   md5: 32f2383f045d0c5f30b79b3a74c8e2eb
@@ -68568,31 +68308,32 @@ packages:
   license: BSD-3-Clause
   size: 40654
   timestamp: 1736211027673
-- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-tf2-kdl-0.25.10-np126py311h7d8ee0e_8.conda
-  sha256: 4464a970c693d861418a30bd5d9f1152fecb9be88ad2b13ca5c3877fa5ad2a04
-  md5: 38665dd2d8d22d6b306632f363f9be89
+- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-tf2-kdl-0.25.14-np126py311hd5de103_13.conda
+  sha256: 0daed93db8785659509e3ec10d2136565c2b677ded038185f36a8b3c7e2b7126
+  md5: d14c228c7f23073da296856a41a20818
   depends:
   - python
   - ros-humble-builtin-interfaces
   - ros-humble-geometry-msgs
   - ros-humble-orocos-kdl-vendor
+  - ros-humble-python-orocos-kdl-vendor
   - ros-humble-ros-workspace
   - ros-humble-tf2
   - ros-humble-tf2-ros
   - ros-humble-tf2-ros-py
-  - ros2-distro-mutex 0.6.* humble_*
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - ros2-distro-mutex 0.7.* humble_*
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - numpy >=1.26.4,<2.0a0
   - python_abi 3.11.* *_cp311
-  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
+  - numpy >=1.26.4,<2.0a0
   license: BSD-3-Clause
-  size: 39132
-  timestamp: 1736236053228
+  size: 38985
+  timestamp: 1753335572741
 - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-tf2-msgs-0.25.10-np126py311h2c3b307_7.conda
   sha256: a2776c3b977fc8675bbff86b3f34ae17b834b2c83564a77fd69cfc6d2714b332
   md5: 0dc644a401df0c9a082f8329c1263d0e
@@ -68672,9 +68413,9 @@ packages:
   license: BSD-3-Clause
   size: 151704
   timestamp: 1736208822
-- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-tf2-msgs-0.25.10-np126py311h7d8ee0e_8.conda
-  sha256: 71a5a71964d47fe2b7cd4b635012a8cb758d4fa9e2eedc7649f1bbe157578b45
-  md5: 845fe8e5cf0f7fd6f0ac7bbbfd7bff13
+- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-tf2-msgs-0.25.14-np126py311hd5de103_13.conda
+  sha256: 60c9a4b5022ba7861fcd77acf813385b412f282e9aaf4317186d93f5f121b354
+  md5: efbcddc74b6f7d7355212a56696a6d60
   depends:
   - python
   - ros-humble-action-msgs
@@ -68682,19 +68423,19 @@ packages:
   - ros-humble-geometry-msgs
   - ros-humble-ros-workspace
   - ros-humble-rosidl-default-runtime
-  - ros2-distro-mutex 0.6.* humble_*
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - ros2-distro-mutex 0.7.* humble_*
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
   - numpy >=1.26.4,<2.0a0
   - python_abi 3.11.* *_cp311
   license: BSD-3-Clause
-  size: 164878
-  timestamp: 1736231296065
+  size: 167547
+  timestamp: 1753326713942
 - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-tf2-py-0.25.10-np126py311h2c3b307_7.conda
   sha256: 578471eb8eb5f27c9d34ab5997534161b85d196a70fa58e428ea54c35023e8c5
   md5: fa58cb44e231cfa8aa7769e0452b8634
@@ -68778,9 +68519,9 @@ packages:
   license: BSD-3-Clause
   size: 48469
   timestamp: 1736209616378
-- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-tf2-py-0.25.10-np126py311h7d8ee0e_8.conda
-  sha256: 95d3859ba600199a7a7319078a031f17744f00c9f2711f6438943f70fc964c75
-  md5: 7ae276c416c256421e20a95b4a69bdeb
+- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-tf2-py-0.25.14-np126py311hd5de103_13.conda
+  sha256: 2a20e3b031bfe702fd511258d76f32978d99bb7792caaffec26e0dfeb679d11b
+  md5: 6abedaf79713b87c1933d393b894a846
   depends:
   - python
   - ros-humble-builtin-interfaces
@@ -68789,19 +68530,19 @@ packages:
   - ros-humble-ros-workspace
   - ros-humble-rpyutils
   - ros-humble-tf2
-  - ros2-distro-mutex 0.6.* humble_*
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - ros2-distro-mutex 0.7.* humble_*
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
   - python_abi 3.11.* *_cp311
-  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
   - numpy >=1.26.4,<2.0a0
   license: BSD-3-Clause
-  size: 45972
-  timestamp: 1736233986136
+  size: 47531
+  timestamp: 1753331728053
 - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-tf2-ros-0.25.10-np126py311h2c3b307_7.conda
   sha256: 4c18b4d53bbdf042f4371926a9ef0eff621903dc0c7e25043e87e4d5a6ab8a60
   md5: 8d313bcb9449e2957fdbf556505db01c
@@ -68900,9 +68641,9 @@ packages:
   license: BSD-3-Clause
   size: 333985
   timestamp: 1736210584897
-- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-tf2-ros-0.25.10-np126py311h7d8ee0e_8.conda
-  sha256: 608de76d4508a16d8ac119e5898aa06bcc071c2b18037f014220dcbb509f2647
-  md5: 307c66fb67f0a5cffd457fe3e9085bc6
+- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-tf2-ros-0.25.14-np126py311hd5de103_13.conda
+  sha256: c7afc2030dd9868d503b27dfdff3c589078ba15b00b0d61f02b1e96e2e9f78bc
+  md5: 81eeefcd047ba10acdf78da9565ffda4
   depends:
   - python
   - ros-humble-builtin-interfaces
@@ -68915,19 +68656,19 @@ packages:
   - ros-humble-ros-workspace
   - ros-humble-tf2
   - ros-humble-tf2-msgs
-  - ros2-distro-mutex 0.6.* humble_*
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - ros2-distro-mutex 0.7.* humble_*
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - numpy >=1.26.4,<2.0a0
   - python_abi 3.11.* *_cp311
-  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
+  - numpy >=1.26.4,<2.0a0
   license: BSD-3-Clause
-  size: 286723
-  timestamp: 1736235303473
+  size: 288371
+  timestamp: 1753334364177
 - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-tf2-ros-py-0.25.10-np126py311h2c3b307_7.conda
   sha256: 9df298e6371ce208b40d72daa90cab8b86a5620d29977b3d9acded105b5606b9
   md5: 68a671871fdfb526f021115745acbc03
@@ -69015,9 +68756,9 @@ packages:
   license: BSD-3-Clause
   size: 44434
   timestamp: 1736210258356
-- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-tf2-ros-py-0.25.10-np126py311h7d8ee0e_8.conda
-  sha256: d01734d8d723c4a864fcf43e1a123ec9ded1f7c8f675e9d855e587d059464c29
-  md5: 2f797996b6549cebce97845c0650876f
+- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-tf2-ros-py-0.25.14-np126py311hd5de103_13.conda
+  sha256: 28c7a373fa23924263fe9f8ffb96e264198f230e36e4d9f9c2700e282edb3516
+  md5: 3adc0c82ae85ed886eb29402dbcf0262
   depends:
   - python
   - ros-humble-geometry-msgs
@@ -69027,19 +68768,19 @@ packages:
   - ros-humble-std-msgs
   - ros-humble-tf2-msgs
   - ros-humble-tf2-py
-  - ros2-distro-mutex 0.6.* humble_*
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - ros2-distro-mutex 0.7.* humble_*
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
   - numpy >=1.26.4,<2.0a0
   - python_abi 3.11.* *_cp311
-  - ros2-distro-mutex >=0.6.0,<0.7.0a0
   license: BSD-3-Clause
-  size: 42203
-  timestamp: 1736234664892
+  size: 42728
+  timestamp: 1753333023954
 - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-tf2-sensor-msgs-0.25.10-np126py311h2c3b307_7.conda
   sha256: de38a0dfe18d1b10d5d72398447c0b20f5a66b5c7ae836f8095a111b55b7e661
   md5: 8ec7342886b74cb140f16b92d0d047f5
@@ -69126,31 +68867,35 @@ packages:
   license: BSD-3-Clause
   size: 38156
   timestamp: 1736210910483
-- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-tf2-sensor-msgs-0.25.10-np126py311h7d8ee0e_8.conda
-  sha256: e120caa132f233d618da99febb1789071d4482253034041ac5f42c26d6b926fd
-  md5: 3ba168b85669f91c86fb6956e5a3fc09
+- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-tf2-sensor-msgs-0.25.14-np126py311hd5de103_13.conda
+  sha256: f430195702b8735dd3ac65e6dcc800ea826e187cdd6a11e45bbff0dda84a7a9e
+  md5: abbf918e7d1af7149ce1c07edd8b320b
   depends:
   - eigen
+  - numpy
   - python
   - ros-humble-eigen3-cmake-module
+  - ros-humble-geometry-msgs
   - ros-humble-ros-workspace
   - ros-humble-sensor-msgs
+  - ros-humble-sensor-msgs-py
+  - ros-humble-std-msgs
   - ros-humble-tf2
   - ros-humble-tf2-ros
   - ros-humble-tf2-ros-py
-  - ros2-distro-mutex 0.6.* humble_*
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - ros2-distro-mutex 0.7.* humble_*
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
   - numpy >=1.26.4,<2.0a0
   - python_abi 3.11.* *_cp311
-  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
   license: BSD-3-Clause
-  size: 37190
-  timestamp: 1736236058899
+  size: 42229
+  timestamp: 1753335848255
 - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-tf2-tools-0.25.10-np126py311h2c3b307_7.conda
   sha256: 7270b4ef9fd242e0fb3c3f3970f271a3789efb62277719339626b74ec5c045b6
   md5: a00a7703b8519ca887eaa7fdb28b657e
@@ -69237,9 +68982,9 @@ packages:
   license: BSD-3-Clause
   size: 21139
   timestamp: 1736210709401
-- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-tf2-tools-0.25.10-np126py311h7d8ee0e_8.conda
-  sha256: ebbf9ea3cf5380a25bba6c6319c597f69d0a959f24e2ae880a5023564d56c77c
-  md5: cc2b3ce1d5b93962ed4f9e393ed77ce3
+- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-tf2-tools-0.25.14-np126py311hd5de103_13.conda
+  sha256: b34d1fdd019c5068e4684d53aeaba5223e24a9bccc670f350284ddd57a7d9689
+  md5: b55ca1b340ac1dbc10b5a4ba733f3f0c
   depends:
   - graphviz
   - python
@@ -69249,19 +68994,19 @@ packages:
   - ros-humble-tf2-msgs
   - ros-humble-tf2-py
   - ros-humble-tf2-ros-py
-  - ros2-distro-mutex 0.6.* humble_*
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - ros2-distro-mutex 0.7.* humble_*
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
   - python_abi 3.11.* *_cp311
   - numpy >=1.26.4,<2.0a0
-  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
   license: BSD-3-Clause
-  size: 26625
-  timestamp: 1736235205001
+  size: 26806
+  timestamp: 1753334833814
 - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-tinyxml-vendor-0.8.3-np126py311h2c3b307_7.conda
   sha256: 76313f87e43fc876d9dbf339ae5f2437b7e1485051de42442fd32cabce90f357
   md5: 314342ffe6366e117e03c233c4fc7467
@@ -69332,27 +69077,27 @@ packages:
   license: BSD-3-Clause
   size: 22467
   timestamp: 1736206634655
-- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-tinyxml-vendor-0.8.3-np126py311h7d8ee0e_8.conda
-  sha256: f8ed7eca96d03c99c0e0d041de3f74bb6211fdaa63245a931b141bcbdae8e7a6
-  md5: c5485178390e6b6cc28d010278fd086f
+- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-tinyxml-vendor-0.8.3-np126py311hd5de103_13.conda
+  sha256: 14d4b044e800aea2e67cb36dd3b4de1b4d32dd27d98b5ca84af879964ba2db5b
+  md5: 31a4b1b2d94817bef7eb38eb09b2f2f7
   depends:
   - python
   - ros-humble-ros-workspace
-  - ros2-distro-mutex 0.6.* humble_*
+  - ros2-distro-mutex 0.7.* humble_*
   - tinyxml
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
   - python_abi 3.11.* *_cp311
-  - numpy >=1.26.4,<2.0a0
-  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
   - tinyxml
+  - numpy >=1.26.4,<2.0a0
   license: BSD-3-Clause
-  size: 19283
-  timestamp: 1736207939938
+  size: 20536
+  timestamp: 1753313028531
 - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-tinyxml2-vendor-0.7.6-np126py311h2c3b307_7.conda
   sha256: 82cddc9517bd4660bea7a2471125f9eb9ede985a89f55f3b8f99f537a81c904c
   md5: 29e0571ab48c0924ab11ec97cd82bb6d
@@ -69422,27 +69167,27 @@ packages:
   license: BSD-3-Clause
   size: 22674
   timestamp: 1736206641776
-- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-tinyxml2-vendor-0.7.6-np126py311h7d8ee0e_8.conda
-  sha256: 567feba6b787c95446035b8129a5bfd6483e92855a559ccd20a7bd1a72468787
-  md5: 434ec3051699d57d0831ff95c14ab8e4
+- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-tinyxml2-vendor-0.7.6-np126py311hd5de103_14.conda
+  sha256: 54e83372626fdab2ac68c794aab090e4762101e34201279c7c9ae2eb800f0540
+  md5: e536f081dad775c1489e2657c92c840d
   depends:
   - python
   - ros-humble-ros-workspace
-  - ros2-distro-mutex 0.6.* humble_*
+  - ros2-distro-mutex 0.7.* humble_*
   - tinyxml2
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
   - numpy >=1.26.4,<2.0a0
-  - tinyxml2 >=10.0.0,<11.0a0
-  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
+  - tinyxml2 >=11.0.0,<11.1.0a0
   - python_abi 3.11.* *_cp311
   license: BSD-3-Clause
-  size: 19443
-  timestamp: 1736207966929
+  size: 21348
+  timestamp: 1757431857946
 - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-tl-expected-1.0.2-np126py311h2c3b307_7.conda
   sha256: 2e508810c29752b16737ea7c6b1393ed5091adaa1ce9cef537c26be26c7fa849
   md5: 56725777e772abc68ea358c2c2dc35c8
@@ -69507,25 +69252,25 @@ packages:
   license: BSD-3-Clause
   size: 31955
   timestamp: 1736206648252
-- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-tl-expected-1.0.2-np126py311h7d8ee0e_8.conda
-  sha256: d8c200d32d690a077554cf0f3f75835cdb25a3a166f0c6c768068967af3178d2
-  md5: 01e51edcc07d247e05917463b2bb9a43
+- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-tl-expected-1.0.2-np126py311hd5de103_13.conda
+  sha256: c13e79907c9cfb3e8a6baa1a8704f3a37c760d3dd1fc220c427f1d6ef827c30b
+  md5: c3ff7828bb40b61d8b9f83eecee7f189
   depends:
   - python
   - ros-humble-ros-workspace
-  - ros2-distro-mutex 0.6.* humble_*
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - ros2-distro-mutex 0.7.* humble_*
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
   - python_abi 3.11.* *_cp311
   - numpy >=1.26.4,<2.0a0
-  - ros2-distro-mutex >=0.6.0,<0.7.0a0
   license: BSD-3-Clause
-  size: 28881
-  timestamp: 1736207992922
+  size: 30001
+  timestamp: 1753313111616
 - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-tracetools-4.1.1-np126py311h2c3b307_7.conda
   sha256: c4cdb72d6d393c8f687632e4038f4936c8b05737607e74dc1f9d5b4d719d5a9e
   md5: b7b04a244845adb1c027beba4612b05b
@@ -69588,25 +69333,25 @@ packages:
   license: BSD-3-Clause
   size: 36251
   timestamp: 1736207512523
-- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-tracetools-4.1.1-np126py311h7d8ee0e_8.conda
-  sha256: 99f8f524298abe684a0a898750f816601012da1eb5a209e92214a2707b55cdb5
-  md5: 60e859a1b9746f1c4939f26752542cc4
+- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-tracetools-4.1.1-np126py311hd5de103_13.conda
+  sha256: c3400a8b4f1b953d5a5b04bb54822b1317619310221b7957639b65073610bf26
+  md5: c78bb3e7ae6e9b4a8de748d4c5f1614a
   depends:
   - python
   - ros-humble-ros-workspace
-  - ros2-distro-mutex 0.6.* humble_*
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - ros2-distro-mutex 0.7.* humble_*
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - ros2-distro-mutex >=0.6.0,<0.7.0a0
   - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
   - numpy >=1.26.4,<2.0a0
   license: BSD-3-Clause
-  size: 28520
-  timestamp: 1736226542206
+  size: 30187
+  timestamp: 1753318816812
 - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-trajectory-msgs-4.2.4-np126py311h2c3b307_7.conda
   sha256: 2c45c08a48609c91cf7ddf99a07d444532df62cfdd3e0d27f2ced33759e300bb
   md5: b732868f9f69f638fe1018db2b89b066
@@ -69686,9 +69431,9 @@ packages:
   license: BSD-3-Clause
   size: 118954
   timestamp: 1736208861451
-- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-trajectory-msgs-4.2.4-np126py311h7d8ee0e_8.conda
-  sha256: ddc2c6d485af7e7cd96ed45721770e3c061d3f39b5d1f5267489c0139ac620d8
-  md5: 039f58376444b90bed2063499fbddd15
+- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-trajectory-msgs-4.9.0-np126py311hd5de103_13.conda
+  sha256: 88a5fd2dafa236a18f6bb8577d5e9ddf6e0725ba32dabb933b6a82aa2d766f7c
+  md5: e8f6abc89e6e029ce87cf069b19bc1a6
   depends:
   - python
   - ros-humble-builtin-interfaces
@@ -69696,19 +69441,19 @@ packages:
   - ros-humble-ros-workspace
   - ros-humble-rosidl-default-runtime
   - ros-humble-std-msgs
-  - ros2-distro-mutex 0.6.* humble_*
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - ros2-distro-mutex 0.7.* humble_*
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - ros2-distro-mutex >=0.6.0,<0.7.0a0
-  - python_abi 3.11.* *_cp311
   - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
   license: BSD-3-Clause
-  size: 126885
-  timestamp: 1736231471258
+  size: 128756
+  timestamp: 1753326838726
 - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-uncrustify-vendor-2.0.2-np126py311h2c3b307_7.conda
   sha256: 34f4089b2862eaa690b67dea3f39bda0a2a56cd15158de3a90a519d2cf5cdd86
   md5: 2ab7fbb64863708e0a4108350511f315
@@ -69780,27 +69525,27 @@ packages:
   license: BSD-3-Clause
   size: 21590
   timestamp: 1736206459677
-- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-uncrustify-vendor-2.0.2-np126py311h7d8ee0e_8.conda
-  sha256: 429ed9e882ed5491d835066f959c24c0305867549cbbc9e5c5e5af690184770e
-  md5: a075c3b0a81c865fcbc794520b518e08
+- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-uncrustify-vendor-2.0.2-np126py311hd5de103_13.conda
+  sha256: 800061ce308d44a90fff00be9f4cb2fdc5d2753e725676e652f76035ca3ec49b
+  md5: 3ea9619b6183dcd4e25d15582ad5eb0c
   depends:
   - python
   - ros-humble-ros-workspace
-  - ros2-distro-mutex 0.6.* humble_*
+  - ros2-distro-mutex 0.7.* humble_*
   - uncrustify
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
   - python_abi 3.11.* *_cp311
   - numpy >=1.26.4,<2.0a0
-  - uncrustify >=0.74.0,<0.75.0a0
-  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - uncrustify >=0.81.0,<0.82.0a0
   license: BSD-3-Clause
-  size: 18323
-  timestamp: 1736207951563
+  size: 19415
+  timestamp: 1753312773099
 - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-unique-identifier-msgs-2.2.1-np126py311h2c3b307_7.conda
   sha256: c4fcd02dac0e3ce9bfc960fe574f8f55b910e08f265b1cf1d09a319a45f0bf9d
   md5: cf71ad54ee011fb5b538f98880ac3e67
@@ -69869,26 +69614,26 @@ packages:
   license: BSD-3-Clause
   size: 65617
   timestamp: 1736208388947
-- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-unique-identifier-msgs-2.2.1-np126py311h7d8ee0e_8.conda
-  sha256: 08e41f818e0513efc5a798dde0e04267699cd7963289a4a14bec74f9ec0b6fd8
-  md5: b0c659d08e8acda94b0ef71ebd06bad7
+- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-unique-identifier-msgs-2.2.1-np126py311hd5de103_13.conda
+  sha256: f5949af08a1bd166db0c51f69b44aad592be1776958235dcb35cd69c5b5efdba
+  md5: a17629424099cba28fbc63a963d0c936
   depends:
   - python
   - ros-humble-ros-workspace
   - ros-humble-rosidl-default-runtime
-  - ros2-distro-mutex 0.6.* humble_*
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - ros2-distro-mutex 0.7.* humble_*
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - numpy >=1.26.4,<2.0a0
-  - ros2-distro-mutex >=0.6.0,<0.7.0a0
   - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
+  - numpy >=1.26.4,<2.0a0
   license: BSD-3-Clause
-  size: 74133
-  timestamp: 1736229735512
+  size: 76144
+  timestamp: 1753322922951
 - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-urdf-2.6.1-np126py311h2c3b307_7.conda
   sha256: 49934ffe1fb16408ba55c109486252780f7d73b080d0e2f552031fc92eb9cfaf
   md5: 1d3db4c06fe6b149e20da0261752908f
@@ -69971,9 +69716,9 @@ packages:
   license: BSD-3-Clause
   size: 126258
   timestamp: 1736208082577
-- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-urdf-2.6.1-np126py311h7d8ee0e_8.conda
-  sha256: d9f5fe36befbce9fed8abece1e4f260e9733dd4045c82cf82b362742aeac2acf
-  md5: fd775fa8ce362c19fc253b193aa2b1b1
+- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-urdf-2.6.1-np126py311hd5de103_13.conda
+  sha256: 30fd83cf2c0b3639bdbf3e9d338b86e0c51e38ebbbdd9765fe6f4b4071fa19bc
+  md5: 7285c8592f2324e4902c318f89d040a1
   depends:
   - python
   - ros-humble-pluginlib
@@ -69982,19 +69727,19 @@ packages:
   - ros-humble-urdf-parser-plugin
   - ros-humble-urdfdom
   - ros-humble-urdfdom-headers
-  - ros2-distro-mutex 0.6.* humble_*
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - ros2-distro-mutex 0.7.* humble_*
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
   - python_abi 3.11.* *_cp311
-  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - numpy >=1.26.4,<2.0a0
   license: BSD-3-Clause
-  size: 114047
-  timestamp: 1736228596532
+  size: 119805
+  timestamp: 1753321672708
 - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-urdf-parser-plugin-2.6.1-np126py311h2c3b307_7.conda
   sha256: e4be64214684a114693b8bcf51bff186fdf19c0d185edb81e070f767eb018259
   md5: 3f1f001b8b81197ce54328b9e0e90954
@@ -70060,26 +69805,26 @@ packages:
   license: BSD-3-Clause
   size: 29779
   timestamp: 1736207527299
-- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-urdf-parser-plugin-2.6.1-np126py311h7d8ee0e_8.conda
-  sha256: 97276cc62a1c0bf08de7c763dd3f7846a1c4ee3a65930c63e848d5a8fee14df8
-  md5: 51a99ac530d518effb3b6d9ccadd5c33
+- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-urdf-parser-plugin-2.6.1-np126py311hd5de103_13.conda
+  sha256: a79d56288abb36ac7048fc8a6ae318bd9f83719923a2941c36f4485047b3aad8
+  md5: b388d041786ba2fe6ac8d39a0deaa5d4
   depends:
   - python
   - ros-humble-ros-workspace
   - ros-humble-urdfdom-headers
-  - ros2-distro-mutex 0.6.* humble_*
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - ros2-distro-mutex 0.7.* humble_*
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
   - numpy >=1.26.4,<2.0a0
   - python_abi 3.11.* *_cp311
   license: BSD-3-Clause
-  size: 26398
-  timestamp: 1736226893979
+  size: 28042
+  timestamp: 1753318899230
 - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-urdfdom-3.0.2-np126py311h2c3b307_7.conda
   sha256: 73f02cf524bd8d8418767239ba7bda3af9fbec34c25f161ca15d189f69b1fdb7
   md5: 508705cafe28eceaab9ee37edadfebbd
@@ -70171,9 +69916,9 @@ packages:
   license: BSD-3-Clause
   size: 110632
   timestamp: 1736207596558
-- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-urdfdom-3.0.2-np126py311h7d8ee0e_8.conda
-  sha256: b456a5f8f1c0291c2c5c5251ae34d78961e40ce2ac1b9f3ba6660822648933fc
-  md5: 7b4a902dedb6f3d9b0312dd195de2d4e
+- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-urdfdom-4.0.1-py311hb04609a_13.conda
+  sha256: 9429f6d89e64e8bccea13b707cc2b87757000b84d3c648a05b993e7239f078a8
+  md5: 498848a3466c324e3d18942a02e3553d
   depends:
   - console_bridge
   - python
@@ -70181,22 +69926,16 @@ packages:
   - ros-humble-ros-workspace
   - ros-humble-tinyxml-vendor
   - ros-humble-urdfdom-headers
-  - ros2-distro-mutex 0.6.* humble_*
+  - ros2-distro-mutex 0.7.* humble_*
   - tinyxml
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  - ucrt >=10.0.20348.0
+  - urdfdom >=4.0.1,<4.1.0a0
   - tinyxml
-  - console_bridge >=1.0.2,<1.1.0a0
-  - numpy >=1.26.4,<2.0a0
-  - ros2-distro-mutex >=0.6.0,<0.7.0a0
   - python_abi 3.11.* *_cp311
+  - console_bridge >=1.0.2,<1.1.0a0
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
   license: BSD-3-Clause
-  size: 107372
-  timestamp: 1736227256598
+  size: 7487
+  timestamp: 1753319624335
 - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-urdfdom-headers-1.0.6-np126py311h2c3b307_7.conda
   sha256: bd3b5c1d7a38ed4c057d1b35f0e3f6743d550c267925db41a87aa744ab2efcf5
   md5: 12d4112736de3561059974c62179203b
@@ -70260,25 +69999,19 @@ packages:
   license: BSD-3-Clause
   size: 27414
   timestamp: 1736205445679
-- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-urdfdom-headers-1.0.6-np126py311h7d8ee0e_8.conda
-  sha256: d315589179509b4440fbdd7d3dc22d2ebc1f3d6249272df95f6c48f1ae4939db
-  md5: 632374dc96dd1fb3568a428c4541a0d3
+- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-urdfdom-headers-1.0.6-py311hb04609a_13.conda
+  sha256: fefdca43cf42bdeffcd4e266ca8909b300c88523562b23b54764daa939301e68
+  md5: 38276d1aec02bffd11c058fe1ec8e1c4
   depends:
   - python
   - ros-humble-ros-workspace
-  - ros2-distro-mutex 0.6.* humble_*
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  - ucrt >=10.0.20348.0
-  - numpy >=1.26.4,<2.0a0
-  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - ros2-distro-mutex 0.7.* humble_*
+  - urdfdom_headers >=1.0.6,<1.1.0a0
   - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
   license: BSD-3-Clause
-  size: 24678
-  timestamp: 1736205753952
+  size: 6617
+  timestamp: 1753308588980
 - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-urdfdom-py-1.2.1-np126py311h2c3b307_7.conda
   sha256: 8a4be504c523add575c5bf5c5809a1496cfb5a631461aa21f2bb428f090a48d6
   md5: 7ed6368c1b7500fda352a8f824814a9e
@@ -70344,28 +70077,22 @@ packages:
   license: BSD-3-Clause
   size: 51990
   timestamp: 1736209656608
-- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-urdfdom-py-1.2.1-np126py311h7d8ee0e_8.conda
-  sha256: 7da0984585280c3fe0c30bb90f4e22b8eb8d5c4aa3f14efa8a8d30de7493dd0f
-  md5: 3e9ea07e4f08c71f99ea6c9681435656
+- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-urdfdom-py-1.2.1-py311hb04609a_13.conda
+  sha256: 67690ff5654f78b7b6f3053c31cfee5cfeb2b082a07e8df2a05750d9bb2f159e
+  md5: f506ed9a1b7639fc4c4d12ea1c22594e
   depends:
   - lxml
   - python
   - pyyaml
   - ros-humble-rclpy
   - ros-humble-ros-workspace
-  - ros2-distro-mutex 0.6.* humble_*
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  - ucrt >=10.0.20348.0
-  - ros2-distro-mutex >=0.6.0,<0.7.0a0
-  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex 0.7.* humble_*
+  - urdfdom-py >=1.2.1,<1.3.0a0
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
   - python_abi 3.11.* *_cp311
   license: BSD-3-Clause
-  size: 57575
-  timestamp: 1736234174794
+  size: 6636
+  timestamp: 1753331921221
 - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-visualization-msgs-4.2.4-np126py311h2c3b307_7.conda
   sha256: 20ba46f0268464d8794a13ff9e10105144711cf78dd23ba15560ccc8fab5edfe
   md5: fcfa4a23cad646713b7bbc18fb7e26ba
@@ -70448,9 +70175,9 @@ packages:
   license: BSD-3-Clause
   size: 254720
   timestamp: 1736209022703
-- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-visualization-msgs-4.2.4-np126py311h7d8ee0e_8.conda
-  sha256: 9ac088f4284c29625c1cdf248d518625d00321a8607d6eae523a3a6ccee1757b
-  md5: dba5d84cd961f39908f18cd46ceec7d4
+- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-visualization-msgs-4.9.0-np126py311hd5de103_13.conda
+  sha256: e3ff8d4f4cb2e6a2ff927000bbbc53a5dde80c03f23fd8778cd29a514c622c38
+  md5: 7975a3c8d4d41017a621e1fbf5e780ac
   depends:
   - python
   - ros-humble-builtin-interfaces
@@ -70459,19 +70186,19 @@ packages:
   - ros-humble-rosidl-default-runtime
   - ros-humble-sensor-msgs
   - ros-humble-std-msgs
-  - ros2-distro-mutex 0.6.* humble_*
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - ros2-distro-mutex 0.7.* humble_*
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
   - python_abi 3.11.* *_cp311
-  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
   - numpy >=1.26.4,<2.0a0
   license: BSD-3-Clause
-  size: 267701
-  timestamp: 1736232013964
+  size: 269268
+  timestamp: 1753327814298
 - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-warehouse-ros-2.0.5-np126py311h2c3b307_7.conda
   sha256: 4a6573da1789b99eaced199138cfb54266dc7db1bb4d581ffa93501b58ffdcde
   md5: 6d493f9b2bdaad205ce9c1ae6d83673f
@@ -70587,9 +70314,9 @@ packages:
   license: BSD-3-Clause
   size: 152543
   timestamp: 1736211156448
-- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-warehouse-ros-2.0.5-np126py311h7d8ee0e_8.conda
-  sha256: 2c4503d6e9b05819e14ec9f125ab28a62a8cc6289fbe20caf450b5944d095b11
-  md5: 5347a0fa1036549cf48a3967db9967d7
+- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-warehouse-ros-2.0.5-np126py311hd5de103_13.conda
+  sha256: 72925dae6b829e372324fb033a95157f5b1ebf1fe0cce564bb012999f73424d5
+  md5: ffd96fb48b2290f1b76593880ae4602a
   depends:
   - libboost-devel
   - libboost-python-devel
@@ -70603,22 +70330,22 @@ packages:
   - ros-humble-tf2
   - ros-humble-tf2-geometry-msgs
   - ros-humble-tf2-ros
-  - ros2-distro-mutex 0.6.* humble_*
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - ros2-distro-mutex 0.7.* humble_*
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
   - libboost-python >=1.86.0,<1.87.0a0
-  - python_abi 3.11.* *_cp311
   - libboost >=1.86.0,<1.87.0a0
   - numpy >=1.26.4,<2.0a0
-  - openssl >=3.4.0,<4.0a0
-  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - python_abi 3.11.* *_cp311
+  - openssl >=3.5.1,<4.0a0
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
   license: BSD-3-Clause
-  size: 181134
-  timestamp: 1736236449052
+  size: 182432
+  timestamp: 1753337808836
 - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-xacro-2.0.8-np126py311h2c3b307_7.conda
   sha256: 0f7c2084453a5ba160e6f3aef033a4c26c86a42a9c824f0274fcff6ad013ad87
   md5: 8c0c92a3a13c0804dd5f8817b72e018b
@@ -70689,27 +70416,27 @@ packages:
   license: BSD-3-Clause
   size: 75804
   timestamp: 1736206464791
-- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-xacro-2.0.8-np126py311h7d8ee0e_8.conda
-  sha256: 840184994d6c927e71f793212c09dadfad4e0995105d42adbbc4e6805c322f3e
-  md5: d02e131d116141cb96afd8736efc8aac
+- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-xacro-2.0.13-np126py311hd5de103_13.conda
+  sha256: fc6f3287407d284e68b2b662d175f812fd6cc873126dc491537c9263f79ef56b
+  md5: f62fef0f3fff6af18d7863907df5b1fa
   depends:
   - python
   - pyyaml
   - ros-humble-ament-index-python
   - ros-humble-ros-workspace
-  - ros2-distro-mutex 0.6.* humble_*
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - ros2-distro-mutex 0.7.* humble_*
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - python_abi 3.11.* *_cp311
   - numpy >=1.26.4,<2.0a0
-  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
   license: BSD-3-Clause
-  size: 81038
-  timestamp: 1736207947626
+  size: 83769
+  timestamp: 1753312853266
 - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-yaml-cpp-vendor-8.0.2-np126py311h2c3b307_7.conda
   sha256: 09ba8fc666229f747e2fd99c8109ced58a71041b62d7437176794dac18888c25
   md5: c8e76afd8d24248addd6ea9fffdb3e0e
@@ -70780,27 +70507,27 @@ packages:
   license: BSD-3-Clause
   size: 21837
   timestamp: 1736206646396
-- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-yaml-cpp-vendor-8.0.2-np126py311h7d8ee0e_8.conda
-  sha256: 61c65afce242f19e0cbb215536d341837a80a61bde3f5131ea43b0980ef5454a
-  md5: 28e2ed45f989770be3a45d05b9ce96b7
+- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-yaml-cpp-vendor-8.0.2-np126py311hd5de103_13.conda
+  sha256: 407e30ac621d0cb361087db1523c3ea952328b9aed8dc882c7d02a601be09378
+  md5: 9454fd6de653c424497e606200fa84ba
   depends:
   - python
   - ros-humble-ros-workspace
-  - ros2-distro-mutex 0.6.* humble_*
+  - ros2-distro-mutex 0.7.* humble_*
   - yaml-cpp
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
   - numpy >=1.26.4,<2.0a0
-  - ros2-distro-mutex >=0.6.0,<0.7.0a0
-  - yaml-cpp >=0.8.0,<0.9.0a0
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
   - python_abi 3.11.* *_cp311
+  - yaml-cpp >=0.8.0,<0.9.0a0
   license: BSD-3-Clause
-  size: 18863
-  timestamp: 1736207971532
+  size: 19736
+  timestamp: 1753312936054
 - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-zstd-vendor-0.15.13-np126py311h2c3b307_7.conda
   sha256: da2d53b05255ca1dccb9352714e17c0587b9cb78b0465b288f7dd7e72696c516
   md5: bd744a023f60b32cd93d921bb894ec08
@@ -70870,27 +70597,27 @@ packages:
   license: BSD-3-Clause
   size: 22176
   timestamp: 1736206652755
-- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-zstd-vendor-0.15.13-np126py311h7d8ee0e_8.conda
-  sha256: 0f7e1d8837fb8baa41d73dd252960b7c5ef8248685f2fcf57df6de924d7a224e
-  md5: dbe5c0bcf884e4a2132d8cfe9b38a6a1
+- conda: https://conda.anaconda.org/robostack-humble/win-64/ros-humble-zstd-vendor-0.15.14-np126py311hd5de103_13.conda
+  sha256: 0309f7e5836467d527309ba70a2c815ca4887febfba8451d694be86f457a7c5e
+  md5: a665ba3d06f31ac8250780b696132362
   depends:
   - python
   - ros-humble-ros-workspace
-  - ros2-distro-mutex 0.6.* humble_*
+  - ros2-distro-mutex 0.7.* humble_*
   - zstd
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
   - numpy >=1.26.4,<2.0a0
-  - zstd >=1.5.6,<1.6.0a0
-  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - zstd >=1.5.7,<1.6.0a0
   - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
   license: BSD-3-Clause
-  size: 18862
-  timestamp: 1736207998368
+  size: 20004
+  timestamp: 1753313177458
 - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros2-distro-mutex-0.6.0-humble_0.conda
   sha256: 7634989268abeecfd928b94bce3722b8fcb8ef8cc94f55636153036dd7d93bed
   md5: 5df036dfe2bb64af00f112c9e1cb7bcd
@@ -70939,18 +70666,18 @@ packages:
   license: BSD-3-Clause
   size: 2407
   timestamp: 1736205117400
-- conda: https://conda.anaconda.org/robostack-humble/win-64/ros2-distro-mutex-0.6.0-humble_0.conda
-  sha256: 02cc764f239bf2c7e10b29fdbacff2a31b293288ce6eefa78d1fe4113b2b645a
-  md5: 92a2eb5e64d6eb3f240c7df7f5bf2478
+- conda: https://conda.anaconda.org/robostack-humble/win-64/ros2-distro-mutex-0.7.0-humble_13.conda
+  sha256: 26383accb38cb8c7cb5c675d74b9f504590d61f62b860f306cd413f009081198
+  md5: 1c35324823f1b1f1f68ce659633201dc
   constrains:
   - libboost 1.86.*
   - libboost-devel 1.86.*
-  - pcl 1.14.1.*
+  - pcl 1.15.0.*
   - gazebo 11.*
-  - libprotobuf 5.28.2.*
+  - libprotobuf 5.29.3.*
   license: BSD-3-Clause
-  size: 2409
-  timestamp: 1736205229087
+  size: 2323
+  timestamp: 1753307971823
 - conda: https://conda.anaconda.org/conda-forge/noarch/rosdistro-1.0.1-pyhd8ed1ab_0.conda
   sha256: bff3b2fe7afe35125669ffcb7d6153db78070a753e1e4ac3b3d8d198eb6d6982
   md5: b7ed380a9088b543e06a4f73985ed03a
@@ -71835,18 +71562,18 @@ packages:
   license_family: MIT
   size: 166508
   timestamp: 1746813647146
-- conda: https://conda.anaconda.org/conda-forge/win-64/spdlog-1.14.1-h9f2357e_1.conda
-  sha256: 3ed3e9aaeb6255914472109a6d25d5119eb196c8d6cc2ec732cffe79ccc789bf
-  md5: b9bff07144f2be7ee32f0b83a79ef21d
+- conda: https://conda.anaconda.org/conda-forge/win-64/spdlog-1.15.3-h430ee68_1.conda
+  sha256: dab3103c03a2d26e40a5c4e83e192d99cf6de806280fe4c1298943970503e56c
+  md5: d195ba9419c5704fc42cfacb88f4c3f0
   depends:
-  - fmt >=11.0.1,<11.1a0
+  - fmt >=11.2.0,<11.3.0a0
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   license: MIT
   license_family: MIT
-  size: 169120
-  timestamp: 1722238639391
+  size: 173572
+  timestamp: 1751348807537
 - conda: https://conda.anaconda.org/conda-forge/win-64/spdlog-1.15.3-ha881ca7_0.conda
   sha256: fe49004db84a236cced9f170a30e5e90ffb470bd30cde5869be3820d44841378
   md5: ed102cefa9bba2d4e739d4234c9f7995
@@ -71919,6 +71646,17 @@ packages:
   license: Unlicense
   size: 400821
   timestamp: 1751135714659
+- conda: https://conda.anaconda.org/conda-forge/win-64/sqlite-3.51.2-hdb435a2_0.conda
+  sha256: 8194c1326f052852dd827f5277ba381228a968e841d410eb18c622cf851b11ba
+  md5: bc9265bd9f30f9ded263cb762a4fc847
+  depends:
+  - libsqlite 3.51.2 hf5d6505_0
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  license: blessing
+  size: 400812
+  timestamp: 1768148302390
 - conda: https://conda.anaconda.org/conda-forge/noarch/stack_data-0.6.3-pyhd8ed1ab_1.conda
   sha256: 570da295d421661af487f1595045760526964f41471021056e993e73089e9c41
   md5: b1b505328da7a6b246787df4b5a49fbc
@@ -72114,18 +71852,6 @@ packages:
   license_family: GPL
   size: 1115168
   timestamp: 1746016949997
-- conda: https://conda.anaconda.org/conda-forge/win-64/swig-4.3.1-h51fbe9b_0.conda
-  sha256: 0f4ce1a10199f4f899eb5887100c4f1584a9733e096a417bf3de21827ae546a0
-  md5: e3d7157af9a0a837225455394e9cf957
-  depends:
-  - pcre2 >=10.44,<10.45.0a0
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  license: GPL-3.0-or-later
-  license_family: GPL
-  size: 1083378
-  timestamp: 1744786575879
 - conda: https://conda.anaconda.org/conda-forge/win-64/swig-4.3.1-hf4c94c2_1.conda
   sha256: 179a523645c682b31e21f6bccb12bd58fa68e227f54d796964e277254ffa8b75
   md5: 94e5e95118a09b93e13ceb9681044be0
@@ -72526,38 +72252,38 @@ packages:
   license_family: MIT
   size: 3592504
   timestamp: 1751116989502
-- conda: https://conda.anaconda.org/conda-forge/win-64/tiledb-2.27.0-ha5813de_1.conda
-  sha256: edd908b22c8ebab2e98e82023b32b2cca5b483b701d9b2cabd36ce11c8516598
-  md5: d26adaf9d96dadfb741c86343973c910
+- conda: https://conda.anaconda.org/conda-forge/win-64/tiledb-2.28.0-h7c9f11d_6.conda
+  sha256: a1ca04927a0b6f19a392f92a48cf17d58de08acfece31d2c24ce3293e6923901
+  md5: fcf35aa7b155045d16f0bde64e7227e0
   depends:
-  - aws-crt-cpp >=0.29.7,<0.29.8.0a0
-  - aws-sdk-cpp >=1.11.458,<1.11.459.0a0
+  - aws-crt-cpp >=0.32.10,<0.32.11.0a0
+  - aws-sdk-cpp >=1.11.510,<1.11.511.0a0
   - azure-core-cpp >=1.14.0,<1.14.1.0a0
   - azure-identity-cpp >=1.10.0,<1.10.1.0a0
   - azure-storage-blobs-cpp >=12.13.0,<12.13.1.0a0
   - azure-storage-common-cpp >=12.8.0,<12.8.1.0a0
   - bzip2 >=1.0.8,<2.0a0
-  - capnproto >=1.0.2,<1.0.3.0a0
-  - fmt >=11.0.2,<11.1a0
+  - capnproto >=1.2.0,<1.2.1.0a0
+  - fmt >=11.2.0,<11.3.0a0
   - libabseil * cxx17*
-  - libabseil >=20240722.0,<20240723.0a0
+  - libabseil >=20250127.1,<20250128.0a0
   - libcrc32c >=1.1.2,<1.2.0a0
-  - libcurl >=8.11.1,<9.0a0
-  - libgoogle-cloud >=2.32.0,<2.33.0a0
-  - libgoogle-cloud-storage >=2.32.0,<2.33.0a0
-  - libwebp-base >=1.4.0,<2.0a0
+  - libcurl >=8.14.1,<9.0a0
+  - libgoogle-cloud >=2.36.0,<2.37.0a0
+  - libgoogle-cloud-storage >=2.36.0,<2.37.0a0
+  - libwebp-base >=1.5.0,<2.0a0
   - libzlib >=1.3.1,<2.0a0
   - lz4-c >=1.10.0,<1.11.0a0
-  - openssl >=3.4.0,<4.0a0
-  - spdlog >=1.14.1,<1.15.0a0
+  - openssl >=3.5.0,<4.0a0
+  - spdlog >=1.15.3,<1.16.0a0
   - ucrt >=10.0.20348.0
   - vc >=14.3,<15
-  - vc14_runtime >=14.42.34433
-  - zstd >=1.5.6,<1.6.0a0
+  - vc14_runtime >=14.44.35208
+  - zstd >=1.5.7,<1.6.0a0
   license: MIT
   license_family: MIT
-  size: 3224949
-  timestamp: 1734025077292
+  size: 3335411
+  timestamp: 1751368658565
 - conda: https://conda.anaconda.org/conda-forge/win-64/tiledb-2.28.0-h8310177_5.conda
   sha256: c969dd6db0c82d3d57aefea4920e5b1fc7d74e68a201ed340d44447899c9fde3
   md5: 88512d215ea7cd67a65c869c33d7c36b
@@ -72721,19 +72447,6 @@ packages:
   license: Zlib
   size: 122269
   timestamp: 1742246179980
-- conda: https://conda.anaconda.org/conda-forge/win-64/tinyxml2-10.0.0-he0c23c2_2.conda
-  sha256: 622e6b974f26eb2f09b9080207c10ed7278c302b229062acb35d67b06d5f1c3d
-  md5: 20cbb014a490241f74d429d2636aba63
-  depends:
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  - ucrt >=10.0.20348.0
-  license: Zlib
-  size: 75392
-  timestamp: 1742462215649
 - conda: https://conda.anaconda.org/conda-forge/win-64/tinyxml2-11.0.0-he0c23c2_0.conda
   sha256: f22e0ef11cce8b25e48a2d4a0ca8a2fc5b89841c36f8ec955b01baff7cd3a924
   md5: e80ff399c7b08f37ecdaeaeb5017b9fb
@@ -73100,13 +72813,17 @@ packages:
   license_family: GPL
   size: 560066
   timestamp: 1647071248484
-- conda: https://conda.anaconda.org/conda-forge/win-64/uncrustify-0.74.0-h57928b3_0.tar.bz2
-  sha256: 5a70ff77953996a1963e4b173854f2064f17efb4d9dfe06b69a3b6ef26eba36d
-  md5: 10bd09d332eaf42e49ac251ee46a434f
+- conda: https://conda.anaconda.org/conda-forge/win-64/uncrustify-0.81.0-he0c23c2_0.conda
+  sha256: 787077c15b69d7fe6f6ded93d62e2180b8d775cdc8b6550d2270e943b3d8b636
+  md5: 4809798e2e5e8749445d08bd4422ce7b
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
   license: GPL-2.0-only
   license_family: GPL
-  size: 443108
-  timestamp: 1647071844452
+  size: 413662
+  timestamp: 1747514675025
 - conda: https://conda.anaconda.org/conda-forge/linux-64/unicodedata2-16.0.0-py311h9ecbd09_0.conda
   sha256: e786fb0925515fffc83e393d2a0e2814eaf9be8a434f1982b399841a2c07980b
   md5: 51a12678b609f5794985fda8372b1a49
@@ -73309,23 +73026,6 @@ packages:
   license_family: BSD
   size: 105695
   timestamp: 1743679565324
-- conda: https://conda.anaconda.org/conda-forge/win-64/urdfdom-4.0.1-h4358a7e_2.conda
-  sha256: 59d443e3305a893e974da0b76194dacaad81c749f26ad579854ca44c030cfbbb
-  md5: e3570629a83afbbdd1c70e61d16b9d4d
-  depends:
-  - urdfdom_headers
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  - ucrt >=10.0.20348.0
-  - tinyxml2 >=10.0.0,<10.1.0a0
-  - console_bridge >=1.0.2,<1.1.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 103159
-  timestamp: 1742386930964
 - conda: https://conda.anaconda.org/conda-forge/win-64/urdfdom-4.0.1-h9d4477b_3.conda
   sha256: 63d4b4153a498aef257d53f4d30c71e6f6f55dc31dbb75224602d98f0e5a0867
   md5: 26ae0f0f8f61962bd3bb3c6b7f3e36b3
@@ -73355,6 +73055,18 @@ packages:
   license_family: BSD
   size: 50499
   timestamp: 1725540016732
+- conda: https://conda.anaconda.org/conda-forge/win-64/urdfdom-py-1.2.1-py311h5da1550_6.conda
+  sha256: 2ce970f545fc16e5e59125ec2d691d1b3ea046af54d6886a14c2184d3aa1e1b0
+  md5: 524936cea26be4387f15c01fc2ca0f24
+  depends:
+  - lxml
+  - python >=3.11,<3.12.0a0
+  - pyyaml
+  - setuptools
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 59073
+  timestamp: 1756847540183
 - conda: https://conda.anaconda.org/conda-forge/linux-64/urdfdom_headers-1.1.2-h84d6215_0.conda
   sha256: 9f4090616ed1cb509bb65f1edb11b23c86d929db0ea3af2bf84277caa4337c40
   md5: 4872efb515124284f8cee0f957f3edce
@@ -73396,6 +73108,16 @@ packages:
   license_family: BSD
   size: 19265
   timestamp: 1726152487304
+- conda: https://conda.anaconda.org/conda-forge/win-64/urdfdom_headers-1.0.6-h5362a0b_2.tar.bz2
+  sha256: 3fe393a1ee9a822955f91d7d4e7512bc37e17add16b535abf69d0e5483441fd1
+  md5: 969393fa1623d777ab8a1345f3af449a
+  depends:
+  - vc >=14.1,<15
+  - vs2015_runtime >=14.16.27033
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 18704
+  timestamp: 1649177142878
 - conda: https://conda.anaconda.org/conda-forge/win-64/urdfdom_headers-1.1.2-hc790b64_0.conda
   sha256: 4bc9527ce62587bbe26dfea4a53ae5e39f3c5e29377f9ecea33f788e5f70bfa0
   md5: 5156a06b1bccf0ac108a4c2317e2fbd7
@@ -73649,15 +73371,21 @@ packages:
   license_family: BSD
   size: 28110
   timestamp: 1747923152877
-- conda: https://conda.anaconda.org/conda-forge/win-64/vtk-9.3.1-qt_py311h85ceb33_215.conda
-  sha256: f7d53e7b24553645b17d94ced0463319f830d66951edcdf87e2a6696abdf9f62
-  md5: 674658a26c3e2d6c3dd659b6c08fb993
+- conda: https://conda.anaconda.org/conda-forge/win-64/vtk-9.4.2-hbdaaff1_4.conda
+  sha256: 9cc68d1a9ffa92df9461347311ae947b0e6ea6ba64a8e0fa83ab7f9e90994b0c
+  md5: 4d1012a0cd7074c01cee123b05374588
   depends:
-  - vtk-base 9.3.1 qt_py311h86964fa_215
+  - eigen
+  - expat
+  - libboost-devel
+  - liblzma-devel
+  - python_abi 3.11.* *_cp311
+  - tbb-devel
+  - vtk-base >=9.4.2,<9.4.3.0a0
   license: BSD-3-Clause
   license_family: BSD
-  size: 23898
-  timestamp: 1739143409552
+  size: 29033
+  timestamp: 1757099511399
 - conda: https://conda.anaconda.org/conda-forge/win-64/vtk-9.4.2-hbf458c8_3.conda
   sha256: d3c0ce6ed988636f2cfb75565d56c7df10d00da902222b779c20b423af2190a1
   md5: fbe90658f79832ca6af42e67abf19906
@@ -74055,50 +73783,51 @@ packages:
   license_family: BSD
   size: 42203426
   timestamp: 1747922992646
-- conda: https://conda.anaconda.org/conda-forge/win-64/vtk-base-9.3.1-qt_py311h86964fa_215.conda
-  sha256: 9caa69fd73aa7ed0a8f83a2a174183072b0a785a6dfb7b5486b38b62c4e60ece
-  md5: ed51709bc1d6da63bf927e88910f8532
+- conda: https://conda.anaconda.org/conda-forge/win-64/vtk-base-9.4.2-py311h0d49f04_1.conda
+  sha256: 1dbad204cb3a3d3cd8a31b0237a642ee1b54a45e99d85bb584e1da20d25347a7
+  md5: 85ee7a2abe83ddd708d66710ad462be5
   depends:
-  - double-conversion >=3.3.0,<3.4.0a0
-  - ffmpeg >=7.1.0,<8.0a0
-  - freetype >=2.12.1,<3.0a0
+  - double-conversion >=3.3.1,<3.4.0a0
+  - ffmpeg >=7.1.1,<8.0a0
   - gl2ps >=1.4.2,<1.4.3.0a0
-  - glew >=2.1.0,<2.2.0a0
-  - hdf5 >=1.14.3,<1.14.4.0a0
+  - hdf5 >=1.14.6,<1.14.7.0a0
   - jsoncpp >=1.9.6,<1.9.7.0a0
-  - libexpat >=2.6.4,<3.0a0
-  - libjpeg-turbo >=3.0.0,<4.0a0
-  - liblzma >=5.6.4,<6.0a0
+  - libexpat >=2.7.0,<3.0a0
+  - libfreetype >=2.13.3
+  - libfreetype6 >=2.13.3
+  - libjpeg-turbo >=3.1.0,<4.0a0
+  - liblzma >=5.8.1,<6.0a0
   - libnetcdf >=4.9.2,<4.9.3.0a0
   - libogg >=1.3.5,<1.4.0a0
-  - libpng >=1.6.46,<1.7.0a0
-  - libsqlite >=3.48.0,<4.0a0
+  - libpng >=1.6.47,<1.7.0a0
+  - libsqlite >=3.49.2,<4.0a0
   - libtheora >=1.1.1,<1.2.0a0
   - libtiff >=4.7.0,<4.8.0a0
-  - libxml2 >=2.13.5,<2.14.0a0
+  - libxml2 >=2.13.8,<2.14.0a0
   - libzlib >=1.3.1,<2.0a0
   - loguru
   - lz4-c >=1.10.0,<1.11.0a0
+  - matplotlib-base >=2.0.0
   - nlohmann_json
   - numpy
-  - proj >=9.5.1,<9.6.0a0
-  - pugixml >=1.14,<1.15.0a0
+  - proj >=9.6.0,<9.7.0a0
+  - pugixml >=1.15,<1.16.0a0
   - python >=3.11,<3.12.0a0
   - python_abi 3.11.* *_cp311
-  - qt6-main >=6.8.2,<6.9.0a0
+  - qt6-main >=6.9.0,<6.10.0a0
   - tbb >=2021.13.0
   - ucrt >=10.0.20348.0
   - utfcpp
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.42.34438
   - wslink
   constrains:
-  - libboost_headers
+  - libboost-headers >=1.86.0,<1.87.0a0
   - paraview ==9999999999
   license: BSD-3-Clause
   license_family: BSD
-  size: 34698206
-  timestamp: 1739143275157
+  size: 40414468
+  timestamp: 1747933296909
 - conda: https://conda.anaconda.org/conda-forge/win-64/vtk-base-9.4.2-py39ha1f65a8_1.conda
   sha256: 03eefd11e172a98a16f857e6a2e6932699868d7dbdedfa8e492cb500d5f7c569
   md5: 15c857313f53039e2aa76943ce986cc0

--- a/pixi.toml
+++ b/pixi.toml
@@ -211,8 +211,8 @@ ros-humble-test-msgs = "*"
 ros-humble-moveit = "*"
 ros-humble-hardware-interface = "*"
 ros-humble-moveit-visual-tools = "*"
-ros-humble-gazebo-msgs = "*"
 ros-humble-controller-manager = "*"
+ros-humble-ros-gz-interfaces = "*"
 
 # Ideally we should not duplicate the tasks for each feature, but unfortunatly this is currently required
 [feature.ros2.tasks]


### PR DESCRIPTION
As per title, it is necessary for `build-ros2` pixi task.